### PR TITLE
release: v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+## [0.2.3] - 2026-07-31
+
+### Added
+
+- Add sanitized GPT-5.6 Sol and Luna AI Agent examples, a model-selector
+  compatibility preview, and the completed Docker sidecar state to both the
+  GitHub and npm README experiences.
+
 ## [0.2.2] - 2026-07-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relmio",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relmio",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "ssh2": "1.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relmio",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Turn a supported ChatGPT/Codex OAuth sign-in into a private OpenAI-compatible endpoint, starting with self-hosted n8n.",
   "keywords": [
     "relmio",


### PR DESCRIPTION
## Summary

- Release Relmio `0.2.3` so the synchronized npm README and sanitized GPT-5.6/sidecar screenshots reach the live npm package page.
- Update `package.json` and `package-lock.json` to the new immutable patch version.
- Record the README experience update in the changelog.

## Validation

- `npm ci --ignore-scripts`
- `npm run check` — all 70 tests passed
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm run package:build -- .release`
- Inspected `.release/relmio-0.2.3.tgz`; the npm README and sanitized example images are present
- `git diff --check`

## Publishing

After this release commit passes CI and merges to `main`, tag `v0.2.3` and publish the GitHub release to trigger npm trusted publishing.
