### PR TITLE
release: v0.2.4 with openai-oauth attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+## [0.2.4] - 2026-07-31
+
+### Changed
+
+- Add explicit foundation and attribution language for Evan Zhou Dev's
+  `openai-oauth` project to the GitHub and npm README explanations.
+
 ## [0.2.3] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -697,6 +697,17 @@ provide an OpenAI-compatible interface without asking users to buy separate
 OpenAI Platform API credits. The exact upstream behavior, supported models,
 and access rules can change.
 
+### Foundation and attribution
+
+Relmio's core sign-in and upstream request path are built on the
+[`openai-oauth`](https://github.com/EvanZhouDev/openai-oauth) project by Evan
+Zhou Dev. The upstream project provides an SDK/helper for integrating ChatGPT
+login into local apps and enabling Sign in with ChatGPT flows. Relmio uses
+that foundation for its private OAuth sidecar, then adds n8n discovery,
+verified SSH/SFTP deployment, Docker networking, and OpenAI-compatible
+configuration around it. The upstream project remains separately maintained;
+review its README, license, and notices for its own terms and behavior.
+
 ```mermaid
 flowchart LR
   subgraph Local["Your computer"]

--- a/npm/README.md
+++ b/npm/README.md
@@ -157,6 +157,15 @@ an OpenAI-compatible path without creating an OpenAI Platform API key or
 requiring separate API credits. The upstream service and its access rules may
 change.
 
+### Foundation and attribution
+
+Relmio is built on [`openai-oauth`](https://github.com/EvanZhouDev/openai-oauth)
+by Evan Zhou Dev. That upstream SDK/helper provides the foundation for ChatGPT
+login in local apps and Sign in with ChatGPT flows; Relmio wraps it with n8n
+discovery, verified SSH/SFTP deployment, Docker networking, and
+OpenAI-compatible configuration. Review the upstream project for its own
+license, notices, and supported behavior.
+
 ## Known limitations
 
 - Only models supported by Codex are available. The list changes over time and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relmio",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relmio",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "ssh2": "1.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relmio",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Turn a supported ChatGPT/Codex OAuth sign-in into a private OpenAI-compatible endpoint, starting with self-hosted n8n.",
   "keywords": [
     "relmio",

--- a/test/package-contents.test.js
+++ b/test/package-contents.test.js
@@ -161,6 +161,8 @@ test("npm package substitutes a registry-safe README without changing GitHub dia
   assert.doesNotMatch(npmReadme, /relmio\.jpfusin\.tech/u);
   assert.match(npmReadme, /## Known limitations/u);
   assert.match(npmReadme, /## Legal/u);
+  assert.match(npmReadme, /### Foundation and attribution/u);
+  assert.match(npmReadme, /openai-oauth.*Evan\s+Zhou\s+Dev/isu);
   assert.match(
     npmReadme,
     /https:\/\/cdn\.jsdelivr\.net\/npm\/relmio@latest\/docs\/images\/brand\/relmio-mark\.svg/u,

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -116,6 +116,8 @@ test("public README documents the latest npm walkthrough and sanitized images", 
   assert.match(readme, /img\.shields\.io\/npm\/v\/relmio/u);
   assert.match(readme, /docs\/images\/brand\/relmio-mark\.svg/u);
   assert.match(readme, /https:\/\/relmio\.vercel\.app\//u);
+  assert.match(readme, /### Foundation and attribution/u);
+  assert.match(readme, /openai-oauth.*Evan\s+Zhou\s+Dev/isu);
   assert.doesNotMatch(readme, /relmio\.jpfusin\.tech/u);
   assert.match(readme, /## Known limitations/u);
   assert.match(readme, /## Legal/u);


### PR DESCRIPTION
## Summary

- Add explicit attribution to Evan Zhou Dev's `openai-oauth` project in both README variants.
- Explain that `openai-oauth` provides the foundational ChatGPT login and Sign in with ChatGPT capability, while Relmio adds n8n discovery, verified SSH/SFTP deployment, Docker networking, and OpenAI-compatible configuration.
- Release the documentation update as `relmio@0.2.4`.

## Validation

- `npm ci --ignore-scripts`
- `npm run check` — all 70 tests passed
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm run package:build -- .release`
- Inspected the npm tarball README for attribution and no Mermaid markup
- `git diff --check`

After merge, tag `v0.2.4` and publish the GitHub release to trigger trusted npm publishing.
