### PR TITLE
Release Relmio v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,6 @@ checks the registry separately after publication.
 
 ## Unreleased
 
-### Changed
-
-- Prepare the hosted chat for Vercel's Node.js 22 runtime and repository-driven
-  preview and production deployments.
-- Return ChatGPT OAuth callbacks to the deployment that started sign-in so
-  Vercel preview URLs and the production domain both work.
-- Run hosted web linting, type checks, builds, tests, and dependency auditing
-  in GitHub Actions alongside repository-driven deployments.
-
-### Fixed
-
-- Stream hosted chat responses incrementally through deployment proxies and
-  surface safe request errors instead of leaving an empty assistant message.
-- Distinguish a ChatGPT hosting-network challenge from an expired OAuth
-  session without exposing upstream response bodies or credentials.
-
 ## [0.2.1] - 2026-07-30
 
 ### Added
@@ -30,13 +14,33 @@ checks the registry separately after publication.
 - Add the hosted ChatGPT site link to the package metadata and public guides.
 - Document the upstream Codex relay model, known limitations, and legal
   responsibilities in both the GitHub and npm README variants.
+- Add a command-first install page for the current n8n and Hostinger VPS
+  wizard, plus a GitHub control with live package and repository metadata.
+- Credit Evan Zhou Dev's `openai-oauth` method on the hosted Relmio page.
 
 ### Changed
 
 - Refresh the local setup wizard and hosted chat presentation with the Relmio
   redesign, including clearer progress, copy feedback, responsive layouts, and
   request-state affordances.
-- Set the package homepage to the hosted Relmio site.
+- Move the hosted chat and package homepage to
+  [relmio.vercel.app](https://relmio.vercel.app/) with Node.js 22 and
+  repository-driven preview and production deployments.
+- Return ChatGPT OAuth callbacks to the deployment that started sign-in so
+  Vercel preview URLs and the production domain both work.
+- Run hosted web linting, type checks, builds, tests, and dependency auditing
+  in GitHub Actions alongside repository-driven deployments.
+- Point package and documentation metadata at the canonical `relmio`
+  repository.
+- License Relmio under Apache 2.0 and preserve the upstream `openai-oauth`
+  attribution in the distributed notice.
+
+### Fixed
+
+- Stream hosted chat responses incrementally through deployment proxies and
+  surface safe request errors instead of leaving an empty assistant message.
+- Distinguish a ChatGPT hosting-network challenge from an expired OAuth
+  session without exposing upstream response bodies or credentials.
 
 ## [0.2.0] - 2026-07-29
 
@@ -209,11 +213,11 @@ checks the registry separately after publication.
 - The sidecar uses an internal-only Docker network endpoint and no published
   VPS port.
 
-[0.1.7]: https://github.com/Demonbane18/n8n-openai-oauth-setup/compare/v0.1.6...v0.1.7
-[0.1.6]: https://github.com/Demonbane18/n8n-openai-oauth-setup/compare/v0.1.5...v0.1.6
-[0.1.5]: https://github.com/Demonbane18/n8n-openai-oauth-setup/compare/v0.1.4...v0.1.5
-[0.1.4]: https://github.com/Demonbane18/n8n-openai-oauth-setup/compare/v0.1.3...v0.1.4
-[0.1.3]: https://github.com/Demonbane18/n8n-openai-oauth-setup/compare/v0.1.2...v0.1.3
-[0.1.2]: https://github.com/Demonbane18/n8n-openai-oauth-setup/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/Demonbane18/n8n-openai-oauth-setup/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/Demonbane18/n8n-openai-oauth-setup/releases/tag/v0.1.0
+[0.1.7]: https://github.com/Demonbane18/relmio/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/Demonbane18/relmio/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/Demonbane18/relmio/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/Demonbane18/relmio/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/Demonbane18/relmio/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/Demonbane18/relmio/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/Demonbane18/relmio/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/Demonbane18/relmio/releases/tag/v0.1.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Demonbane18
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Relmio contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+Relmio
+Copyright 2026 Relmio contributors
+
+Relmio uses software and methods developed by Evan Zhou and the OpenAI OAuth
+contributors:
+
+OpenAI OAuth
+Copyright 2026 Evan Zhou and OpenAI OAuth contributors
+https://github.com/EvanZhouDev/openai-oauth
+
+OpenAI OAuth is licensed under the Apache License, Version 2.0.

--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@
   <p>
     <a href="#choose-a-setup-path">Get started</a>
     &nbsp;·&nbsp;
-    <a href="https://relmio.jpfusin.tech/">Hosted ChatGPT site</a>
+    <a href="https://relmio.vercel.app/">Hosted ChatGPT site</a>
     &nbsp;·&nbsp;
-    <a href="https://github.com/Demonbane18/n8n-openai-oauth-setup/issues/new">Report an issue</a>
+    <a href="https://github.com/Demonbane18/relmio/issues/new">Report an issue</a>
     &nbsp;·&nbsp;
-    <a href="https://github.com/Demonbane18/n8n-openai-oauth-setup/stargazers">Leave a star</a>
+    <a href="https://github.com/Demonbane18/relmio/stargazers">Leave a star</a>
   </p>
   <p>
     <a href="https://www.npmjs.com/package/relmio"><img src="https://img.shields.io/npm/v/relmio.svg" alt="npm version"></a>
-    <a href="https://github.com/Demonbane18/n8n-openai-oauth-setup/actions/workflows/ci.yml"><img src="https://github.com/Demonbane18/n8n-openai-oauth-setup/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
+    <a href="https://github.com/Demonbane18/relmio/actions/workflows/ci.yml"><img src="https://github.com/Demonbane18/relmio/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
     <a href="package.json"><img src="https://img.shields.io/badge/Node.js-22%2B-43853d.svg" alt="Node.js 22 or newer"></a>
-    <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT license"></a>
-    <a href="https://github.com/Demonbane18/n8n-openai-oauth-setup/stargazers"><img src="https://img.shields.io/github/stars/Demonbane18/n8n-openai-oauth-setup?style=flat" alt="GitHub stars"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="Apache License 2.0"></a>
+    <a href="https://github.com/Demonbane18/relmio/stargazers"><img src="https://img.shields.io/github/stars/Demonbane18/relmio?style=flat" alt="GitHub stars"></a>
   </p>
 </div>
 
@@ -133,9 +133,13 @@ SuperGrok/xAI OAuth feasibility track.
 ## Hosted ChatGPT site
 
 Try the hosted browser experience at
-[relmio.jpfusin.tech](https://relmio.jpfusin.tech/). It provides a separate
+[relmio.vercel.app](https://relmio.vercel.app/). It provides a separate
 ChatGPT sign-in and a small request-bound chat demo; it does not create an
 OpenAI Platform API key or replace the local n8n setup wizard.
+
+The site's [Install wizard](https://relmio.vercel.app/install) page provides
+the copyable npm command for the current self-hosted n8n and Hostinger VPS
+setup path.
 
 ## Choose a setup path
 
@@ -337,8 +341,8 @@ The npm command above is the recommended path. Contributors can instead run
 the source checkout:
 
 ```bash
-git clone https://github.com/Demonbane18/n8n-openai-oauth-setup.git
-cd n8n-openai-oauth-setup
+git clone https://github.com/Demonbane18/relmio.git
+cd relmio
 npm ci --ignore-scripts
 npm start
 ```
@@ -776,9 +780,9 @@ account or infrastructure details.
 <p>
   <a href="CONTRIBUTING.md">Contribution guide</a>
   &nbsp;·&nbsp;
-  <a href="https://github.com/Demonbane18/n8n-openai-oauth-setup/compare">Submit a pull request</a>
+  <a href="https://github.com/Demonbane18/relmio/compare">Submit a pull request</a>
   &nbsp;·&nbsp;
-  <a href="https://github.com/Demonbane18/n8n-openai-oauth-setup/issues/new">Open an issue</a>
+  <a href="https://github.com/Demonbane18/relmio/issues/new">Open an issue</a>
 </p>
 
 ## Security and responsible disclosure
@@ -788,7 +792,7 @@ Please use the private reporting path described in
 Do not publish credentials, OAuth material, host details, or an exploit in a
 public issue.
 
-If this project saves you time, please consider [starring the repository](https://github.com/Demonbane18/n8n-openai-oauth-setup/stargazers).
+If this project saves you time, please consider [starring the repository](https://github.com/Demonbane18/relmio/stargazers).
 
 ## Sources and further reading
 
@@ -807,5 +811,6 @@ If this project saves you time, please consider [starring the repository](https:
 
 ## License
 
-[MIT](LICENSE). The upstream `openai-oauth` project has its own license and
-legal notice; review both before distributing or deploying this setup.
+[Apache License 2.0](LICENSE). Relmio's [NOTICE](NOTICE) preserves the
+upstream `openai-oauth` attribution; review both projects' notices before
+distributing or deploying this setup.

--- a/docs/npm-publish.md
+++ b/docs/npm-publish.md
@@ -203,7 +203,7 @@ On the npm package's **Trusted Publisher** form, use:
 |---|---|
 | Publisher | GitHub Actions |
 | Organization or user | `Demonbane18` |
-| Repository | `n8n-openai-oauth-setup` |
+| Repository | `relmio` |
 | Workflow filename | `publish.yml` |
 | Environment name | `npm` |
 | Allowed action | Allow npm publish |

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,15 +1,15 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/Demonbane18/n8n-openai-oauth-setup/main/docs/images/brand/relmio-mark.svg" alt="Relmio logo" width="88">
+  <img src="https://cdn.jsdelivr.net/npm/relmio@latest/docs/images/brand/relmio-mark.svg" alt="Relmio logo" width="88">
   <h1>Relmio</h1>
   <p>Relay a supported ChatGPT/Codex sign-in to OpenAI-compatible clients, starting with self-hosted n8n.</p>
   <p>
-    <a href="https://github.com/Demonbane18/n8n-openai-oauth-setup">Full guide</a>
+    <a href="https://github.com/Demonbane18/relmio">Full guide</a>
     &nbsp;·&nbsp;
-    <a href="https://relmio.jpfusin.tech/">Hosted ChatGPT site</a>
+    <a href="https://relmio.vercel.app/">Hosted ChatGPT site</a>
     &nbsp;·&nbsp;
-    <a href="https://github.com/Demonbane18/n8n-openai-oauth-setup/issues/new">Report an issue</a>
+    <a href="https://github.com/Demonbane18/relmio/issues/new">Report an issue</a>
     &nbsp;·&nbsp;
-    <a href="https://github.com/Demonbane18/n8n-openai-oauth-setup/blob/main/docs/roadmap.md">Roadmap</a>
+    <a href="https://github.com/Demonbane18/relmio/blob/main/docs/roadmap.md">Roadmap</a>
   </p>
 </div>
 
@@ -22,9 +22,13 @@ exact change plan, and the final n8n credential settings.
 The existing n8n image, Compose file, container, and workflows stay untouched.
 
 Try the hosted browser demo at
-[relmio.jpfusin.tech](https://relmio.jpfusin.tech/). It is a separate
+[relmio.vercel.app](https://relmio.vercel.app/). It is a separate
 request-bound ChatGPT experience; the npm package remains the local wizard for
 installing the private n8n sidecar.
+
+Use the site's [Install wizard](https://relmio.vercel.app/install) page for a
+copyable command tailored to the current self-hosted n8n and Hostinger VPS
+setup path.
 
 ## Quick start
 
@@ -62,7 +66,7 @@ Relmio currently provides tested setup instructions for:
 The broader direction is to support local chatbots, custom applications,
 OpenAI-compatible clients, and provider adapters without tying the public
 product name to n8n. SuperGrok/xAI OAuth is a gated feasibility item on the
-[provider roadmap](https://github.com/Demonbane18/n8n-openai-oauth-setup/blob/main/docs/roadmap.md);
+[provider roadmap](https://github.com/Demonbane18/relmio/blob/main/docs/roadmap.md);
 it is not currently advertised as supported.
 
 ## Visual walkthrough
@@ -72,23 +76,23 @@ data, and no real credential or session information.
 
 ### 1. Confirm the local ChatGPT/Codex sign-in
 
-<img src="https://raw.githubusercontent.com/Demonbane18/n8n-openai-oauth-setup/main/docs/images/setup/01-local-sign-in-ready.png" alt="Sanitized local sign-in ready screen" width="720">
+<img src="https://cdn.jsdelivr.net/npm/relmio@latest/docs/images/setup/01-local-sign-in-ready.png" alt="Sanitized local sign-in ready screen" width="720">
 
 ### 2. Verify the VPS identity
 
-<img src="https://raw.githubusercontent.com/Demonbane18/n8n-openai-oauth-setup/main/docs/images/setup/02-vps-identity-confirmed.png" alt="Sanitized VPS fingerprint confirmation screen" width="720">
+<img src="https://cdn.jsdelivr.net/npm/relmio@latest/docs/images/setup/02-vps-identity-confirmed.png" alt="Sanitized VPS fingerprint confirmation screen" width="720">
 
 ### 3. Choose the detected n8n container and network
 
-<img src="https://raw.githubusercontent.com/Demonbane18/n8n-openai-oauth-setup/main/docs/images/setup/03-n8n-detected.png" alt="Sanitized n8n discovery screen" width="720">
+<img src="https://cdn.jsdelivr.net/npm/relmio@latest/docs/images/setup/03-n8n-detected.png" alt="Sanitized n8n discovery screen" width="720">
 
 ### 4. Review the exact sidecar-only plan
 
-<img src="https://raw.githubusercontent.com/Demonbane18/n8n-openai-oauth-setup/main/docs/images/setup/04-install-plan.png" alt="Sanitized installation plan screen" width="720">
+<img src="https://cdn.jsdelivr.net/npm/relmio@latest/docs/images/setup/04-install-plan.png" alt="Sanitized installation plan screen" width="720">
 
 ### 5. Copy the verified n8n settings
 
-<img src="https://raw.githubusercontent.com/Demonbane18/n8n-openai-oauth-setup/main/docs/images/setup/05-bridge-ready.png" alt="Sanitized verified bridge screen" width="720">
+<img src="https://cdn.jsdelivr.net/npm/relmio@latest/docs/images/setup/05-bridge-ready.png" alt="Sanitized verified bridge screen" width="720">
 
 Use these values in an n8n OpenAI credential:
 
@@ -151,13 +155,16 @@ OpenAI may change or disable the underlying services at any time.
 
 ## Documentation
 
-- [Complete GitHub README and manual fallback](https://github.com/Demonbane18/n8n-openai-oauth-setup#readme)
-- [Configure n8n AI and HTTP nodes](https://github.com/Demonbane18/n8n-openai-oauth-setup/blob/main/docs/n8n-configuration.md)
-- [Troubleshooting](https://github.com/Demonbane18/n8n-openai-oauth-setup/blob/main/docs/troubleshooting.md)
-- [Security and limitations](https://github.com/Demonbane18/n8n-openai-oauth-setup/blob/main/docs/security.md)
-- [Refresh, upgrade, rollback, and uninstall](https://github.com/Demonbane18/n8n-openai-oauth-setup/blob/main/docs/maintenance.md)
-- [Changelog](https://github.com/Demonbane18/n8n-openai-oauth-setup/blob/main/CHANGELOG.md)
+- [Complete GitHub README and manual fallback](https://github.com/Demonbane18/relmio#readme)
+- [Configure n8n AI and HTTP nodes](https://github.com/Demonbane18/relmio/blob/main/docs/n8n-configuration.md)
+- [Troubleshooting](https://github.com/Demonbane18/relmio/blob/main/docs/troubleshooting.md)
+- [Security and limitations](https://github.com/Demonbane18/relmio/blob/main/docs/security.md)
+- [Refresh, upgrade, rollback, and uninstall](https://github.com/Demonbane18/relmio/blob/main/docs/maintenance.md)
+- [Changelog](https://github.com/Demonbane18/relmio/blob/main/CHANGELOG.md)
 
 ## License
 
-[MIT](https://github.com/Demonbane18/n8n-openai-oauth-setup/blob/main/LICENSE)
+[Apache License 2.0](https://github.com/Demonbane18/relmio/blob/main/LICENSE).
+See the package
+[NOTICE](https://github.com/Demonbane18/relmio/blob/main/NOTICE) for the
+upstream `openai-oauth` attribution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,14 @@
     "": {
       "name": "relmio",
       "version": "0.2.1",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "ssh2": "1.17.0"
       },
       "bin": {
-        "relmio": "src/cli.js",
+        "n8n-openai-oauth-setup": "src/cli.js",
         "planrelay": "src/cli.js",
-        "n8n-openai-oauth-setup": "src/cli.js"
+        "relmio": "src/cli.js"
       },
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "version": "0.2.1",
   "description": "Turn a supported ChatGPT/Codex OAuth sign-in into a private OpenAI-compatible endpoint, starting with self-hosted n8n.",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Demonbane18/n8n-openai-oauth-setup.git"
+    "url": "git+https://github.com/Demonbane18/relmio.git"
   },
   "bugs": {
-    "url": "https://github.com/Demonbane18/n8n-openai-oauth-setup/issues"
+    "url": "https://github.com/Demonbane18/relmio/issues"
   },
-  "homepage": "https://relmio.jpfusin.tech/",
+  "homepage": "https://relmio.vercel.app/",
   "engines": {
     "node": ">=22"
   },
@@ -28,7 +28,8 @@
     "README.md",
     "SPEC.md",
     "CHANGELOG.md",
-    "LICENSE"
+    "LICENSE",
+    "NOTICE"
   ],
   "scripts": {
     "start": "node src/cli.js",

--- a/test/package-contents.test.js
+++ b/test/package-contents.test.js
@@ -18,6 +18,7 @@ const projectRoot = fileURLToPath(new URL("..", import.meta.url));
 const expectedPackedFiles = new Set([
   "CHANGELOG.md",
   "LICENSE",
+  "NOTICE",
   "README.md",
   "SPEC.md",
   "package.json",
@@ -149,20 +150,21 @@ test("npm package substitutes a registry-safe README without changing GitHub dia
   assert.match(githubReadme, /```mermaid/u);
   assert.doesNotMatch(npmReadme, /```mermaid/u);
   assert.match(npmReadme, /npx --yes --ignore-scripts relmio@latest/u);
-  assert.match(npmReadme, /https:\/\/relmio\.jpfusin\.tech\//u);
+  assert.match(npmReadme, /https:\/\/relmio\.vercel\.app\//u);
+  assert.doesNotMatch(npmReadme, /relmio\.jpfusin\.tech/u);
   assert.match(npmReadme, /## Known limitations/u);
   assert.match(npmReadme, /## Legal/u);
   assert.match(
     npmReadme,
-    /https:\/\/raw\.githubusercontent\.com\/Demonbane18\/n8n-openai-oauth-setup\/main\/docs\/images\/brand\/relmio-mark\.svg/u,
+    /https:\/\/cdn\.jsdelivr\.net\/npm\/relmio@latest\/docs\/images\/brand\/relmio-mark\.svg/u,
   );
   assert.match(
     npmReadme,
-    /https:\/\/raw\.githubusercontent\.com\/Demonbane18\/n8n-openai-oauth-setup\/main\/docs\/images\/setup\/05-bridge-ready\.png/u,
+    /https:\/\/cdn\.jsdelivr\.net\/npm\/relmio@latest\/docs\/images\/setup\/05-bridge-ready\.png/u,
   );
 
   for (const [, source] of npmReadme.matchAll(/<img[^>]+src="([^"]+)"/gu)) {
-    assert.match(source, /^https:\/\/raw\.githubusercontent\.com\//u);
+    assert.match(source, /^https:\/\/cdn\.jsdelivr\.net\/npm\/relmio@latest\//u);
   }
 });
 

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -3,7 +3,12 @@ import { access, readFile } from "node:fs/promises";
 import test from "node:test";
 
 test("project pins the reviewed SSH dependency and Node runtime", async () => {
-  const packageJson = JSON.parse(await readFile("package.json", "utf8"));
+  const [packageContents, license, notice] = await Promise.all([
+    readFile("package.json", "utf8"),
+    readFile("LICENSE", "utf8"),
+    readFile("NOTICE", "utf8"),
+  ]);
+  const packageJson = JSON.parse(packageContents);
 
   assert.equal(packageJson.engines.node, ">=22");
   assert.equal(packageJson.packageManager, "npm@10.9.8");
@@ -13,8 +18,21 @@ test("project pins the reviewed SSH dependency and Node runtime", async () => {
   assert.equal(packageJson.bin.planrelay, "src/cli.js");
   assert.equal(packageJson.bin["n8n-openai-oauth-setup"], "src/cli.js");
   assert.equal(packageJson.private, undefined);
-  assert.equal(packageJson.license, "MIT");
-  assert.equal(packageJson.homepage, "https://relmio.jpfusin.tech/");
+  assert.equal(packageJson.license, "Apache-2.0");
+  assert.match(license, /Apache License/u);
+  assert.doesNotMatch(license, /^MIT License$/mu);
+  assert.match(license, /3\. Grant of Patent License\./u);
+  assert.match(notice, /Evan Zhou and OpenAI OAuth contributors/u);
+  assert.match(notice, /github\.com\/EvanZhouDev\/openai-oauth/u);
+  assert.equal(
+    packageJson.repository.url,
+    "git+https://github.com/Demonbane18/relmio.git",
+  );
+  assert.equal(
+    packageJson.bugs.url,
+    "https://github.com/Demonbane18/relmio/issues",
+  );
+  assert.equal(packageJson.homepage, "https://relmio.vercel.app/");
 });
 
 test("double-click launchers only install local dependencies and start the wizard", async () => {
@@ -97,7 +115,8 @@ test("public README documents the latest npm walkthrough and sanitized images", 
   assert.match(readme, /\[Changelog\]\(CHANGELOG\.md\)/u);
   assert.match(readme, /img\.shields\.io\/npm\/v\/relmio/u);
   assert.match(readme, /docs\/images\/brand\/relmio-mark\.svg/u);
-  assert.match(readme, /https:\/\/relmio\.jpfusin\.tech\//u);
+  assert.match(readme, /https:\/\/relmio\.vercel\.app\//u);
+  assert.doesNotMatch(readme, /relmio\.jpfusin\.tech/u);
   assert.match(readme, /## Known limitations/u);
   assert.match(readme, /## Legal/u);
 });

--- a/web/app/api/project-meta/route.ts
+++ b/web/app/api/project-meta/route.ts
@@ -1,0 +1,61 @@
+const fallbackVersion = "0.2.1";
+const cacheHeader = "public, s-maxage=900, stale-while-revalidate=3600";
+
+async function fetchMetadata(url: string, headers?: HeadersInit) {
+  try {
+    const response = await fetch(url, {
+      headers,
+      next: { revalidate: 900 },
+    });
+    return response.ok ? ((await response.json()) as unknown) : null;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export async function GET() {
+  const [repositoryMetadata, packageMetadata] = await Promise.all([
+    fetchMetadata("https://api.github.com/repos/Demonbane18/relmio", {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "relmio-web",
+    }),
+    fetchMetadata("https://registry.npmjs.org/relmio/latest"),
+  ]);
+
+  let stars: number | null = null;
+  let version = fallbackVersion;
+
+  if (isRecord(repositoryMetadata)) {
+    const repositoryStars = repositoryMetadata.stargazers_count;
+    if (
+      typeof repositoryStars === "number" &&
+      Number.isInteger(repositoryStars) &&
+      repositoryStars >= 0
+    ) {
+      stars = repositoryStars;
+    }
+  }
+
+  if (isRecord(packageMetadata)) {
+    const packageVersion = packageMetadata.version;
+    if (
+      typeof packageVersion === "string" &&
+      /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u.test(packageVersion)
+    ) {
+      version = packageVersion;
+    }
+  }
+
+  return Response.json(
+    { stars, version },
+    {
+      headers: {
+        "Cache-Control": cacheHeader,
+      },
+    },
+  );
+}

--- a/web/app/components/CopyCommand.tsx
+++ b/web/app/components/CopyCommand.tsx
@@ -17,6 +17,12 @@ export function CopyCommand() {
   }, []);
 
   async function copy() {
+    setCopied(true);
+    if (revertTimer.current !== null) {
+      window.clearTimeout(revertTimer.current);
+    }
+    revertTimer.current = window.setTimeout(() => setCopied(false), 1800);
+
     try {
       await navigator.clipboard.writeText(command);
     } catch {
@@ -30,11 +36,6 @@ export function CopyCommand() {
       document.execCommand("copy");
       textarea.remove();
     }
-    setCopied(true);
-    if (revertTimer.current !== null) {
-      window.clearTimeout(revertTimer.current);
-    }
-    revertTimer.current = window.setTimeout(() => setCopied(false), 1800);
   }
 
   return (

--- a/web/app/components/RepositoryButton.tsx
+++ b/web/app/components/RepositoryButton.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type ProjectMeta = {
+  stars: number | null;
+  version: string;
+};
+
+const fallbackMeta: ProjectMeta = {
+  stars: null,
+  version: "0.2.1",
+};
+
+function formatStars(stars: number) {
+  return new Intl.NumberFormat("en", {
+    notation: stars >= 1_000 ? "compact" : "standard",
+    maximumFractionDigits: 1,
+  }).format(stars);
+}
+
+export function RepositoryButton() {
+  const [meta, setMeta] = useState(fallbackMeta);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    void fetch("/api/project-meta", {
+      credentials: "same-origin",
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) return;
+        const nextMeta = (await response.json()) as Partial<ProjectMeta>;
+        setMeta({
+          stars:
+            typeof nextMeta.stars === "number" && nextMeta.stars >= 0
+              ? nextMeta.stars
+              : null,
+          version:
+            typeof nextMeta.version === "string"
+              ? nextMeta.version
+              : fallbackMeta.version,
+        });
+      })
+      .catch(() => {});
+
+    return () => controller.abort();
+  }, []);
+
+  const stars = meta.stars === null ? "—" : formatStars(meta.stars);
+
+  return (
+    <a
+      className="repository-button"
+      href="https://github.com/Demonbane18/relmio"
+      target="_blank"
+      rel="noreferrer"
+      aria-label={`Open Relmio version ${meta.version} on GitHub. ${
+        meta.stars === null
+          ? "GitHub star count is currently unavailable."
+          : `${meta.stars} GitHub stars.`
+      }`}
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          fill="currentColor"
+          d="M12 .7a11.5 11.5 0 0 0-3.64 22.41c.58.11.79-.25.79-.56v-2.23c-3.22.7-3.9-1.37-3.9-1.37-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.71.08-.71 1.16.08 1.77 1.19 1.77 1.19 1.04 1.77 2.72 1.26 3.38.96.1-.75.4-1.26.73-1.55-2.57-.29-5.28-1.29-5.28-5.69 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.16 1.18a10.9 10.9 0 0 1 5.76 0c2.19-1.49 3.16-1.18 3.16-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.83 1.19 3.09 0 4.42-2.71 5.4-5.29 5.69.42.36.79 1.06.79 2.14v3.17c0 .31.21.68.8.56A11.5 11.5 0 0 0 12 .7Z"
+        />
+      </svg>
+      <strong>GitHub</strong>
+      <span className="repository-stat">
+        <span aria-hidden="true">★</span>
+        {stars}
+      </span>
+      <span className="repository-version">v{meta.version}</span>
+    </a>
+  );
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -159,23 +159,72 @@ main {
   color: var(--teal-deep);
 }
 
-.header-action {
+.repository-button {
   justify-self: end;
-  padding: 10px 17px;
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 6px 8px 6px 13px;
   border: 1px solid var(--ink);
   border-radius: 999px;
-  font-size: 0.83rem;
+  background: var(--ink);
+  color: var(--white);
+  font-size: 0.78rem;
   font-weight: 650;
   transition:
     background 200ms var(--ease),
     color 200ms var(--ease),
-    transform 200ms var(--ease);
+    transform 200ms var(--ease),
+    border-color 200ms var(--ease);
 }
 
-.header-action:hover {
-  background: var(--ink);
-  color: var(--white);
+.repository-button:hover {
+  border-color: var(--teal);
+  background: var(--teal);
   transform: translateY(-1px);
+}
+
+.repository-button > svg {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+}
+
+.repository-button strong {
+  font-size: 0.8rem;
+}
+
+.repository-stat,
+.repository-version {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 9px;
+  border-radius: 999px;
+  background: rgb(255 255 255 / 10%);
+  color: #dce6e2;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.66rem;
+  font-weight: 650;
+}
+
+.repository-version {
+  background: var(--white);
+  color: var(--ink);
+}
+
+.install-back-link {
+  justify-self: center;
+  color: var(--ink-soft);
+  font-size: 0.86rem;
+  font-weight: 600;
+  transition: color 180ms var(--ease);
+}
+
+.install-back-link:hover {
+  color: var(--teal);
 }
 
 /* ---------- Hero ---------- */
@@ -1374,6 +1423,162 @@ main {
   background: var(--mint);
 }
 
+/* ---------- Install wizard ---------- */
+
+.install-shell {
+  min-height: 100vh;
+}
+
+.install-page {
+  min-height: calc(100vh - 73px);
+  display: grid;
+  place-items: center;
+  padding: clamp(72px, 10vw, 132px) 20px;
+  background:
+    radial-gradient(
+      42% 50% at 50% 6%,
+      color-mix(in srgb, var(--teal) 12%, transparent),
+      transparent 72%
+    ),
+    var(--paper-light);
+}
+
+.install-panel {
+  width: min(760px, 100%);
+  text-align: center;
+}
+
+.install-eyebrow {
+  width: fit-content;
+  margin-inline: auto;
+}
+
+.install-panel h1 {
+  max-width: 700px;
+  margin: 0 auto;
+  font-size: clamp(3rem, 7.5vw, 5.4rem);
+  line-height: 0.98;
+  letter-spacing: -0.065em;
+}
+
+.install-lede {
+  max-width: 650px;
+  margin: 26px auto 0;
+  color: var(--ink-soft);
+  font-size: clamp(1.05rem, 2vw, 1.2rem);
+  line-height: 1.62;
+}
+
+.install-command-stage {
+  max-width: 650px;
+  margin: 40px auto 0;
+  text-align: left;
+}
+
+.install-command-stage > p {
+  margin: 0 0 10px;
+  color: var(--ink-soft);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.7rem;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.install-command-stage .install-command {
+  width: 100%;
+  min-height: 66px;
+  margin: 0;
+  padding: 14px 17px;
+  border-color: var(--dark);
+  background: var(--dark);
+  color: var(--white);
+  box-shadow: var(--shadow-lg);
+}
+
+.install-command-stage .install-command:hover {
+  border-color: var(--teal);
+}
+
+.install-command-stage .install-command code {
+  font-size: clamp(0.76rem, 2vw, 0.9rem);
+}
+
+.install-command-stage .copy-hint {
+  margin-left: auto;
+  background: rgb(255 255 255 / 10%);
+  color: var(--white);
+}
+
+.install-boundary {
+  max-width: 650px;
+  margin: 24px auto 0;
+  padding: 18px 20px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--white);
+  color: var(--ink-soft);
+  font-size: 0.86rem;
+  line-height: 1.55;
+  text-align: left;
+}
+
+.install-boundary strong {
+  color: var(--ink);
+}
+
+.install-steps {
+  max-width: 650px;
+  margin: 18px auto 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--white);
+  text-align: left;
+  overflow: hidden;
+}
+
+.install-steps li {
+  min-height: 156px;
+  padding: 20px;
+  border-right: 1px solid var(--line);
+}
+
+.install-steps li:last-child {
+  border-right: 0;
+}
+
+.install-steps li > span {
+  display: block;
+  margin-bottom: 24px;
+  color: var(--teal);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.68rem;
+  font-weight: 750;
+}
+
+.install-steps strong {
+  font-size: 0.85rem;
+}
+
+.install-steps p {
+  margin: 7px 0 0;
+  color: var(--ink-soft);
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+
+.install-page-actions {
+  margin-top: 28px;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 /* ---------- Footer ---------- */
 
 footer {
@@ -1400,6 +1605,14 @@ footer > p {
   font-size: 0.78rem;
   line-height: 1.5;
   text-align: center;
+}
+
+footer > p a {
+  color: var(--ink);
+  font-weight: 650;
+  text-decoration: underline;
+  text-decoration-color: var(--line-strong);
+  text-underline-offset: 3px;
 }
 
 footer > div {
@@ -1566,9 +1779,21 @@ footer > div {
     min-height: 64px;
   }
 
-  .header-action {
-    padding: 9px 12px;
-    font-size: 0.74rem;
+  .repository-button {
+    padding-left: 10px;
+  }
+
+  .repository-button strong {
+    display: none;
+  }
+
+  .repository-stat,
+  .repository-version {
+    padding-inline: 7px;
+  }
+
+  .install-back-link {
+    display: none;
   }
 
   .hero {
@@ -1579,6 +1804,32 @@ footer > div {
 
   .hero h1 {
     font-size: clamp(2.9rem, 13vw, 4.4rem);
+  }
+
+  .install-page {
+    min-height: calc(100vh - 65px);
+    padding: 58px 14px 72px;
+  }
+
+  .install-steps {
+    grid-template-columns: 1fr;
+  }
+
+  .install-steps li {
+    min-height: 0;
+    display: grid;
+    grid-template-columns: 34px 1fr;
+    gap: 12px;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .install-steps li:last-child {
+    border-bottom: 0;
+  }
+
+  .install-steps li > span {
+    margin: 2px 0 0;
   }
 
   .route-lane {

--- a/web/app/install/page.tsx
+++ b/web/app/install/page.tsx
@@ -1,0 +1,104 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import { CopyCommand } from "../components/CopyCommand";
+import { RepositoryButton } from "../components/RepositoryButton";
+
+export const metadata: Metadata = {
+  title: "Install Relmio for n8n",
+  description:
+    "Run the local Relmio wizard for a self-hosted n8n deployment, including Hostinger VPS setups.",
+};
+
+const steps = [
+  {
+    index: "01",
+    title: "Run locally",
+    copy: "Start the wizard on your own computer, not on the VPS.",
+  },
+  {
+    index: "02",
+    title: "Verify the VPS",
+    copy: "Confirm the SSH fingerprint before entering your server password.",
+  },
+  {
+    index: "03",
+    title: "Approve the sidecar",
+    copy: "Review the plan before Relmio writes its separate Docker project.",
+  },
+];
+
+export default function InstallPage() {
+  return (
+    <main className="install-shell" id="main-content">
+      <a className="skip-link" href="#install-command">
+        Skip to installation command
+      </a>
+      <header className="site-header install-header">
+        <div className="site-header-inner">
+          <Link className="brand" href="/" aria-label="Relmio home">
+            <Image
+              src="/relmio-mark.svg"
+              alt=""
+              width={38}
+              height={38}
+              priority
+            />
+            <span>Relmio</span>
+          </Link>
+          <Link className="install-back-link" href="/">
+            Hosted chat
+          </Link>
+          <RepositoryButton />
+        </div>
+      </header>
+
+      <section className="install-page">
+        <div className="install-panel">
+          <p className="eyebrow install-eyebrow">
+            <span className="status-dot" aria-hidden="true" />
+            n8n + Hostinger VPS
+          </p>
+          <h1>Install Relmio for n8n</h1>
+          <p className="install-lede">
+            Run one local wizard to sign in with ChatGPT, verify your VPS, and
+            install a private OpenAI-compatible sidecar beside n8n.
+          </p>
+
+          <div className="install-command-stage" id="install-command">
+            <p>Run in Terminal or PowerShell</p>
+            <CopyCommand />
+          </div>
+
+          <p className="install-boundary">
+            <strong>Run this on your own computer.</strong> Relmio supports the
+            self-hosted n8n and Hostinger VPS method for now. It does not edit,
+            rebuild, or restart your existing n8n container.
+          </p>
+
+          <ol className="install-steps">
+            {steps.map((step) => (
+              <li key={step.index}>
+                <span>{step.index}</span>
+                <div>
+                  <strong>{step.title}</strong>
+                  <p>{step.copy}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+
+          <div className="install-page-actions">
+            <Link className="button button-primary" href="/">
+              Back to Relmio
+              <span aria-hidden="true">↖</span>
+            </Link>
+            <Link className="button button-secondary" href="/#security">
+              Review the safety boundary
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
+import Link from "next/link";
 import { ChatConsole } from "./components/ChatConsole";
-import { CopyCommand } from "./components/CopyCommand";
+import { RepositoryButton } from "./components/RepositoryButton";
 
 const capabilities = [
   {
@@ -58,14 +59,7 @@ export default function Home() {
             <a href="#security">Security</a>
             <a href="#chat">Chat</a>
           </nav>
-          <a
-            className="header-action"
-            href="https://www.npmjs.com/package/relmio"
-            target="_blank"
-            rel="noreferrer"
-          >
-            View npm package
-          </a>
+          <RepositoryButton />
         </div>
       </header>
 
@@ -80,25 +74,22 @@ export default function Home() {
             <span>One clean path to your tools.</span>
           </h1>
           <p className="hero-lede">
-            Relmio connects a supported ChatGPT/Codex sign-in to the
-            OpenAI-shaped workflows you already use—starting with n8n, now
-            with a secure hosted chat.
+            Test a supported ChatGPT sign-in in the hosted chat. For n8n,
+            install Relmio&apos;s private sidecar and keep the relay inside
+            your own Docker network.
           </p>
           <div className="hero-actions">
             <a className="button button-primary" href="#chat">
               Try the secure chat
               <span aria-hidden="true">↘</span>
             </a>
-            <a
+            <Link
               className="button button-secondary"
-              href="https://www.npmjs.com/package/relmio"
-              target="_blank"
-              rel="noreferrer"
+              href="/install"
             >
-              Install for n8n
-            </a>
+              Install wizard
+            </Link>
           </div>
-          <CopyCommand />
         </div>
 
         <div className="relay-visual" aria-label="Relmio request flow">
@@ -241,15 +232,13 @@ export default function Home() {
           <p className="section-label">Start locally</p>
           <h2>Bring your own plan. Keep your own boundary.</h2>
         </div>
-        <a
+        <Link
           className="button button-primary"
-          href="https://www.npmjs.com/package/relmio"
-          target="_blank"
-          rel="noreferrer"
+          href="/install"
         >
-          Open Relmio on npm
-          <span aria-hidden="true">↗</span>
-        </a>
+          Install the wizard
+          <span aria-hidden="true">↘</span>
+        </Link>
       </section>
 
       <footer>
@@ -257,7 +246,17 @@ export default function Home() {
           <Image src="/relmio-mark.svg" alt="" width={32} height={32} />
           <span>Relmio</span>
         </a>
-        <p>Private OpenAI-compatible access, beginning with self-hosted n8n.</p>
+        <p>
+          Hosted sign-in uses the{" "}
+          <a
+            href="https://github.com/EvanZhouDev/openai-oauth"
+            target="_blank"
+            rel="noreferrer"
+          >
+            openai-oauth method by Evan Zhou Dev
+          </a>
+          .
+        </p>
         <div>
           <a
             href="https://www.npmjs.com/package/relmio"
@@ -267,7 +266,7 @@ export default function Home() {
             npm
           </a>
           <a
-            href="https://github.com/Demonbane18/n8n-openai-oauth-setup"
+            href="https://github.com/Demonbane18/relmio"
             target="_blank"
             rel="noreferrer"
           >

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -33,12 +33,74 @@ test("server-renders the Relmio product page", async () => {
   assert.match(html, /<title>Relmio — Your ChatGPT plan, relayed<\/title>/i);
   assert.match(html, /Your ChatGPT plan\./);
   assert.match(html, /One clean path to your tools\./);
+  assert.match(html, /Test a supported ChatGPT sign-in in the hosted chat\./);
+  assert.match(
+    html,
+    /keep the relay inside your own Docker network\./,
+  );
+  assert.doesNotMatch(html, /OpenAI-shaped workflows you already use/);
   assert.match(html, /Try the secure chat/);
+  assert.match(html, /href="\/install"[^>]*>Install wizard<\/a>/);
   assert.match(html, /Connect, then ask\./);
   assert.match(html, /Private where it matters\./);
-  assert.match(html, /npx --yes --ignore-scripts relmio@latest/);
-  assert.match(html, /https:\/\/github\.com\/Demonbane18\/n8n-openai-oauth-setup/);
+  assert.doesNotMatch(html, /npx --yes --ignore-scripts relmio@latest/);
+  assert.match(html, /https:\/\/github\.com\/Demonbane18\/relmio/);
+  assert.match(html, /openai-oauth/);
+  assert.match(html, /Evan Zhou Dev/);
   assert.doesNotMatch(html, /codex-preview|Your site is taking shape/);
+});
+
+test("renders a command-first n8n and Hostinger VPS install page", async () => {
+  const response = await requestApp("/install");
+  assert.equal(response.status, 200);
+
+  const html = await response.text();
+  assert.match(html, /Install Relmio for n8n/);
+  assert.match(html, /Hostinger VPS/);
+  assert.match(html, /npx --yes --ignore-scripts relmio@latest/);
+  assert.match(html, /Copy installation command/);
+  assert.match(html, /Run this on your own computer/);
+  assert.doesNotMatch(html, /href="https:\/\/www\.npmjs\.com/);
+});
+
+test("returns current repository stars and npm version for the GitHub control", async (t) => {
+  t.mock.method(globalThis, "fetch", async (input) => {
+    const url = String(input);
+    if (url.includes("api.github.com/repos/Demonbane18/relmio")) {
+      return Response.json({ stargazers_count: 42 });
+    }
+    if (url.includes("registry.npmjs.org/relmio/latest")) {
+      return Response.json({ version: "0.2.1" });
+    }
+    return new Response("Not found", { status: 404 });
+  });
+
+  const response = await requestApp("/api/project-meta");
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    stars: 42,
+    version: "0.2.1",
+  });
+  assert.match(response.headers.get("cache-control") ?? "", /s-maxage=900/);
+});
+
+test("falls back safely when project metadata is malformed", async (t) => {
+  t.mock.method(
+    globalThis,
+    "fetch",
+    async () =>
+      new Response("{", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+
+  const response = await requestApp("/api/project-meta");
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    stars: null,
+    version: "0.2.1",
+  });
 });
 
 test("rejects non-string chat prompts before reading credentials", async () => {


### PR DESCRIPTION
## Summary
- add the command-first n8n and Hostinger VPS install page
- show live GitHub stars and the published package version
- move public links to relmio.vercel.app and credit openai-oauth
- adopt Apache-2.0 with a distributed upstream NOTICE
- finalize the streaming fix and Vercel release documentation

## Verification
- npm run check (69 tests)
- web lint and typecheck
- web test (14 tests)
- Next.js Vercel production build
- Vinext rollback build
- npm audit: 0 vulnerabilities
- Opera GX visual QA
- reviewed relmio-0.2.1.tgz