### PR TITLE
Migrate hosted Relmio chat to Vercel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,47 @@ jobs:
 
       - name: Preview the npm package
         run: npm pack --dry-run
+
+  web-quality:
+    name: Hosted web quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          package-manager-cache: false
+
+      - name: Install and verify npm 10.9.8
+        shell: bash
+        run: |
+          npm install --global --ignore-scripts npm@10.9.8
+          test "$(npm --version)" = "10.9.8"
+
+      - name: Install pinned web dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts
+
+      - name: Lint the hosted web app
+        run: npm run lint
+
+      - name: Type-check the hosted web app
+        run: npm run typecheck
+
+      - name: Build the native Vercel application
+        run: npm run build:vercel
+
+      - name: Build and test the rollback hosting application
+        run: npm test
+
+      - name: Audit hosted web production dependencies
+        run: npm audit --audit-level=high

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ auth.json
 .codex-local-context.md
 graphify-out/
 .DS_Store
+.vercel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ checks the registry separately after publication.
 
 - Stream hosted chat responses incrementally through deployment proxies and
   surface safe request errors instead of leaving an empty assistant message.
+- Distinguish a ChatGPT hosting-network challenge from an expired OAuth
+  session without exposing upstream response bodies or credentials.
 
 ## [0.2.1] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ checks the registry separately after publication.
 
 ## Unreleased
 
-No unreleased changes.
+### Fixed
+
+- Stream hosted chat responses incrementally through deployment proxies and
+  surface safe request errors instead of leaving an empty assistant message.
 
 ## [0.2.1] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+### Changed
+
+- Prepare the hosted chat for Vercel's Node.js 22 runtime and repository-driven
+  preview and production deployments.
+- Return ChatGPT OAuth callbacks to the deployment that started sign-in so
+  Vercel preview URLs and the production domain both work.
+- Run hosted web linting, type checks, builds, tests, and dependency auditing
+  in GitHub Actions alongside repository-driven deployments.
+
 ### Fixed
 
 - Stream hosted chat responses incrementally through deployment proxies and

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "start": "node src/cli.js",
     "preview": "node scripts/preview.js",
     "package:build": "node scripts/build-npm-package.js",
-    "test": "node --test",
+    "test": "node --test test/*.test.js",
     "lint": "node scripts/check-syntax.js",
     "release:check": "node scripts/check-release-metadata.js",
     "check": "npm run lint && npm run release:check && npm test"

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -2,6 +2,8 @@ import { createOpenAIOAuth } from "@openai-oauth/ai-sdk";
 import { openaiCredentials } from "@openai-oauth/react/server";
 import { streamText } from "ai";
 
+export const runtime = "nodejs";
+
 const MAX_PROMPT_LENGTH = 3000;
 const STREAM_ERROR_MESSAGE =
   "The response stream failed. Reconnect ChatGPT and try again.";

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -5,6 +5,52 @@ import { streamText } from "ai";
 const MAX_PROMPT_LENGTH = 3000;
 const STREAM_ERROR_MESSAGE =
   "The response stream failed. Reconnect ChatGPT and try again.";
+const HOSTING_NETWORK_BLOCKED_MESSAGE =
+  "ChatGPT blocked requests from this hosting network. Relmio's chat backend must run outside Cloudflare Workers.";
+
+function errorStatusCode(error: unknown): number | undefined {
+  if (!error || typeof error !== "object" || !("statusCode" in error)) {
+    return undefined;
+  }
+
+  return typeof error.statusCode === "number" ? error.statusCode : undefined;
+}
+
+function errorResponseHeader(
+  error: unknown,
+  headerName: string,
+): string | undefined {
+  if (!error || typeof error !== "object" || !("responseHeaders" in error)) {
+    return undefined;
+  }
+
+  const headers = error.responseHeaders;
+  if (headers instanceof Headers) {
+    return headers.get(headerName) ?? undefined;
+  }
+
+  if (!headers || typeof headers !== "object") {
+    return undefined;
+  }
+
+  const value = Reflect.get(headers, headerName.toLowerCase());
+  return typeof value === "string" ? value : undefined;
+}
+
+function streamErrorMessage(error: unknown): string {
+  const statusCode = errorStatusCode(error);
+  const mitigation = errorResponseHeader(error, "cf-mitigated");
+  const isHostingChallenge = statusCode === 403 && mitigation === "challenge";
+
+  console.error("Relmio upstream chat request failed.", {
+    category: isHostingChallenge ? "hosting-network-blocked" : "upstream-error",
+    statusCode: statusCode ?? "unknown",
+  });
+
+  return isHostingChallenge
+    ? HOSTING_NETWORK_BLOCKED_MESSAGE
+    : STREAM_ERROR_MESSAGE;
+}
 
 export async function POST(request: Request) {
   let body: unknown;
@@ -53,7 +99,7 @@ export async function POST(request: Request) {
         "Content-Encoding": "none",
         "X-Content-Type-Options": "nosniff",
       },
-      onError: () => STREAM_ERROR_MESSAGE,
+      onError: streamErrorMessage,
     });
   } catch {
     return Response.json(

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -3,6 +3,8 @@ import { openaiCredentials } from "@openai-oauth/react/server";
 import { streamText } from "ai";
 
 const MAX_PROMPT_LENGTH = 3000;
+const STREAM_ERROR_MESSAGE =
+  "The response stream failed. Reconnect ChatGPT and try again.";
 
 export async function POST(request: Request) {
   let body: unknown;
@@ -45,11 +47,13 @@ export async function POST(request: Request) {
       maxOutputTokens: 600,
     });
 
-    return result.toTextStreamResponse({
+    return result.toUIMessageStreamResponse({
       headers: {
         "Cache-Control": "no-store",
+        "Content-Encoding": "none",
         "X-Content-Type-Options": "nosniff",
       },
+      onError: () => STREAM_ERROR_MESSAGE,
     });
   } catch {
     return Response.json(

--- a/web/app/components/ChatConsole.tsx
+++ b/web/app/components/ChatConsole.tsx
@@ -20,8 +20,6 @@ const suggestions = [
   "What should I protect like a password?",
 ];
 
-const hostedChatCallbackUrl = "https://relmio.jpfusin.tech/";
-
 export function ChatConsole() {
   const [authStatus, setAuthStatus] =
     useState<SignInWithChatGPTState["status"]>("checking");
@@ -121,7 +119,6 @@ export function ChatConsole() {
 
       <div className="auth-row">
         <SignInWithChatGPT
-          callbackPath={hostedChatCallbackUrl}
           className="chatgpt-connect"
           loadingLabel="Checking ChatGPT…"
           redirectingLabel="Opening ChatGPT…"

--- a/web/app/components/ChatConsole.tsx
+++ b/web/app/components/ChatConsole.tsx
@@ -36,7 +36,6 @@ export function ChatConsole() {
     stop,
   } = useCompletion({
     api: "/api/chat",
-    streamProtocol: "text",
     onError(error) {
       setLocalError(
         error.message || "The request could not be completed. Try again.",
@@ -155,11 +154,11 @@ export function ChatConsole() {
                 <p>{lastPrompt}</p>
               </div>
             ) : null}
-            <div className="message message-assistant">
-              <span>Relmio</span>
-              <p>
-                {completion ||
-                  (isLoading ? (
+            {completion || isLoading ? (
+              <div className="message message-assistant">
+                <span>Relmio</span>
+                <p>
+                  {completion || (
                     <span
                       className="typing-dots"
                       role="status"
@@ -169,11 +168,10 @@ export function ChatConsole() {
                       <i />
                       <i />
                     </span>
-                  ) : (
-                    ""
-                  ))}
-              </p>
-            </div>
+                  )}
+                </p>
+              </div>
+            ) : null}
           </>
         )}
       </div>

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    root: process.cwd(),
+  },
 };
 
 export default nextConfig;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -34,7 +34,7 @@
         "wrangler": "4.115.0"
       },
       "engines": {
-        "node": ">=22.13.0"
+        "node": "22.x"
       }
     },
     "node_modules/@ai-sdk/gateway": {

--- a/web/package.json
+++ b/web/package.json
@@ -3,14 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=22.13.0"
+    "node": "22.x"
   },
   "scripts": {
     "dev": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext dev",
     "build": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext build",
+    "build:vercel": "next build",
     "start": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext start",
-    "test": "npm run build && node --test tests/rendered-html.test.mjs",
-    "lint": "eslint . --ignore-pattern dist --ignore-pattern .next"
+    "test": "npm run build && node --test tests/*.test.mjs",
+    "lint": "eslint . --ignore-pattern dist --ignore-pattern .next",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@ai-sdk/react": "3.0.239",

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -54,6 +54,122 @@ test("rejects non-string chat prompts before reading credentials", async () => {
   });
 });
 
+test("streams chat over the UI message protocol without proxy buffering", async () => {
+  const [chatConsole, chatRoute] = await Promise.all([
+    readFile(new URL("../app/components/ChatConsole.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../app/api/chat/route.ts", import.meta.url), "utf8"),
+  ]);
+
+  assert.doesNotMatch(chatConsole, /streamProtocol:\s*"text"/u);
+  assert.match(chatRoute, /toUIMessageStreamResponse/u);
+  assert.match(chatRoute, /"Content-Encoding":\s*"none"/u);
+  assert.match(chatRoute, /onError:\s*\(\)\s*=>/u);
+});
+
+test("returns a streaming error event instead of an empty completion", async (t) => {
+  t.mock.method(globalThis, "fetch", async () =>
+    Response.json(
+      { error: { message: "private upstream detail" } },
+      { status: 401 },
+    ),
+  );
+  t.mock.method(console, "error", () => {});
+
+  const response = await requestApp("/api/chat", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer test-token",
+      "chatgpt-account-id": "test-account",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ prompt: "hello" }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "text/event-stream");
+  assert.equal(response.headers.get("content-encoding"), "none");
+  assert.equal(response.headers.get("x-vercel-ai-ui-message-stream"), "v1");
+
+  const stream = await response.text();
+  assert.match(stream, /"type":"error"/u);
+  assert.match(
+    stream,
+    /The response stream failed\. Reconnect ChatGPT and try again\./u,
+  );
+  assert.doesNotMatch(stream, /private upstream detail/u);
+});
+
+test("forwards incremental model text as separate chat stream events", async (t) => {
+  const upstreamEvents = [
+    {
+      type: "response.created",
+      response: { id: "response-test", created_at: 1, model: "gpt-5.4-mini" },
+    },
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "message", id: "message-test", phase: "final_answer" },
+    },
+    {
+      type: "response.output_text.delta",
+      item_id: "message-test",
+      delta: "Hello",
+    },
+    {
+      type: "response.output_text.delta",
+      item_id: "message-test",
+      delta: " world",
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "message", id: "message-test", phase: "final_answer" },
+    },
+    {
+      type: "response.completed",
+      response: {
+        usage: {
+          input_tokens: 1,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens: 2,
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      },
+    },
+  ];
+  const upstreamStream = `${upstreamEvents
+    .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+    .join("")}data: [DONE]\n\n`;
+
+  t.mock.method(globalThis, "fetch", async (input) =>
+    String(input).includes("/responses")
+      ? new Response(upstreamStream, {
+          headers: { "content-type": "text/event-stream" },
+        })
+      : Response.json(
+          { error: { message: "Model catalog unavailable in this test." } },
+          { status: 503 },
+        ),
+  );
+
+  const response = await requestApp("/api/chat", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer test-token",
+      "chatgpt-account-id": "test-account",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ prompt: "hello" }),
+  });
+
+  assert.equal(response.status, 200);
+  const stream = await response.text();
+  assert.match(stream, /"type":"text-delta".*"delta":"Hello"/u);
+  assert.match(stream, /"type":"text-delta".*"delta":" world"/u);
+  assert.ok(stream.indexOf('"delta":"Hello"') < stream.indexOf('"delta":" world"'));
+  assert.match(stream, /data: \[DONE\]/u);
+});
+
 test("ships the request-bound chat and removes starter assets", async () => {
   const [chatConsole, chatRoute, layout, packageJson] = await Promise.all([
     readFile(new URL("../app/components/ChatConsole.tsx", import.meta.url), "utf8"),

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -221,15 +221,12 @@ test("ships the request-bound chat and removes starter assets", async () => {
   );
 });
 
-test("pins hosted ChatGPT callbacks to the custom Relmio domain", async () => {
+test("returns hosted ChatGPT callbacks to the active deployment origin", async () => {
   const chatConsole = await readFile(
     new URL("../app/components/ChatConsole.tsx", import.meta.url),
     "utf8",
   );
 
-  assert.match(
-    chatConsole,
-    /const hostedChatCallbackUrl = "https:\/\/relmio\.jpfusin\.tech\/";/u,
-  );
-  assert.match(chatConsole, /callbackPath=\{hostedChatCallbackUrl\}/u);
+  assert.doesNotMatch(chatConsole, /callbackPath=/u);
+  assert.doesNotMatch(chatConsole, /relmio\.jpfusin\.tech/u);
 });

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -63,7 +63,7 @@ test("streams chat over the UI message protocol without proxy buffering", async 
   assert.doesNotMatch(chatConsole, /streamProtocol:\s*"text"/u);
   assert.match(chatRoute, /toUIMessageStreamResponse/u);
   assert.match(chatRoute, /"Content-Encoding":\s*"none"/u);
-  assert.match(chatRoute, /onError:\s*\(\)\s*=>/u);
+  assert.match(chatRoute, /onError:\s*streamErrorMessage/u);
 });
 
 test("returns a streaming error event instead of an empty completion", async (t) => {
@@ -97,6 +97,38 @@ test("returns a streaming error event instead of an empty completion", async (t)
     /The response stream failed\. Reconnect ChatGPT and try again\./u,
   );
   assert.doesNotMatch(stream, /private upstream detail/u);
+});
+
+test("identifies a ChatGPT challenge against the hosting network", async (t) => {
+  t.mock.method(globalThis, "fetch", async () =>
+    new Response("<html>private challenge body</html>", {
+      status: 403,
+      headers: {
+        "cf-mitigated": "challenge",
+        "content-type": "text/html",
+      },
+    }),
+  );
+  t.mock.method(console, "error", () => {});
+
+  const response = await requestApp("/api/chat", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer test-token",
+      "chatgpt-account-id": "test-account",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ prompt: "hello" }),
+  });
+
+  assert.equal(response.status, 200);
+  const stream = await response.text();
+  assert.match(stream, /"type":"error"/u);
+  assert.match(
+    stream,
+    /ChatGPT blocked requests from this hosting network\./u,
+  );
+  assert.doesNotMatch(stream, /private challenge body|test-token/u);
 });
 
 test("forwards incremental model text as separate chat stream events", async (t) => {

--- a/web/tests/vercel-migration.test.mjs
+++ b/web/tests/vercel-migration.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("builds the hosted app as a Node.js 22 Next.js project on Vercel", async () => {
+  const [packageJsonSource, vercelConfigSource, nextConfig, chatRoute] =
+    await Promise.all([
+      readFile(new URL("../package.json", import.meta.url), "utf8"),
+      readFile(new URL("../vercel.json", import.meta.url), "utf8"),
+      readFile(new URL("../next.config.ts", import.meta.url), "utf8"),
+      readFile(new URL("../app/api/chat/route.ts", import.meta.url), "utf8"),
+    ]);
+
+  const packageJson = JSON.parse(packageJsonSource);
+  const vercelConfig = JSON.parse(vercelConfigSource);
+
+  assert.equal(packageJson.engines.node, "22.x");
+  assert.equal(packageJson.scripts["build:vercel"], "next build");
+  assert.equal(vercelConfig.framework, "nextjs");
+  assert.equal(vercelConfig.buildCommand, "npm run build:vercel");
+  assert.equal(vercelConfig.installCommand, "npm ci --ignore-scripts");
+  assert.match(nextConfig, /turbopack:\s*\{\s*root: process\.cwd\(\),?\s*\}/u);
+  assert.match(chatRoute, /export const runtime = "nodejs";/u);
+});
+
+test("returns OAuth callbacks to whichever deployment started sign-in", async () => {
+  const chatConsole = await readFile(
+    new URL("../app/components/ChatConsole.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.doesNotMatch(chatConsole, /callbackPath=/u);
+  assert.doesNotMatch(chatConsole, /relmio\.jpfusin\.tech/u);
+});
+
+test("runs web quality gates in GitHub CI for repository-driven deploys", async () => {
+  const [packageJsonSource, workflow] = await Promise.all([
+    readFile(new URL("../package.json", import.meta.url), "utf8"),
+    readFile(new URL("../../.github/workflows/ci.yml", import.meta.url), "utf8"),
+  ]);
+  const packageJson = JSON.parse(packageJsonSource);
+
+  assert.equal(packageJson.scripts.typecheck, "tsc --noEmit");
+  assert.match(workflow, /web-quality:/u);
+  assert.match(workflow, /working-directory: web/u);
+  assert.match(workflow, /run: npm run lint/u);
+  assert.match(workflow, /run: npm run typecheck/u);
+  assert.match(workflow, /run: npm run build:vercel/u);
+  assert.match(workflow, /run: npm test/u);
+  assert.match(workflow, /run: npm audit --audit-level=high/u);
+});

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "npm run build:vercel",
+  "installCommand": "npm ci --ignore-scripts"
+}


### PR DESCRIPTION
## What changed

- add a native Next.js/Vercel build on Node.js 22
- run the chat route explicitly on the Node.js runtime
- return OAuth callbacks to the deployment origin, including preview URLs
- add hosted-web lint, typecheck, native Vercel build, rollback build/tests, and dependency audit to GitHub Actions
- preserve the existing Vinext/Sites build as a rollback path

## Why

The current Cloudflare Worker deployment reaches ChatGPT with valid request-bound OAuth headers, but the upstream request is challenged at the hosting-network boundary and streaming fails. The working upstream reference application runs its backend on Vercel. This migration moves Relmio's server-side chat request to Vercel's Node runtime while retaining safe errors and incremental streaming.

## Verification

- `npm run build:vercel`
- `npm test` in `web/` (11 tests)
- `npm run lint` in `web/`
- `npm run typecheck` in `web/`
- `npm run check` at repository root (80 tests)
- root and web `npm audit --audit-level=high` (0 vulnerabilities)
- `npm pack --dry-run`
