### PR TITLE
Add universal wizard install options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+### Added
+
+- Add a curl-based wizard bootstrap for macOS, Linux, WSL, and Git Bash that
+  reuses Node.js 22+ or downloads and checksum-verifies a temporary official
+  runtime when Node.js is not installed.
+- Add an accessible Curl / NPX switcher to the hosted install page so users can
+  copy the command that matches their local runtime.
+
 ## [0.2.5] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,7 +41,21 @@ and the new private OAuth sidecar running together.
 
 ## Quick install
 
-Copy and paste this into your terminal on your own computer:
+On macOS, Linux, WSL, or Git Bash, copy and paste this into your terminal on
+your own computer:
+
+```bash
+curl -fsSL https://relmio.vercel.app/install.sh | sh
+```
+
+This starts the wizard without installing Node.js first. The open-source
+[bootstrap script](web/public/install.sh) reuses Node.js 22 or newer when it is
+already available. Otherwise it downloads the current official Node.js 22
+runtime to a private temporary directory, verifies its SHA-256 checksum, runs
+Relmio with npm lifecycle scripts disabled, and removes the temporary runtime
+when the wizard closes. It does not install Node.js system-wide.
+
+Already have Node.js 22 or newer? You can use NPX instead:
 
 ```bash
 npx --yes --ignore-scripts relmio@latest
@@ -261,9 +275,9 @@ OpenAI Platform API key or replace the local n8n setup wizard.
   <figcaption>Successful hosted-chat state: the browser extension completed the OAuth handoff and Relmio shows the ChatGPT session as connected.</figcaption>
 </figure>
 
-The site's [Install wizard](https://relmio.vercel.app/install) page provides
-the copyable npm command for the current self-hosted n8n and Hostinger VPS
-setup path.
+The site's [Install wizard](https://relmio.vercel.app/install) page provides a
+clickable Curl / NPX switcher for the current self-hosted n8n and Hostinger VPS
+setup path. Curl is the recommended default when Node.js is not installed.
 
 ## Choose a setup path
 
@@ -272,14 +286,14 @@ container, image, Compose file, and workflows alone.
 
 | Path | Best for | What you do |
 |---|---|---|
-| **npm browser wizard** | Most users | Follow guided screens, verify the server identity, review the plan, then approve |
+| **Browser wizard** | Most users | Run one curl command, follow guided screens, verify the server identity, review the plan, then approve |
 | **Manual setup** | Wizard failures, unusual VPS setups, debugging, and contributors | Run the underlying login, SSH, file, and Docker Compose steps yourself |
 
 ```mermaid
 flowchart TD
   Start["I want to connect my<br/>self-hosted n8n"]
   Choice{"Can I use the local<br/>browser wizard?"}
-  Wizard["Option A<br/>Run the npm wizard"]
+  Wizard["Option A<br/>Run the browser wizard"]
   Manual["Option B<br/>Follow the manual commands"]
   Review["Review what will change<br/>before remote writes"]
   Result["Same result<br/>one private OAuth sidecar beside n8n"]
@@ -302,8 +316,9 @@ you want to inspect, reproduce, improve, or debug the method, use
 
 ### Requirements
 
-- A local macOS, Windows, or Linux computer with
-  [Node.js 22 or newer](https://nodejs.org/en/download)
+- A local macOS or Linux computer, or Windows with WSL or Git Bash
+- `curl`, `awk`, `tar`, and a SHA-256 tool (`sha256sum` or `shasum`); Git Bash
+  also needs `unzip`. These are already available on most supported systems
 - A browser and a ChatGPT account eligible to use the upstream Codex flow
 - A self-hosted n8n Docker container on a VPS
 - Docker Engine and Docker Compose v2 on the VPS
@@ -317,12 +332,28 @@ you want to inspect, reproduce, improve, or debug the method, use
 > authenticates to your VPS and writes files there. Keep a recoverable backup
 > before granting it access.
 
-Do **not** run the npm command on the VPS. Run it on the computer where you
+Do **not** run the curl command on the VPS. Run it on the computer where you
 will complete the browser sign-in.
 
 ### 1. Start the newest published wizard
 
-Open Terminal, PowerShell, or another local shell:
+Open Terminal, WSL, or Git Bash:
+
+#### Curl (recommended)
+
+```bash
+curl -fsSL https://relmio.vercel.app/install.sh | sh
+```
+
+The bootstrap uses a supported Node.js installation when present. If Node.js
+is missing or older than 22, it downloads and verifies a temporary official
+Node.js 22 runtime without installing it system-wide.
+
+Native Windows PowerShell users, or anyone who already has
+[Node.js 22 or newer](https://nodejs.org/en/download), can run the npm package
+directly instead:
+
+#### NPX (requires Node.js 22+)
 
 ```bash
 npx --yes --ignore-scripts relmio@latest
@@ -334,7 +365,7 @@ update saved commands to `relmio`. The new package still exposes the legacy
 executable alias, and existing sidecar directories, service names, hostnames,
 and credentials remain compatible.
 
-Keep that terminal open. The command starts a one-time web server on
+Keep that terminal open. Either command starts a one-time web server on
 `127.0.0.1`, prints a private session URL, and opens the wizard in your
 browser. It does not globally install this package.
 
@@ -461,7 +492,7 @@ For complete copy-paste recipes for an **AI Agent**, **Basic LLM Chain**, and
 
 ## Run from a repository clone
 
-The npm command above is the recommended path. Contributors can instead run
+The curl command above is the recommended path. Contributors can instead run
 the source checkout:
 
 ```bash
@@ -797,12 +828,12 @@ Automated tests enforce this boundary.
 
 ## Refresh, update, and remove
 
-To refresh an expired ChatGPT session, run the same npm command again, choose
+To refresh an expired ChatGPT session, run the same curl command again, choose
 **Refresh ChatGPT sign-in**, verify the timestamp, and approve the update to
 the same wizard-managed sidecar:
 
 ```bash
-npx --yes --ignore-scripts relmio@latest
+curl -fsSL https://relmio.vercel.app/install.sh | sh
 ```
 
 The update targets only the sidecar. It does not restart n8n. For rollback,

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -7,6 +7,10 @@ Every command on this page targets the separate
 
 The easiest method:
 
+```bash
+curl -fsSL https://relmio.vercel.app/install.sh | sh
+```
+
 1. Start the local wizard again.
 2. Select **Refresh ChatGPT sign-in**.
 3. Complete the newest browser sign-in page.

--- a/docs/security.md
+++ b/docs/security.md
@@ -92,8 +92,12 @@ The current release pins:
 - `ssh2` `1.17.0`
 - `openai-oauth` `2.0.0`
 
-Install scripts are disabled for local dependencies. The generated sidecar
-also installs `openai-oauth` with `--ignore-scripts`.
+The curl bootstrap reuses a compatible local Node.js runtime or downloads the
+current official Node.js 22 archive to a private temporary directory. It
+validates the archive against Node.js's SHA-256 manifest before execution and
+removes it when the wizard closes. npm lifecycle scripts are disabled when the
+bootstrap starts Relmio. The generated sidecar also installs `openai-oauth`
+with `--ignore-scripts`.
 
 Do not replace pinned versions with `latest` in production. Follow the upgrade
 checklist in [maintenance.md](maintenance.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,17 +30,23 @@ it after the wizard saves the credential.
 
 ## Confirm the local package first
 
-Run these commands on your own computer, not on the VPS:
+Close every old wizard terminal and browser tab, then run the newest published
+build on your own computer, not on the VPS:
+
+```bash
+curl -fsSL https://relmio.vercel.app/install.sh | sh
+```
+
+This command does not require Node.js to be installed. It reuses Node.js 22 or
+newer when available, or downloads an official temporary runtime and verifies
+its SHA-256 checksum before execution.
+
+If you are using the native PowerShell or existing-Node fallback, confirm Node
+is version 22 or newer and check the published package version first:
 
 ```bash
 node --version
 npm view relmio version
-```
-
-Node must be version 22 or newer. Then close every old wizard terminal and
-browser tab and start the newest published build:
-
-```bash
 npx --yes --ignore-scripts relmio@latest
 ```
 
@@ -49,7 +55,7 @@ newest printed `http://127.0.0.1:...` URL into the browser. That URL contains a
 temporary setup token: do not post it in an issue or screenshot.
 
 You do not need to sign in to npm, configure npm 2FA, or own this package to
-run its public `npx` command. npm authentication is required only for the
+run either public command. npm authentication is required only for the
 maintainer who publishes a release.
 
 ## Quick VPS checks
@@ -88,7 +94,8 @@ bypassed.
 
 | Symptom | Meaning | Fix |
 |---|---|---|
-| `node: command not found`, `node is not recognized`, or Node is older than 22 | The local runtime is missing or unsupported. | Install Node.js 22 or newer on the local computer, open a new terminal, and rerun the `@latest` command. Do not install it on the VPS for the wizard. |
+| `node: command not found`, `node is not recognized`, or Node is older than 22 | The NPX fallback cannot use the local runtime. | Use the curl command above to run with a verified temporary runtime, or install Node.js 22 or newer locally. Do not install it on the VPS for the wizard. |
+| The curl installer reports a checksum mismatch | The Node.js download did not match the official SHA-256 manifest, so it was not executed. | Retry on a trusted connection. Do not bypass the check. If it repeats, use an existing Node.js 22+ installation and report the sanitized error. |
 | The browser did not open | The automatic browser launch failed, but the local server may still be running. | Keep the newest terminal open and copy its newest `127.0.0.1` setup URL into the browser. Do not reuse a URL from a closed terminal. |
 | An old wizard page reports an invalid or expired setup session | The local server was closed or a newer wizard run created a different one-time session token. | Close the old page and use only the URL printed by the currently running terminal. |
 | `npx` appears to run an older wizard | An old terminal or tab is still active, or the package was run without an explicit tag. | Close old runs, check `npm view relmio version`, then run `npx --yes --ignore-scripts relmio@latest`. |

--- a/docs/video-outline.md
+++ b/docs/video-outline.md
@@ -41,17 +41,20 @@ Use this simple explanation:
 
 On screen: the Mermaid flowchart in the README.
 
-### 2:20 — Start the npm package
+### 2:20 — Start the wizard
 
 Run locally:
 
 ```bash
-npx --yes --ignore-scripts relmio@latest
+curl -fsSL https://relmio.vercel.app/install.sh | sh
 ```
 
 Explain that:
 
-- `npx` downloads and runs the published version for this session;
+- no preinstalled Node.js runtime is required;
+- the bootstrap reuses Node.js 22+ or downloads and checksum-verifies a
+  temporary official Node.js 22 runtime;
+- npm lifecycle scripts stay disabled when it starts the published package;
 - the wizard binds to `127.0.0.1`;
 - the printed setup URL is private and temporary;
 - the terminal must remain open until the wizard finishes.

--- a/npm/README.md
+++ b/npm/README.md
@@ -72,20 +72,41 @@ installing the private n8n sidecar.
 </figure>
 
 Use the site's [Install wizard](https://relmio.vercel.app/install) page for a
-copyable command tailored to the current self-hosted n8n and Hostinger VPS
-setup path.
+clickable Curl / NPX command switcher tailored to the current self-hosted n8n
+and Hostinger VPS setup path. Curl is the recommended default when Node.js is
+not installed.
 
 ## Quick start
 
-Run this on your own macOS, Windows, or Linux computer—not on the VPS:
+Run this on your own macOS or Linux computer, or from WSL or Git Bash on
+Windows. Do not run it on the VPS:
+
+### Curl (recommended)
+
+```bash
+curl -fsSL https://relmio.vercel.app/install.sh | sh
+```
+
+No Node.js installation is required first. The
+[bootstrap script](https://github.com/Demonbane18/relmio/blob/main/web/public/install.sh)
+reuses Node.js 22 or newer when available. Otherwise it downloads the current
+official Node.js 22 runtime to a private temporary directory, verifies its
+SHA-256 checksum, runs Relmio with npm lifecycle scripts disabled, and removes
+the temporary runtime when the wizard closes.
+
+Native Windows PowerShell users, or users who already have Node.js 22 or newer,
+can run the npm package directly:
+
+### NPX (requires Node.js 22+)
 
 ```bash
 npx --yes --ignore-scripts relmio@latest
 ```
 
-Requirements:
+### Requirements
 
-- Node.js 22 or newer
+- `curl`, `awk`, `tar`, and either `sha256sum` or `shasum` for the universal
+  command; Git Bash also needs `unzip`
 - A browser and an eligible ChatGPT/Codex account
 - A self-hosted n8n Docker deployment on a VPS
 - Docker Compose v2, SSH access, and a Docker network shared with n8n

--- a/test/documentation.test.js
+++ b/test/documentation.test.js
@@ -46,6 +46,11 @@ test("README keeps both setup paths and layman diagrams visible", async () => {
 
   assert.match(readme, /## Choose a setup path/u);
   assert.match(readme, /## Quick start with the npm package/u);
+  assert.match(
+    readme,
+    /curl -fsSL https:\/\/relmio\.vercel\.app\/install\.sh \| sh/u,
+  );
+  assert.match(readme, /without installing Node\.js first/u);
   assert.match(readme, /## Manual setup and debugging/u);
   assert.match(readme, /The wizard is a convenience layer, not a requirement/u);
   assert.ok(mermaidBlocks.length >= 4);

--- a/test/install-script.test.js
+++ b/test/install-script.test.js
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const installScript = "web/public/install.sh";
+const supportsPortableFixture =
+  ["darwin", "linux"].includes(process.platform) &&
+  ["arm64", "x64"].includes(process.arch);
+
+async function writeExecutable(path, contents) {
+  await writeFile(path, contents, "utf8");
+  await chmod(path, 0o755);
+}
+
+async function createPortableNodeFixture(root, { validChecksum = true } = {}) {
+  const platform = process.platform === "darwin" ? "darwin" : "linux";
+  const architecture = process.arch === "arm64" ? "arm64" : "x64";
+  const version = "v22.23.2";
+  const basename = `node-${version}-${platform}-${architecture}`;
+  const fixtureRoot = join(root, "fixture");
+  const archiveRoot = join(fixtureRoot, basename);
+  const nodePath = join(archiveRoot, "bin", "node");
+  const npmCli = join(archiveRoot, "lib", "node_modules", "npm", "bin");
+  const archive = join(root, `${basename}.tar.gz`);
+  const manifest = join(root, "SHASUMS256.txt");
+
+  await mkdir(npmCli, { recursive: true });
+  await mkdir(join(archiveRoot, "bin"), { recursive: true });
+  await writeExecutable(
+    nodePath,
+    '#!/bin/sh\nprintf "%s\\n" "$@" > "$RELMIO_TEST_LOG"\n',
+  );
+  await writeFile(join(npmCli, "npx-cli.js"), "// fixture\n", "utf8");
+  await execFileAsync("tar", ["-czf", archive, "-C", fixtureRoot, basename]);
+
+  const digest = createHash("sha256").update(await readFile(archive)).digest("hex");
+  const checksum = validChecksum ? digest : "0".repeat(64);
+  await writeFile(manifest, `${checksum}  ${basename}.tar.gz\n`, "utf8");
+
+  return { archive, basename, manifest };
+}
+
+async function createBootstrapEnvironment({ validChecksum = true } = {}) {
+  const root = await mkdtemp(join(tmpdir(), "relmio-install-test-"));
+  const fakeBin = join(root, "bin");
+  const bootstrapTemp = join(root, "tmp");
+  const log = join(root, "invocation.log");
+  const fixture = await createPortableNodeFixture(root, { validChecksum });
+
+  await mkdir(fakeBin);
+  await mkdir(bootstrapTemp);
+  await writeExecutable(
+    join(fakeBin, "node"),
+    '#!/bin/sh\nprintf "18\\n"\n',
+  );
+  await writeExecutable(join(fakeBin, "npx"), "#!/bin/sh\nexit 96\n");
+  await writeExecutable(
+    join(fakeBin, "curl"),
+    `#!/bin/sh
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    --proto | --proto-redir | --connect-timeout | --max-time | --retry | --retry-delay)
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+case "$url" in
+  https://nodejs.org/download/release/latest-v22.x/SHASUMS256.txt)
+    cp "$RELMIO_TEST_MANIFEST" "$output"
+    ;;
+  https://nodejs.org/download/release/v22.23.2/node-v22.23.2-*.tar.gz)
+    cp "$RELMIO_TEST_ARCHIVE" "$output"
+    ;;
+  *)
+    exit 95
+    ;;
+esac
+`,
+  );
+
+  return {
+    bootstrapTemp,
+    fixture,
+    log,
+    root,
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      TMPDIR: bootstrapTemp,
+      RELMIO_TEST_ARCHIVE: fixture.archive,
+      RELMIO_TEST_LOG: log,
+      RELMIO_TEST_MANIFEST: fixture.manifest,
+    },
+  };
+}
+
+test(
+  "curl installer reuses an installed Node 22 runtime",
+  { skip: process.platform === "win32" },
+  async (t) => {
+    const root = await mkdtemp(join(tmpdir(), "relmio-installed-node-test-"));
+    const fakeBin = join(root, "bin");
+    const log = join(root, "invocation.log");
+    t.after(() => rm(root, { recursive: true, force: true }));
+
+    await mkdir(fakeBin);
+    await writeExecutable(
+      join(fakeBin, "node"),
+      '#!/bin/sh\nprintf "22\\n"\n',
+    );
+    await writeExecutable(
+      join(fakeBin, "npx"),
+      '#!/bin/sh\nprintf "%s\\n" "$@" > "$RELMIO_TEST_LOG"\n',
+    );
+    await writeExecutable(join(fakeBin, "curl"), "#!/bin/sh\nexit 97\n");
+
+    const { stdout } = await execFileAsync("/bin/sh", [installScript], {
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        RELMIO_TEST_LOG: log,
+      },
+    });
+
+    assert.match(stdout, /Using installed Node\.js 22/u);
+    assert.deepEqual((await readFile(log, "utf8")).trim().split("\n"), [
+      "--yes",
+      "--ignore-scripts",
+      "relmio@latest",
+    ]);
+  },
+);
+
+test(
+  "curl installer downloads, verifies, and removes a temporary Node runtime",
+  { skip: !supportsPortableFixture },
+  async (t) => {
+    const setup = await createBootstrapEnvironment();
+    t.after(() => rm(setup.root, { recursive: true, force: true }));
+
+    const { stdout } = await execFileAsync("/bin/sh", [installScript], {
+      env: setup.env,
+    });
+    const invocation = (await readFile(setup.log, "utf8")).trim().split("\n");
+
+    assert.match(stdout, /Downloading a temporary Node\.js 22 runtime/u);
+    assert.match(stdout, /Verified Node\.js download/u);
+    assert.match(
+      invocation[0],
+      new RegExp(`${setup.fixture.basename}/lib/node_modules/npm/bin/npx-cli\\.js$`, "u"),
+    );
+    assert.deepEqual(invocation.slice(1), [
+      "--yes",
+      "--ignore-scripts",
+      "relmio@latest",
+    ]);
+    assert.deepEqual(await readdir(setup.bootstrapTemp), []);
+  },
+);
+
+test(
+  "curl installer refuses a temporary Node runtime with the wrong checksum",
+  { skip: !supportsPortableFixture },
+  async (t) => {
+    const setup = await createBootstrapEnvironment({ validChecksum: false });
+    t.after(() => rm(setup.root, { recursive: true, force: true }));
+
+    await assert.rejects(
+      execFileAsync("/bin/sh", [installScript], { env: setup.env }),
+      /Node\.js download checksum did not match/u,
+    );
+    await assert.rejects(readFile(setup.log, "utf8"), { code: "ENOENT" });
+    assert.deepEqual(await readdir(setup.bootstrapTemp), []);
+  },
+);

--- a/test/package-contents.test.js
+++ b/test/package-contents.test.js
@@ -157,6 +157,10 @@ test("npm package substitutes a registry-safe README without changing GitHub dia
 
   assert.match(githubReadme, /```mermaid/u);
   assert.doesNotMatch(npmReadme, /```mermaid/u);
+  assert.match(
+    npmReadme,
+    /curl -fsSL https:\/\/relmio\.vercel\.app\/install\.sh \| sh/u,
+  );
   assert.match(npmReadme, /npx --yes --ignore-scripts relmio@latest/u);
   assert.match(npmReadme, /https:\/\/relmio\.vercel\.app\//u);
   assert.doesNotMatch(npmReadme, /relmio\.jpfusin\.tech/u);

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -106,6 +106,10 @@ test("public README documents the latest npm walkthrough and sanitized images", 
 
   assert.match(
     readme,
+    /curl -fsSL https:\/\/relmio\.vercel\.app\/install\.sh \| sh/u,
+  );
+  assert.match(
+    readme,
     /npx --yes --ignore-scripts relmio@latest/u,
   );
   assert.match(readme, /docs\/images\/setup\/01-local-sign-in-ready\.png/u);

--- a/web/app/components/CopyCommand.tsx
+++ b/web/app/components/CopyCommand.tsx
@@ -1,12 +1,38 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import {
+  type KeyboardEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
-const command = "npx --yes --ignore-scripts relmio@latest";
+const installMethods = [
+  {
+    id: "curl",
+    label: "Curl",
+    command: "curl -fsSL https://relmio.vercel.app/install.sh | sh",
+    note: "Curl works without a Node.js install on macOS, Linux, WSL, or Git Bash.",
+    recommended: true,
+  },
+  {
+    id: "npx",
+    label: "NPX",
+    command: "npx --yes --ignore-scripts relmio@latest",
+    note: "NPX requires Node.js 22 or newer and also works in PowerShell.",
+    recommended: false,
+  },
+] as const;
+
+type InstallMethod = (typeof installMethods)[number];
+type InstallMethodId = InstallMethod["id"];
 
 export function CopyCommand() {
-  const [copied, setCopied] = useState(false);
+  const [selectedMethod, setSelectedMethod] =
+    useState<InstallMethodId>("curl");
+  const [copiedMethod, setCopiedMethod] = useState<InstallMethodId | null>(null);
   const revertTimer = useRef<number | null>(null);
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   useEffect(() => {
     return () => {
@@ -16,18 +42,47 @@ export function CopyCommand() {
     };
   }, []);
 
-  async function copy() {
-    setCopied(true);
+  function selectMethod(method: InstallMethod) {
+    setSelectedMethod(method.id);
+    setCopiedMethod(null);
     if (revertTimer.current !== null) {
       window.clearTimeout(revertTimer.current);
+      revertTimer.current = null;
     }
-    revertTimer.current = window.setTimeout(() => setCopied(false), 1800);
+  }
 
+  function moveBetweenTabs(
+    event: KeyboardEvent<HTMLButtonElement>,
+    currentIndex: number,
+  ) {
+    let nextIndex: number | null = null;
+
+    if (event.key === "ArrowRight") {
+      nextIndex = (currentIndex + 1) % installMethods.length;
+    } else if (event.key === "ArrowLeft") {
+      nextIndex =
+        (currentIndex - 1 + installMethods.length) % installMethods.length;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = installMethods.length - 1;
+    }
+
+    if (nextIndex === null) {
+      return;
+    }
+
+    event.preventDefault();
+    selectMethod(installMethods[nextIndex]);
+    tabRefs.current[nextIndex]?.focus();
+  }
+
+  async function copy(method: InstallMethod) {
     try {
-      await navigator.clipboard.writeText(command);
+      await navigator.clipboard.writeText(method.command);
     } catch {
       const textarea = document.createElement("textarea");
-      textarea.value = command;
+      textarea.value = method.command;
       textarea.readOnly = true;
       textarea.style.position = "fixed";
       textarea.style.opacity = "0";
@@ -36,21 +91,87 @@ export function CopyCommand() {
       document.execCommand("copy");
       textarea.remove();
     }
+
+    setCopiedMethod(method.id);
+    if (revertTimer.current !== null) {
+      window.clearTimeout(revertTimer.current);
+    }
+    revertTimer.current = window.setTimeout(
+      () => setCopiedMethod(null),
+      1800,
+    );
   }
 
   return (
-    <button
-      type="button"
-      className={`install-command${copied ? " copied" : ""}`}
-      onClick={copy}
-      aria-label={`Copy installation command: ${command}`}
-      aria-live="polite"
-    >
-      <span className="terminal-mark" aria-hidden="true">
-        $
-      </span>
-      <code>{command}</code>
-      <span className="copy-hint">{copied ? "Copied" : "Copy"}</span>
-    </button>
+    <div className="install-method-picker">
+      <div
+        className="install-method-tabs"
+        role="tablist"
+        aria-label="Installation method"
+      >
+        {installMethods.map((method, index) => {
+          const selected = selectedMethod === method.id;
+
+          return (
+            <button
+              key={method.id}
+              ref={(element) => {
+                tabRefs.current[index] = element;
+              }}
+              type="button"
+              className="install-method-tab"
+              id={`install-method-${method.id}-tab`}
+              role="tab"
+              aria-selected={selected}
+              aria-controls={`install-method-${method.id}-panel`}
+              tabIndex={selected ? 0 : -1}
+              onClick={() => selectMethod(method)}
+              onKeyDown={(event) => moveBetweenTabs(event, index)}
+            >
+              {method.label}
+              {method.recommended ? <span>Recommended</span> : null}
+            </button>
+          );
+        })}
+      </div>
+
+      {installMethods.map((method) => {
+        const selected = selectedMethod === method.id;
+        const copied = copiedMethod === method.id;
+
+        return (
+          <div
+            key={method.id}
+            className="install-method-panel"
+            id={`install-method-${method.id}-panel`}
+            role="tabpanel"
+            aria-labelledby={`install-method-${method.id}-tab`}
+            hidden={!selected}
+          >
+            <button
+              type="button"
+              className={`install-command${copied ? " copied" : ""}`}
+              onClick={() => copy(method)}
+              aria-label={`Copy installation command (${method.label}): ${method.command}`}
+              aria-describedby={`install-method-${method.id}-note`}
+            >
+              <span className="terminal-mark" aria-hidden="true">
+                $
+              </span>
+              <code>{method.command}</code>
+              <span className="copy-hint" role="status" aria-live="polite">
+                {copied ? "Copied" : "Copy"}
+              </span>
+            </button>
+            <p
+              className="install-method-note"
+              id={`install-method-${method.id}-note`}
+            >
+              {method.note}
+            </p>
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1534,6 +1534,71 @@ main {
   text-transform: uppercase;
 }
 
+.install-method-picker {
+  display: grid;
+  gap: 12px;
+}
+
+.install-method-tabs {
+  width: fit-content;
+  min-height: 52px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--line) 35%, var(--white));
+}
+
+.install-method-tab {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 16px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  color: var(--ink-soft);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 750;
+  cursor: pointer;
+  transition:
+    background 180ms var(--ease),
+    border-color 180ms var(--ease),
+    color 180ms var(--ease),
+    box-shadow 180ms var(--ease);
+}
+
+.install-method-tab span {
+  color: var(--teal-deep);
+  font-size: 0.62rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.install-method-tab[aria-selected="true"] {
+  border-color: color-mix(in srgb, var(--line) 80%, transparent);
+  background: var(--white);
+  color: var(--ink);
+  box-shadow: var(--shadow-sm);
+}
+
+.install-method-tab:hover {
+  color: var(--ink);
+}
+
+.install-method-tab:focus-visible,
+.install-command-stage .install-command:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--teal) 38%, transparent);
+  outline-offset: 2px;
+}
+
+.install-method-panel[hidden] {
+  display: none;
+}
+
 .install-command-stage .install-command {
   width: 100%;
   min-height: 66px;
@@ -1550,13 +1615,23 @@ main {
 }
 
 .install-command-stage .install-command code {
+  flex: 1;
   font-size: clamp(0.76rem, 2vw, 0.9rem);
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .install-command-stage .copy-hint {
   margin-left: auto;
   background: rgb(255 255 255 / 10%);
   color: var(--white);
+}
+
+.install-method-note {
+  margin: 10px 2px 0;
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  line-height: 1.5;
 }
 
 .install-boundary {

--- a/web/app/install/page.tsx
+++ b/web/app/install/page.tsx
@@ -7,7 +7,7 @@ import { RepositoryButton } from "../components/RepositoryButton";
 export const metadata: Metadata = {
   title: "Install Relmio for n8n",
   description:
-    "Run the local Relmio wizard for a self-hosted n8n deployment, including Hostinger VPS setups.",
+    "Run the local Relmio wizard without installing Node.js first, including for Hostinger VPS setups.",
 };
 
 const steps = [
@@ -62,18 +62,20 @@ export default function InstallPage() {
           <h1>Install Relmio for n8n</h1>
           <p className="install-lede">
             Run one local wizard to sign in with ChatGPT, verify your VPS, and
-            install a private OpenAI-compatible sidecar beside n8n.
+            install a private OpenAI-compatible sidecar beside n8n. Use Curl
+            for a managed temporary runtime, or NPX when Node.js is ready.
           </p>
 
           <div className="install-command-stage" id="install-command">
-            <p>Run in Terminal or PowerShell</p>
+            <p>Choose an installation method</p>
             <CopyCommand />
           </div>
 
           <p className="install-boundary">
-            <strong>Run this on your own computer.</strong> Relmio supports the
-            self-hosted n8n and Hostinger VPS method for now. It does not edit,
-            rebuild, or restart your existing n8n container.
+            <strong>Run this on your own computer, not on the VPS.</strong>{" "}
+            Choose Curl to avoid installing Node.js first, or NPX if Node.js
+            22 or newer is already installed. Relmio does not edit, rebuild,
+            or restart your existing n8n container.
           </p>
 
           <ol className="install-steps">

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -1,0 +1,189 @@
+#!/bin/sh
+
+set -eu
+
+minimum_node_major=22
+node_dist_url="https://nodejs.org/download/release"
+temporary_directory=""
+
+say() {
+  printf 'Relmio installer: %s\n' "$1"
+}
+
+fail() {
+  printf 'Relmio installer: %s\n' "$1" >&2
+  exit 1
+}
+
+download() {
+  curl -fsSL \
+    --proto '=https' \
+    --proto-redir '=https' \
+    --connect-timeout 15 \
+    --max-time 600 \
+    --retry 2 \
+    --retry-delay 1 \
+    "$1" -o "$2"
+}
+
+cleanup() {
+  if [ -n "$temporary_directory" ] && [ -d "$temporary_directory" ]; then
+    rm -rf -- "$temporary_directory"
+  fi
+}
+
+installed_node_major=""
+if command -v node >/dev/null 2>&1; then
+  installed_node_major="$(
+    node -p 'Number(process.versions.node.split(".")[0])' 2>/dev/null || true
+  )"
+fi
+
+case "$installed_node_major" in
+  '' | *[!0-9]*) ;;
+  *)
+    if [ "$installed_node_major" -ge "$minimum_node_major" ] \
+      && command -v npx >/dev/null 2>&1; then
+      say "Using installed Node.js ${installed_node_major} runtime."
+      npx --yes --ignore-scripts relmio@latest </dev/null
+      exit $?
+    fi
+    ;;
+esac
+
+command -v curl >/dev/null 2>&1 \
+  || fail "curl is required to download the portable runtime."
+command -v tar >/dev/null 2>&1 \
+  || fail "tar is required to unpack the portable runtime."
+command -v awk >/dev/null 2>&1 \
+  || fail "awk is required to select the portable runtime."
+
+case "$(uname -s)" in
+  Darwin)
+    node_platform="darwin"
+    archive_extension="tar.gz"
+    ;;
+  Linux)
+    node_platform="linux"
+    archive_extension="tar.gz"
+    ;;
+  MINGW* | MSYS* | CYGWIN*)
+    node_platform="win"
+    archive_extension="zip"
+    command -v unzip >/dev/null 2>&1 \
+      || fail "unzip is required when running from Git Bash."
+    ;;
+  *)
+    fail "Unsupported operating system. Use macOS, Linux, WSL, or Git Bash."
+    ;;
+esac
+
+case "$(uname -m)" in
+  arm64 | aarch64)
+    node_architecture="arm64"
+    ;;
+  x86_64 | amd64)
+    node_architecture="x64"
+    ;;
+  *)
+    fail "Unsupported CPU architecture. Relmio supports arm64 and x64."
+    ;;
+esac
+
+umask 077
+temporary_directory="$(
+  mktemp -d "${TMPDIR:-/tmp}/relmio.XXXXXX"
+)" || fail "Could not create a temporary directory."
+trap cleanup EXIT HUP INT TERM
+
+manifest_path="$temporary_directory/SHASUMS256.txt"
+manifest_url="$node_dist_url/latest-v22.x/SHASUMS256.txt"
+
+say "Downloading a temporary Node.js 22 runtime."
+download "$manifest_url" "$manifest_path" \
+  || fail "Could not download the official Node.js checksum manifest."
+
+archive_suffix="-${node_platform}-${node_architecture}.${archive_extension}"
+archive_name="$(
+  awk -v suffix="$archive_suffix" '
+    substr($2, length($2) - length(suffix) + 1) == suffix {
+      print $2
+      exit
+    }
+  ' "$manifest_path"
+)"
+
+case "$archive_name" in
+  node-v22.*"$archive_suffix") ;;
+  *)
+    fail "The Node.js manifest did not contain a supported runtime."
+    ;;
+esac
+case "$archive_name" in
+  *[!A-Za-z0-9._-]*)
+    fail "The Node.js manifest returned an invalid filename."
+    ;;
+esac
+
+expected_checksum="$(
+  awk -v filename="$archive_name" '$2 == filename { print $1; exit }' \
+    "$manifest_path"
+)"
+case "$expected_checksum" in
+  *[!0-9A-Fa-f]* | '')
+    fail "The Node.js manifest returned an invalid checksum."
+    ;;
+esac
+[ "${#expected_checksum}" -eq 64 ] \
+  || fail "The Node.js manifest returned an invalid checksum."
+
+version_and_platform="${archive_name#node-}"
+node_version="${version_and_platform%%-*}"
+case "$node_version" in
+  v22.*) ;;
+  *)
+    fail "The Node.js manifest returned an unexpected version."
+    ;;
+esac
+case "${node_version#v}" in
+  *[!0-9.]* | '')
+    fail "The Node.js manifest returned an invalid version."
+    ;;
+esac
+
+archive_path="$temporary_directory/$archive_name"
+archive_url="$node_dist_url/$node_version/$archive_name"
+download "$archive_url" "$archive_path" \
+  || fail "Could not download the official Node.js runtime."
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_checksum="$(sha256sum "$archive_path" | awk '{ print $1 }')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual_checksum="$(shasum -a 256 "$archive_path" | awk '{ print $1 }')"
+else
+  fail "sha256sum or shasum is required to verify the Node.js download."
+fi
+
+[ "$actual_checksum" = "$expected_checksum" ] \
+  || fail "Node.js download checksum did not match; nothing was executed."
+say "Verified Node.js download."
+
+if [ "$archive_extension" = "zip" ]; then
+  unzip -q "$archive_path" -d "$temporary_directory"
+  archive_root="${archive_name%.zip}"
+  node_binary="$temporary_directory/$archive_root/node.exe"
+  npx_cli="$temporary_directory/$archive_root/node_modules/npm/bin/npx-cli.js"
+else
+  tar -xzf "$archive_path" -C "$temporary_directory"
+  archive_root="${archive_name%.tar.gz}"
+  node_binary="$temporary_directory/$archive_root/bin/node"
+  npx_cli="$temporary_directory/$archive_root/lib/node_modules/npm/bin/npx-cli.js"
+fi
+
+[ -x "$node_binary" ] \
+  || fail "The verified Node.js archive did not contain its runtime."
+[ -f "$npx_cli" ] \
+  || fail "The verified Node.js archive did not contain npm."
+
+say "Starting the newest Relmio wizard."
+"$node_binary" "$npx_cli" --yes --ignore-scripts relmio@latest </dev/null

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -64,13 +64,29 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
   const response = await requestApp("/install");
   assert.equal(response.status, 200);
 
-  const html = await response.text();
+  const [html, installScript] = await Promise.all([
+    response.text(),
+    readFile(new URL("../dist/client/install.sh", import.meta.url), "utf8"),
+  ]);
   assert.match(html, /Install Relmio for n8n/);
   assert.match(html, /Hostinger VPS/);
+  assert.match(
+    html,
+    /curl -fsSL https:\/\/relmio\.vercel\.app\/install\.sh \| sh/,
+  );
   assert.match(html, /npx --yes --ignore-scripts relmio@latest/);
+  assert.match(html, /role="tablist"[^>]*aria-label="Installation method"/);
+  assert.match(html, /role="tab"[^>]*aria-selected="true"[^>]*>[^<]*Curl/);
+  assert.match(html, /role="tab"[^>]*aria-selected="false"[^>]*>[^<]*NPX/);
+  assert.match(html, /Curl works without a Node\.js install/);
+  assert.match(html, /NPX requires Node\.js 22 or newer/);
+  assert.match(html, /macOS, Linux, WSL, or Git Bash/);
   assert.match(html, /Copy installation command/);
   assert.match(html, /Run this on your own computer/);
   assert.doesNotMatch(html, /href="https:\/\/www\.npmjs\.com/);
+  assert.match(installScript, /^#!\/bin\/sh/m);
+  assert.match(installScript, /Node\.js download checksum did not match/);
+  assert.match(installScript, /--ignore-scripts relmio@latest/);
 });
 
 test("returns current repository stars and npm version for the GitHub control", async (t) => {


### PR DESCRIPTION
## What changed

- add a hosted Curl bootstrap that reuses Node.js 22+ or downloads and checksum-verifies a temporary official Node.js 22 runtime
- add an accessible Curl / NPX switcher with method-specific copy feedback on the Vercel install page
- synchronize the repository README, npm README source, maintenance, security, troubleshooting, video, and changelog copy
- add installer and rendered-page regression coverage

## Why

The wizard's NPX-only entry point required users to install Node.js first. The Curl path removes that prerequisite while keeping NPX available for users who already have Node.js 22 or newer.

## Verification

- `npm run check` — 73 tests passed
- web lint and TypeScript checks passed
- web build and test suite — 14 tests passed
- native `npm run build:vercel` passed
- exact `relmio-0.2.5.tgz` contents and npm README inspected
- root and web offline audits reported zero vulnerabilities; GitHub CI runs the online audits
- Curl/NPX click, copy feedback, and keyboard navigation verified in Opera GX
