### PR TITLE
docs: add quick install and explain the sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@
   </p>
 </div>
 
+## Quick install
+
+Copy and paste this into your terminal on your own computer:
+
+```bash
+npx --yes --ignore-scripts relmio@latest
+```
+
 Relmio is a local browser wizard that currently installs
 [`openai-oauth@2.0.0`](https://github.com/EvanZhouDev/openai-oauth/releases/tag/v2.0.0)
 as a separate Docker sidecar beside a self-hosted n8n instance. It guides a

--- a/README.md
+++ b/README.md
@@ -148,6 +148,25 @@ This is the standard sidecar pattern: a small, modular helper alongside an
 existing application. For a beginner-friendly overview, see
 [Justin Rice's explanation of software sidecars](https://medium.com/@justinricedev/what-is-a-software-sidecar-8f89feff09f9).
 
+### A tricycle is a useful analogy
+
+Think of n8n as a motorcycle: it already gets your workflow where it needs to
+go. Relmio adds a sidecar, turning the pair into a tricycle with extra room for
+passengers. The motorcycle remains the same, while the sidecar adds a new
+capability, in this case ChatGPT/Codex sign-in and translation for n8n.
+
+```mermaid
+flowchart LR
+  Motorcycle["Motorcycle<br/>your existing n8n"]
+  Sidecar["Sidecar<br/>Relmio helper"]
+  Tricycle["Tricycle<br/>n8n + Relmio"]
+  Passengers["Extra seats<br/>new capabilities for more workflows"]
+
+  Motorcycle -->|"stays unchanged"| Tricycle
+  Sidecar -->|"adds sign-in and translation"| Tricycle
+  Tricycle -->|"makes room for"| Passengers
+```
+
 ## Current scope and direction
 
 **Available now:** Relmio signs in locally, verifies a VPS over SSH, and

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ one automation platform.
 <summary><strong>Table of contents</strong></summary>
 
 - [What this does, in plain English](#what-this-does-in-plain-english)
+- [What is a sidecar?](#what-is-a-sidecar)
 - [Current scope and direction](#current-scope-and-direction)
 - [Hosted ChatGPT site](#hosted-chatgpt-site)
 - [Choose a setup path](#choose-a-setup-path)
@@ -122,6 +123,30 @@ Think of the sidecar as an interpreter in a private room: n8n speaks the API
 format it already knows, while the sidecar handles the different sign-in
 method. The sidecar shares a private Docker network with n8n; port `10531` is
 not published to the internet.
+
+## What is a sidecar?
+
+A sidecar is a small helper program that runs beside a larger program. It adds
+one missing capability without changing the main program. In Relmio, your n8n
+stays as it is; the private sidecar handles ChatGPT/Codex sign-in and translates
+n8n's normal requests. Remove the sidecar and your existing n8n is still
+unchanged.
+
+```mermaid
+flowchart LR
+  N8N["Your n8n<br/>stays the same"]
+  Sidecar["Relmio sidecar<br/>small private helper"]
+  ChatGPT["ChatGPT/Codex<br/>your sign-in"]
+
+  N8N -->|"sends a request"| Sidecar
+  Sidecar -->|"handles sign-in"| ChatGPT
+  ChatGPT -->|"returns an answer"| Sidecar
+  Sidecar -->|"sends the answer"| N8N
+```
+
+This is the standard sidecar pattern: a small, modular helper alongside an
+existing application. For a beginner-friendly overview, see
+[Justin Rice's explanation of software sidecars](https://medium.com/@justinricedev/what-is-a-software-sidecar-8f89feff09f9).
 
 ## Current scope and direction
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -26,6 +26,10 @@ private sidecar adds ChatGPT/Codex sign-in and request translation while your
 existing n8n stays unchanged. This follows the sidecar pattern described in
 [Justin Rice's beginner-friendly overview](https://medium.com/@justinricedev/what-is-a-software-sidecar-8f89feff09f9).
 
+Think of it like a motorcycle gaining a sidecar: together they become a
+tricycle with extra seats. n8n is the motorcycle; Relmio is the sidecar that
+adds the missing capability without changing n8n.
+
 Try the hosted browser demo at
 [relmio.vercel.app](https://relmio.vercel.app/). It is a separate
 request-bound ChatGPT experience; the npm package remains the local wizard for

--- a/npm/README.md
+++ b/npm/README.md
@@ -21,6 +21,11 @@ exact change plan, and the final n8n credential settings.
 
 The existing n8n image, Compose file, container, and workflows stay untouched.
 
+A sidecar is a small helper program that runs beside a larger program. Relmio's
+private sidecar adds ChatGPT/Codex sign-in and request translation while your
+existing n8n stays unchanged. This follows the sidecar pattern described in
+[Justin Rice's beginner-friendly overview](https://medium.com/@justinricedev/what-is-a-software-sidecar-8f89feff09f9).
+
 Try the hosted browser demo at
 [relmio.vercel.app](https://relmio.vercel.app/). It is a separate
 request-bound ChatGPT experience; the npm package remains the local wizard for


### PR DESCRIPTION
## Summary\n- add a prominent copy-paste quick install command near the top of the GitHub README\n- explain the Relmio sidecar in beginner-friendly language with a simple Mermaid diagram\n- add the matching text-only explanation to npm/README.md\n- credit Justin Rice's sidecar overview as the explanatory source\n\n## Verification\n- npm run check\n- npm audit --audit-level=high\n- npm run package:build -- .release\n- 69 tests passing