### PR TITLE
release: v0.2.2 keyword metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+## [0.2.2] - 2026-07-30
+
+### Added
+
+- Add aligned npm keywords and GitHub repository topics for Relmio, GPT model
+  variants, n8n, AI agents, and API-key discovery.
+
 ## [0.2.1] - 2026-07-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relmio",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relmio",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "ssh2": "1.17.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,21 @@
 {
   "name": "relmio",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Turn a supported ChatGPT/Codex OAuth sign-in into a private OpenAI-compatible endpoint, starting with self-hosted n8n.",
+  "keywords": [
+    "relmio",
+    "gpt-5-6-sol",
+    "gpt-5-6-terra",
+    "gpt-5-6-luna",
+    "gpt-2-0-image",
+    "n8n",
+    "ai-agent",
+    "api-key",
+    "ai",
+    "chatgpt",
+    "codex",
+    "openai"
+  ],
   "type": "module",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary\n- add the requested keyword set to package.json for npm discovery\n- release patch version 0.2.2 so npm can publish the immutable metadata\n- keep CHANGELOG and package-lock synchronized\n- align GitHub repository topics with the package keywords using GitHub-safe lowercase slugs\n\n## Keywords\nrelmio, gpt-5-6-sol, gpt-5-6-terra, gpt-5-6-luna, gpt-2-0-image, n8n, ai-agent, api-key, ai, chatgpt, codex, openai\n\n## Verification\n- npm ci --ignore-scripts\n- npm run check (69 tests passing)\n- npm audit --audit-level=high\n- npm run package:build -- .release\n- tarball package metadata inspected