### PR TITLE
Add native Windows wizard installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,38 @@ jobs:
 
       - name: Audit hosted web production dependencies
         run: npm audit --audit-level=high
+
+  windows-bootstrap:
+    name: Native Windows bootstrap
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          package-manager-cache: false
+
+      - name: Parse the installer with Windows PowerShell 5.1
+        shell: powershell
+        run: |
+          $tokens = $null
+          $errors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path "web/public/install.ps1"),
+            [ref]$tokens,
+            [ref]$errors
+          ) | Out-Null
+          if ($errors.Count -ne 0) {
+            $errors | ForEach-Object { Write-Error $_.Message }
+            throw "Windows PowerShell 5.1 could not parse install.ps1."
+          }
+
+      - name: Test the native Windows bootstrap
+        run: node --test test/install-powershell-script.test.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ checks the registry separately after publication.
 - Add a curl-based wizard bootstrap for macOS, Linux, WSL, and Git Bash that
   reuses Node.js 22+ or downloads and checksum-verifies a temporary official
   runtime when Node.js is not installed.
-- Add an accessible Curl / NPX switcher to the hosted install page so users can
-  copy the command that matches their local runtime.
+- Add a native Windows PowerShell bootstrap for PowerShell and Command Prompt
+  that works without Git Bash or a preinstalled Node.js runtime and verifies
+  the temporary official Windows archive before execution.
+- Expand the hosted installer into an accessible macOS/Linux, PowerShell,
+  Command Prompt, and NPX terminal switcher.
 
 ## [0.2.5] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -41,19 +41,35 @@ and the new private OAuth sidecar running together.
 
 ## Quick install
 
-On macOS, Linux, WSL, or Git Bash, copy and paste this into your terminal on
-your own computer:
+Choose the terminal already on your own computer. Do not run these commands on
+the VPS.
+
+### macOS, Linux, WSL, or Git Bash
 
 ```bash
 curl -fsSL https://relmio.vercel.app/install.sh | sh
 ```
 
-This starts the wizard without installing Node.js first. The open-source
-[bootstrap script](web/public/install.sh) reuses Node.js 22 or newer when it is
-already available. Otherwise it downloads the current official Node.js 22
-runtime to a private temporary directory, verifies its SHA-256 checksum, runs
-Relmio with npm lifecycle scripts disabled, and removes the temporary runtime
-when the wizard closes. It does not install Node.js system-wide.
+### Windows PowerShell
+
+```powershell
+irm https://relmio.vercel.app/install.ps1 | iex
+```
+
+### Windows Command Prompt
+
+```bat
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
+```
+
+These commands start the wizard without installing Node.js or Git Bash first.
+The open-source [POSIX](web/public/install.sh) and
+[Windows PowerShell](web/public/install.ps1) bootstraps reuse Node.js 22 or
+newer when it is already available. Otherwise they download the matching
+current official Node.js 22 runtime to a private temporary directory, verify
+its SHA-256 checksum, run Relmio with npm lifecycle scripts disabled, and
+remove the temporary runtime when the wizard closes. They do not install
+Node.js system-wide.
 
 Already have Node.js 22 or newer? You can use NPX instead:
 
@@ -276,8 +292,8 @@ OpenAI Platform API key or replace the local n8n setup wizard.
 </figure>
 
 The site's [Install wizard](https://relmio.vercel.app/install) page provides a
-clickable Curl / NPX switcher for the current self-hosted n8n and Hostinger VPS
-setup path. Curl is the recommended default when Node.js is not installed.
+clickable macOS/Linux, PowerShell, Command Prompt, and NPX switcher for the
+current self-hosted n8n and Hostinger VPS setup path.
 
 ## Choose a setup path
 
@@ -316,9 +332,11 @@ you want to inspect, reproduce, improve, or debug the method, use
 
 ### Requirements
 
-- A local macOS or Linux computer, or Windows with WSL or Git Bash
-- `curl`, `awk`, `tar`, and a SHA-256 tool (`sha256sum` or `shasum`); Git Bash
-  also needs `unzip`. These are already available on most supported systems
+- A local macOS, Linux, or Windows computer
+- On macOS/Linux/WSL/Git Bash: `curl`, `awk`, `tar`, and a SHA-256 tool
+  (`sha256sum` or `shasum`); Git Bash also needs `unzip`
+- On native Windows: Windows PowerShell 5.1 or PowerShell 7; Command Prompt can
+  launch the included PowerShell bootstrap
 - A browser and a ChatGPT account eligible to use the upstream Codex flow
 - A self-hosted n8n Docker container on a VPS
 - Docker Engine and Docker Compose v2 on the VPS
@@ -332,26 +350,38 @@ you want to inspect, reproduce, improve, or debug the method, use
 > authenticates to your VPS and writes files there. Keep a recoverable backup
 > before granting it access.
 
-Do **not** run the curl command on the VPS. Run it on the computer where you
-will complete the browser sign-in.
+Do **not** run an installer command on the VPS. Run it on the computer where
+you will complete the browser sign-in.
 
 ### 1. Start the newest published wizard
 
-Open Terminal, WSL, or Git Bash:
+Choose the terminal already installed on your computer.
 
-#### Curl (recommended)
+#### macOS, Linux, WSL, or Git Bash
 
 ```bash
 curl -fsSL https://relmio.vercel.app/install.sh | sh
 ```
 
-The bootstrap uses a supported Node.js installation when present. If Node.js
-is missing or older than 22, it downloads and verifies a temporary official
-Node.js 22 runtime without installing it system-wide.
+#### Windows PowerShell
 
-Native Windows PowerShell users, or anyone who already has
-[Node.js 22 or newer](https://nodejs.org/en/download), can run the npm package
-directly instead:
+```powershell
+irm https://relmio.vercel.app/install.ps1 | iex
+```
+
+#### Windows Command Prompt
+
+```bat
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
+```
+
+The POSIX and native Windows bootstraps use a supported Node.js installation
+when present. If Node.js is missing or older than 22, they download and verify
+a temporary official Node.js 22 runtime without installing it system-wide.
+Native Windows does not require Git Bash.
+
+Anyone who already has [Node.js 22 or newer](https://nodejs.org/en/download)
+can run the npm package directly instead:
 
 #### NPX (requires Node.js 22+)
 
@@ -828,9 +858,11 @@ Automated tests enforce this boundary.
 
 ## Refresh, update, and remove
 
-To refresh an expired ChatGPT session, run the same curl command again, choose
-**Refresh ChatGPT sign-in**, verify the timestamp, and approve the update to
-the same wizard-managed sidecar:
+To refresh an expired ChatGPT session, open the
+[install page](https://relmio.vercel.app/install), run the command for your
+terminal again, choose **Refresh ChatGPT sign-in**, verify the timestamp, and
+approve the update to the same wizard-managed sidecar. For example, on
+macOS/Linux:
 
 ```bash
 curl -fsSL https://relmio.vercel.app/install.sh | sh

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -5,10 +5,18 @@ Every command on this page targets the separate
 
 ## Refresh an expired ChatGPT login
 
-The easiest method:
+The easiest method is to open the
+[hosted install page](https://relmio.vercel.app/install) and choose the local
+terminal you already have. For macOS, Linux, WSL, or Git Bash:
 
 ```bash
 curl -fsSL https://relmio.vercel.app/install.sh | sh
+```
+
+For Windows PowerShell, with no Git Bash or preinstalled Node.js required:
+
+```powershell
+irm https://relmio.vercel.app/install.ps1 | iex
 ```
 
 1. Start the local wizard again.

--- a/docs/security.md
+++ b/docs/security.md
@@ -92,12 +92,14 @@ The current release pins:
 - `ssh2` `1.17.0`
 - `openai-oauth` `2.0.0`
 
-The curl bootstrap reuses a compatible local Node.js runtime or downloads the
-current official Node.js 22 archive to a private temporary directory. It
-validates the archive against Node.js's SHA-256 manifest before execution and
-removes it when the wizard closes. npm lifecycle scripts are disabled when the
-bootstrap starts Relmio. The generated sidecar also installs `openai-oauth`
-with `--ignore-scripts`.
+The POSIX and native Windows PowerShell bootstraps reuse a compatible local
+Node.js runtime or download the matching current official Node.js 22 archive
+to a private temporary directory. Each validates the archive against Node.js's
+SHA-256 manifest before execution and removes it when the wizard closes. The
+PowerShell bootstrap accepts only strict Windows x64 or ARM64 archive names,
+uses HTTPS without redirects, and enables TLS 1.2 for Windows PowerShell 5.1.
+npm lifecycle scripts are disabled when either bootstrap starts Relmio. The
+generated sidecar also installs `openai-oauth` with `--ignore-scripts`.
 
 Do not replace pinned versions with `latest` in production. Follow the upgrade
 checklist in [maintenance.md](maintenance.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,18 +31,34 @@ it after the wizard saves the credential.
 ## Confirm the local package first
 
 Close every old wizard terminal and browser tab, then run the newest published
-build on your own computer, not on the VPS:
+build on your own computer, not on the VPS. Choose the command for the terminal
+you already have.
+
+macOS, Linux, WSL, or Git Bash:
 
 ```bash
 curl -fsSL https://relmio.vercel.app/install.sh | sh
 ```
 
-This command does not require Node.js to be installed. It reuses Node.js 22 or
-newer when available, or downloads an official temporary runtime and verifies
-its SHA-256 checksum before execution.
+Windows PowerShell:
 
-If you are using the native PowerShell or existing-Node fallback, confirm Node
-is version 22 or newer and check the published package version first:
+```powershell
+irm https://relmio.vercel.app/install.ps1 | iex
+```
+
+Windows Command Prompt:
+
+```bat
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
+```
+
+These commands do not require Node.js to be installed. The Windows options do
+not require Git Bash. Each bootstrap reuses Node.js 22 or newer when available,
+or downloads an official temporary runtime and verifies its SHA-256 checksum
+before execution.
+
+If you choose the existing-Node fallback, confirm Node is version 22 or newer
+and check the published package version first:
 
 ```bash
 node --version
@@ -55,7 +71,7 @@ newest printed `http://127.0.0.1:...` URL into the browser. That URL contains a
 temporary setup token: do not post it in an issue or screenshot.
 
 You do not need to sign in to npm, configure npm 2FA, or own this package to
-run either public command. npm authentication is required only for the
+run any public command. npm authentication is required only for the
 maintainer who publishes a release.
 
 ## Quick VPS checks
@@ -94,8 +110,9 @@ bypassed.
 
 | Symptom | Meaning | Fix |
 |---|---|---|
-| `node: command not found`, `node is not recognized`, or Node is older than 22 | The NPX fallback cannot use the local runtime. | Use the curl command above to run with a verified temporary runtime, or install Node.js 22 or newer locally. Do not install it on the VPS for the wizard. |
-| The curl installer reports a checksum mismatch | The Node.js download did not match the official SHA-256 manifest, so it was not executed. | Retry on a trusted connection. Do not bypass the check. If it repeats, use an existing Node.js 22+ installation and report the sanitized error. |
+| `node: command not found`, `node is not recognized`, or Node is older than 22 | The NPX fallback cannot use the local runtime. | Use the macOS/Linux curl command or the native Windows PowerShell/Command Prompt command above. Either can run with a verified temporary runtime. Do not install Node.js on the VPS for the wizard. |
+| `curl` or `sh` is not recognized on Windows | The macOS/Linux command was pasted into a native Windows terminal. | Use the PowerShell command in PowerShell, or the longer `powershell -NoProfile ...` command in Command Prompt. Git Bash is not required. |
+| A bootstrap reports a checksum mismatch | The Node.js download did not match the official SHA-256 manifest, so it was not executed. | Retry on a trusted connection. Do not bypass the check. If it repeats, use an existing Node.js 22+ installation and report the sanitized error. |
 | The browser did not open | The automatic browser launch failed, but the local server may still be running. | Keep the newest terminal open and copy its newest `127.0.0.1` setup URL into the browser. Do not reuse a URL from a closed terminal. |
 | An old wizard page reports an invalid or expired setup session | The local server was closed or a newer wizard run created a different one-time session token. | Close the old page and use only the URL printed by the currently running terminal. |
 | `npx` appears to run an older wizard | An old terminal or tab is still active, or the package was run without an explicit tag. | Close old runs, check `npm view relmio version`, then run `npx --yes --ignore-scripts relmio@latest`. |

--- a/docs/video-outline.md
+++ b/docs/video-outline.md
@@ -43,15 +43,21 @@ On screen: the Mermaid flowchart in the README.
 
 ### 2:20 — Start the wizard
 
-Run locally:
+Open the hosted install page and choose the terminal already on the local
+computer. Show both the macOS/Linux and native Windows choices:
 
 ```bash
 curl -fsSL https://relmio.vercel.app/install.sh | sh
 ```
 
+```powershell
+irm https://relmio.vercel.app/install.ps1 | iex
+```
+
 Explain that:
 
 - no preinstalled Node.js runtime is required;
+- native Windows does not require Git Bash and also has a Command Prompt option;
 - the bootstrap reuses Node.js 22+ or downloads and checksum-verifies a
   temporary official Node.js 22 runtime;
 - npm lifecycle scripts stay disabled when it starts the published package;

--- a/npm/README.md
+++ b/npm/README.md
@@ -72,30 +72,41 @@ installing the private n8n sidecar.
 </figure>
 
 Use the site's [Install wizard](https://relmio.vercel.app/install) page for a
-clickable Curl / NPX command switcher tailored to the current self-hosted n8n
-and Hostinger VPS setup path. Curl is the recommended default when Node.js is
-not installed.
+clickable macOS/Linux, PowerShell, Command Prompt, and NPX command switcher
+tailored to the current self-hosted n8n and Hostinger VPS setup path.
 
 ## Quick start
 
-Run this on your own macOS or Linux computer, or from WSL or Git Bash on
-Windows. Do not run it on the VPS:
+Choose the terminal already on your own computer. Do not run these commands on
+the VPS.
 
-### Curl (recommended)
+### macOS, Linux, WSL, or Git Bash
 
 ```bash
 curl -fsSL https://relmio.vercel.app/install.sh | sh
 ```
 
-No Node.js installation is required first. The
-[bootstrap script](https://github.com/Demonbane18/relmio/blob/main/web/public/install.sh)
-reuses Node.js 22 or newer when available. Otherwise it downloads the current
-official Node.js 22 runtime to a private temporary directory, verifies its
-SHA-256 checksum, runs Relmio with npm lifecycle scripts disabled, and removes
-the temporary runtime when the wizard closes.
+### Windows PowerShell
 
-Native Windows PowerShell users, or users who already have Node.js 22 or newer,
-can run the npm package directly:
+```powershell
+irm https://relmio.vercel.app/install.ps1 | iex
+```
+
+### Windows Command Prompt
+
+```bat
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
+```
+
+No Node.js or Git Bash installation is required first. The
+[POSIX](https://github.com/Demonbane18/relmio/blob/main/web/public/install.sh)
+and [Windows PowerShell](https://github.com/Demonbane18/relmio/blob/main/web/public/install.ps1)
+bootstraps reuse Node.js 22 or newer when available. Otherwise they download
+the matching current official Node.js 22 runtime to a private temporary
+directory, verify its SHA-256 checksum, run Relmio with npm lifecycle scripts
+disabled, and remove the temporary runtime when the wizard closes.
+
+Users who already have Node.js 22 or newer can run the npm package directly:
 
 ### NPX (requires Node.js 22+)
 
@@ -105,8 +116,10 @@ npx --yes --ignore-scripts relmio@latest
 
 ### Requirements
 
-- `curl`, `awk`, `tar`, and either `sha256sum` or `shasum` for the universal
-  command; Git Bash also needs `unzip`
+- On macOS/Linux/WSL/Git Bash: `curl`, `awk`, `tar`, and either `sha256sum` or
+  `shasum`; Git Bash also needs `unzip`
+- On native Windows: Windows PowerShell 5.1 or PowerShell 7; Command Prompt can
+  launch the included PowerShell bootstrap
 - A browser and an eligible ChatGPT/Codex account
 - A self-hosted n8n Docker deployment on a VPS
 - Docker Compose v2, SSH access, and a Docker network shared with n8n

--- a/test/documentation.test.js
+++ b/test/documentation.test.js
@@ -40,7 +40,7 @@ test("README and manual guide copy the generated sidecar files exactly", async (
   }
 });
 
-test("README keeps both setup paths and layman diagrams visible", async () => {
+test("README keeps every local install path and layman diagrams visible", async () => {
   const readme = await readFile("README.md", "utf8");
   const mermaidBlocks = readme.match(/```mermaid/gu) ?? [];
 
@@ -50,7 +50,12 @@ test("README keeps both setup paths and layman diagrams visible", async () => {
     readme,
     /curl -fsSL https:\/\/relmio\.vercel\.app\/install\.sh \| sh/u,
   );
-  assert.match(readme, /without installing Node\.js first/u);
+  assert.match(
+    readme,
+    /irm https:\/\/relmio\.vercel\.app\/install\.ps1 \| iex/u,
+  );
+  assert.match(readme, /Windows Command Prompt/u);
+  assert.match(readme, /without installing Node\.js or Git Bash first/u);
   assert.match(readme, /## Manual setup and debugging/u);
   assert.match(readme, /The wizard is a convenience layer, not a requirement/u);
   assert.ok(mermaidBlocks.length >= 4);

--- a/test/install-powershell-script.test.js
+++ b/test/install-powershell-script.test.js
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const installScript = "web/public/install.ps1";
+
+async function findPowerShell() {
+  for (const command of ["pwsh", "powershell"]) {
+    try {
+      const { stdout } = await execFileAsync(command, [
+        "-NoLogo",
+        "-NoProfile",
+        "-Command",
+        "(Get-Process -Id $PID).Path",
+      ]);
+      return stdout.trim();
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  return null;
+}
+
+async function writeExecutable(path, contents) {
+  await writeFile(path, contents, "utf8");
+  await chmod(path, 0o755);
+}
+
+test("PowerShell installer validates the official Windows runtime before execution", async () => {
+  const script = await readFile(installScript, "utf8");
+
+  assert.match(
+    script,
+    /https:\/\/nodejs\.org\/download\/release\/latest-v22\.x\/SHASUMS256\.txt/u,
+  );
+  assert.match(script, /node-\(\?<version>v22\\\.\\d\+\\\.\\d\+\)-win-/u);
+  assert.match(script, /\(\?<architecture>x64\|arm64\)\\\.zip/u);
+  assert.match(script, /Get-FileHash[^\n]+-Algorithm SHA256/u);
+  assert.match(script, /Node\.js download checksum did not match/u);
+  assert.match(script, /-MaximumRedirection 0/u);
+  assert.match(script, /SecurityProtocol[^\n]+Tls12/u);
+  assert.match(script, /Expand-Archive/u);
+  assert.match(script, /--ignore-scripts/u);
+  assert.match(script, /relmio@latest/u);
+  assert.doesNotMatch(script, /\bexit\b/iu);
+});
+
+test(
+  "PowerShell installer reuses an installed Node 22 runtime",
+  async (t) => {
+    const powershell = await findPowerShell();
+    if (!powershell) {
+      t.skip("PowerShell is not installed");
+      return;
+    }
+
+    const root = await mkdtemp(join(tmpdir(), "relmio-powershell-test-"));
+    const fakeBin = join(root, "bin");
+    const log = join(root, "invocation.log");
+    const wrapper = join(root, "invoke-installer.ps1");
+    t.after(() => rm(root, { recursive: true, force: true }));
+
+    await mkdir(fakeBin);
+    if (process.platform === "win32") {
+      await writeFile(join(fakeBin, "node.cmd"), "@echo off\r\necho 22\r\n", "utf8");
+      await writeFile(
+        join(fakeBin, "npx.cmd"),
+        [
+          "@echo off",
+          '> "%RELMIO_TEST_LOG%" echo %~1',
+          '>> "%RELMIO_TEST_LOG%" echo %~2',
+          '>> "%RELMIO_TEST_LOG%" echo %~3',
+          "",
+        ].join("\r\n"),
+        "utf8",
+      );
+    } else {
+      await writeExecutable(join(fakeBin, "node"), '#!/bin/sh\nprintf "22\\n"\n');
+      await writeExecutable(
+        join(fakeBin, "npx"),
+        '#!/bin/sh\nprintf "%s\\n" "$@" > "$RELMIO_TEST_LOG"\n',
+      );
+    }
+
+    await writeFile(
+      wrapper,
+      [
+        '$ErrorActionPreference = "Continue"',
+        '$ProgressPreference = "Continue"',
+        'Invoke-Expression (Get-Content -LiteralPath $env:RELMIO_INSTALL_SCRIPT -Raw)',
+        'Write-Output "PREFERENCES:$ErrorActionPreference/$ProgressPreference"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const { stdout } = await execFileAsync(
+      powershell,
+      ["-NoLogo", "-NoProfile", "-File", wrapper],
+      {
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}${delimiter}${process.env.PATH}`,
+          RELMIO_INSTALL_SCRIPT: resolve(installScript),
+          RELMIO_TEST_LOG: log,
+        },
+      },
+    );
+
+    assert.match(stdout, /Using installed Node\.js 22 runtime/u);
+    assert.match(stdout, /PREFERENCES:Continue\/Continue/u);
+    assert.deepEqual((await readFile(log, "utf8")).trim().split(/\r?\n/u), [
+      "--yes",
+      "--ignore-scripts",
+      "relmio@latest",
+    ]);
+  },
+);

--- a/web/app/components/CopyCommand.tsx
+++ b/web/app/components/CopyCommand.tsx
@@ -9,18 +9,33 @@ import {
 
 const installMethods = [
   {
-    id: "curl",
-    label: "Curl",
+    id: "posix",
+    label: "macOS / Linux",
     command: "curl -fsSL https://relmio.vercel.app/install.sh | sh",
-    note: "Curl works without a Node.js install on macOS, Linux, WSL, or Git Bash.",
-    recommended: true,
+    note: "For macOS, Linux, WSL, or Git Bash. No preinstalled Node.js required.",
+    prompt: "$",
+  },
+  {
+    id: "powershell",
+    label: "PowerShell",
+    command: "irm https://relmio.vercel.app/install.ps1 | iex",
+    note: "Use Windows PowerShell or PowerShell 7 on Windows. No Git Bash or preinstalled Node.js required.",
+    prompt: "PS>",
+  },
+  {
+    id: "cmd",
+    label: "CMD",
+    command:
+      'powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"',
+    note: "Open Command Prompt, not PowerShell. This launches the same verified Windows installer.",
+    prompt: ">",
   },
   {
     id: "npx",
     label: "NPX",
     command: "npx --yes --ignore-scripts relmio@latest",
-    note: "NPX requires Node.js 22 or newer and also works in PowerShell.",
-    recommended: false,
+    note: "NPX requires Node.js 22 or newer and works in any local terminal.",
+    prompt: "$",
   },
 ] as const;
 
@@ -29,7 +44,7 @@ type InstallMethodId = InstallMethod["id"];
 
 export function CopyCommand() {
   const [selectedMethod, setSelectedMethod] =
-    useState<InstallMethodId>("curl");
+    useState<InstallMethodId>("posix");
   const [copiedMethod, setCopiedMethod] = useState<InstallMethodId | null>(null);
   const revertTimer = useRef<number | null>(null);
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -107,7 +122,7 @@ export function CopyCommand() {
       <div
         className="install-method-tabs"
         role="tablist"
-        aria-label="Installation method"
+        aria-label="Local terminal"
       >
         {installMethods.map((method, index) => {
           const selected = selectedMethod === method.id;
@@ -129,7 +144,6 @@ export function CopyCommand() {
               onKeyDown={(event) => moveBetweenTabs(event, index)}
             >
               {method.label}
-              {method.recommended ? <span>Recommended</span> : null}
             </button>
           );
         })}
@@ -156,7 +170,7 @@ export function CopyCommand() {
               aria-describedby={`install-method-${method.id}-note`}
             >
               <span className="terminal-mark" aria-hidden="true">
-                $
+                {method.prompt}
               </span>
               <code>{method.command}</code>
               <span className="copy-hint" role="status" aria-live="polite">

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1526,12 +1526,9 @@ main {
 
 .install-command-stage > p {
   margin: 0 0 10px;
-  color: var(--ink-soft);
-  font-family: var(--font-geist-mono), monospace;
-  font-size: 0.7rem;
-  font-weight: 650;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  color: var(--ink);
+  font-size: 0.84rem;
+  font-weight: 750;
 }
 
 .install-method-picker {
@@ -1540,10 +1537,10 @@ main {
 }
 
 .install-method-tabs {
-  width: fit-content;
+  width: 100%;
   min-height: 52px;
-  display: inline-flex;
-  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 4px;
   padding: 4px;
   border: 1px solid var(--line);
@@ -1554,14 +1551,14 @@ main {
 .install-method-tab {
   min-height: 44px;
   display: inline-flex;
+  justify-content: center;
   align-items: center;
-  gap: 8px;
-  padding: 0 16px;
+  padding: 0 10px;
   border: 1px solid transparent;
   border-radius: 7px;
   color: var(--ink-soft);
   font: inherit;
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   font-weight: 750;
   cursor: pointer;
   transition:
@@ -1569,13 +1566,6 @@ main {
     border-color 180ms var(--ease),
     color 180ms var(--ease),
     box-shadow 180ms var(--ease);
-}
-
-.install-method-tab span {
-  color: var(--teal-deep);
-  font-size: 0.62rem;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
 }
 
 .install-method-tab[aria-selected="true"] {
@@ -1603,6 +1593,8 @@ main {
   width: 100%;
   min-height: 66px;
   margin: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   padding: 14px 17px;
   border-color: var(--dark);
   background: var(--dark);
@@ -1615,14 +1607,13 @@ main {
 }
 
 .install-command-stage .install-command code {
-  flex: 1;
   font-size: clamp(0.76rem, 2vw, 0.9rem);
   overflow-wrap: anywhere;
+  text-align: left;
   white-space: normal;
 }
 
 .install-command-stage .copy-hint {
-  margin-left: auto;
   background: rgb(255 255 255 / 10%);
   color: var(--white);
 }
@@ -1933,6 +1924,14 @@ footer > div {
   .install-page {
     min-height: calc(100vh - 65px);
     padding: 58px 14px 72px;
+  }
+
+  .install-method-tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .install-method-tab {
+    padding-inline: 8px;
   }
 
   .install-steps {

--- a/web/app/install/page.tsx
+++ b/web/app/install/page.tsx
@@ -7,24 +7,24 @@ import { RepositoryButton } from "../components/RepositoryButton";
 export const metadata: Metadata = {
   title: "Install Relmio for n8n",
   description:
-    "Run the local Relmio wizard without installing Node.js first, including for Hostinger VPS setups.",
+    "Run the local Relmio wizard from macOS, Linux, PowerShell, or Command Prompt without installing Node.js first.",
 };
 
 const steps = [
   {
     index: "01",
-    title: "Run locally",
-    copy: "Start the wizard on your own computer, not on the VPS.",
+    title: "Choose your terminal",
+    copy: "Use macOS/Linux, PowerShell, CMD, or NPX. Windows does not need Git Bash.",
   },
   {
     index: "02",
-    title: "Verify the VPS",
-    copy: "Confirm the SSH fingerprint before entering your server password.",
+    title: "Start locally",
+    copy: "Paste the command on your own computer and keep that terminal open.",
   },
   {
     index: "03",
-    title: "Approve the sidecar",
-    copy: "Review the plan before Relmio writes its separate Docker project.",
+    title: "Verify, then approve",
+    copy: "Confirm the SSH fingerprint and sidecar plan before any VPS write.",
   },
 ];
 
@@ -62,20 +62,22 @@ export default function InstallPage() {
           <h1>Install Relmio for n8n</h1>
           <p className="install-lede">
             Run one local wizard to sign in with ChatGPT, verify your VPS, and
-            install a private OpenAI-compatible sidecar beside n8n. Use Curl
-            for a managed temporary runtime, or NPX when Node.js is ready.
+            install a private OpenAI-compatible sidecar beside n8n. Choose the
+            terminal already on your computer—native Windows works without Git
+            Bash or a preinstalled Node.js runtime.
           </p>
 
           <div className="install-command-stage" id="install-command">
-            <p>Choose an installation method</p>
+            <p>Choose your local terminal</p>
             <CopyCommand />
           </div>
 
           <p className="install-boundary">
             <strong>Run this on your own computer, not on the VPS.</strong>{" "}
-            Choose Curl to avoid installing Node.js first, or NPX if Node.js
-            22 or newer is already installed. Relmio does not edit, rebuild,
-            or restart your existing n8n container.
+            The macOS/Linux and native Windows options reuse Node.js 22+ when
+            available, or download and verify a temporary official runtime.
+            NPX is for computers that already have Node.js 22 or newer. Relmio
+            does not edit, rebuild, or restart your existing n8n container.
           </p>
 
           <ol className="install-steps">

--- a/web/public/install.ps1
+++ b/web/public/install.ps1
@@ -1,0 +1,160 @@
+& {
+  $ErrorActionPreference = "Stop"
+  $ProgressPreference = "SilentlyContinue"
+  Set-StrictMode -Version 3.0
+
+  $minimumNodeMajor = 22
+  $nodeDistributionUrl = "https://nodejs.org/download/release"
+  $temporaryDirectory = $null
+  $previousSecurityProtocol = $null
+  $securityProtocolChanged = $false
+
+  function Write-RelmioInstallerMessage {
+    param([Parameter(Mandatory = $true)][string]$Message)
+
+    Write-Host "Relmio installer: $Message"
+  }
+
+  function Save-RelmioHttpsFile {
+    param(
+      [Parameter(Mandatory = $true)][string]$Uri,
+      [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    if (-not $Uri.StartsWith("https://", [System.StringComparison]::Ordinal)) {
+      throw "Refusing to download from a non-HTTPS address."
+    }
+
+    Invoke-WebRequest `
+      -Uri $Uri `
+      -OutFile $Destination `
+      -UseBasicParsing `
+      -MaximumRedirection 0 `
+      -TimeoutSec 600 `
+      -ErrorAction Stop
+  }
+
+  function Find-RelmioNpxCommand {
+    $command = Get-Command "npx.cmd" -CommandType Application -ErrorAction SilentlyContinue |
+      Select-Object -First 1
+    if ($null -eq $command) {
+      $command = Get-Command "npx" -CommandType Application, ExternalScript -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    }
+    return $command
+  }
+
+  try {
+    $nodeCommand = Get-Command "node" -CommandType Application -ErrorAction SilentlyContinue |
+      Select-Object -First 1
+    $npxCommand = Find-RelmioNpxCommand
+    $installedNodeMajor = 0
+
+    if ($null -ne $nodeCommand -and $null -ne $npxCommand) {
+      $installedNodeMajorText = & $nodeCommand.Source -p 'process.versions.node.split(".")[0]' 2>$null
+      if (
+        $LASTEXITCODE -eq 0 -and
+        [int]::TryParse(([string]$installedNodeMajorText).Trim(), [ref]$installedNodeMajor) -and
+        $installedNodeMajor -ge $minimumNodeMajor
+      ) {
+        Write-RelmioInstallerMessage "Using installed Node.js $installedNodeMajor runtime."
+        & $npxCommand.Source --yes --ignore-scripts relmio@latest
+        $relmioStatus = $LASTEXITCODE
+        if ($relmioStatus -ne 0) {
+          throw "Relmio finished with status $relmioStatus."
+        }
+        return
+      }
+    }
+
+    $windowsArchitecture = if (
+      -not [string]::IsNullOrWhiteSpace($env:PROCESSOR_ARCHITEW6432)
+    ) {
+      $env:PROCESSOR_ARCHITEW6432
+    } else {
+      $env:PROCESSOR_ARCHITECTURE
+    }
+
+    $nodeArchitecture = switch ($windowsArchitecture.ToUpperInvariant()) {
+      "AMD64" { "x64"; break }
+      "ARM64" { "arm64"; break }
+      default {
+        throw "Unsupported CPU architecture. Relmio supports Windows x64 and ARM64."
+      }
+    }
+
+    $previousSecurityProtocol = [Net.ServicePointManager]::SecurityProtocol
+    [Net.ServicePointManager]::SecurityProtocol = $previousSecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+    $securityProtocolChanged = $true
+
+    $temporaryDirectory = Join-Path `
+      ([IO.Path]::GetTempPath()) `
+      ("relmio-" + [Guid]::NewGuid().ToString("N"))
+    [IO.Directory]::CreateDirectory($temporaryDirectory) | Out-Null
+
+    $manifestPath = Join-Path $temporaryDirectory "SHASUMS256.txt"
+    $manifestUrl = "https://nodejs.org/download/release/latest-v22.x/SHASUMS256.txt"
+
+    Write-RelmioInstallerMessage "Downloading a temporary Node.js 22 runtime."
+    Save-RelmioHttpsFile -Uri $manifestUrl -Destination $manifestPath
+
+    $manifestPattern = '^(?<checksum>[0-9A-Fa-f]{64})\s+(?<filename>node-(?<version>v22\.\d+\.\d+)-win-(?<architecture>x64|arm64)\.zip)$'
+    $runtimeEntries = @(
+      foreach ($line in Get-Content -LiteralPath $manifestPath) {
+        if ($line -match $manifestPattern -and $Matches["architecture"] -eq $nodeArchitecture) {
+          [PSCustomObject]@{
+            Checksum = $Matches["checksum"].ToLowerInvariant()
+            Filename = $Matches["filename"]
+            Version = $Matches["version"]
+          }
+        }
+      }
+    )
+
+    if ($runtimeEntries.Count -ne 1) {
+      throw "The Node.js manifest did not contain exactly one supported Windows runtime."
+    }
+
+    $runtime = $runtimeEntries[0]
+    $archivePath = Join-Path $temporaryDirectory $runtime.Filename
+    $archiveUrl = "$nodeDistributionUrl/$($runtime.Version)/$($runtime.Filename)"
+    Save-RelmioHttpsFile -Uri $archiveUrl -Destination $archivePath
+
+    $actualChecksum = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if (-not [string]::Equals($actualChecksum, $runtime.Checksum, [StringComparison]::Ordinal)) {
+      throw "Node.js download checksum did not match; nothing was executed."
+    }
+    Write-RelmioInstallerMessage "Verified Node.js download."
+
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $temporaryDirectory -Force
+    $archiveRoot = [IO.Path]::GetFileNameWithoutExtension($runtime.Filename)
+    $nodeBinary = Join-Path $temporaryDirectory "$archiveRoot\node.exe"
+    $npxCli = Join-Path $temporaryDirectory "$archiveRoot\node_modules\npm\bin\npx-cli.js"
+
+    if (-not (Test-Path -LiteralPath $nodeBinary -PathType Leaf)) {
+      throw "The verified Node.js archive did not contain its runtime."
+    }
+    if (-not (Test-Path -LiteralPath $npxCli -PathType Leaf)) {
+      throw "The verified Node.js archive did not contain npm."
+    }
+
+    Write-RelmioInstallerMessage "Starting the newest Relmio wizard."
+    & $nodeBinary $npxCli --yes --ignore-scripts relmio@latest
+    $relmioStatus = $LASTEXITCODE
+    if ($relmioStatus -ne 0) {
+      throw "Relmio finished with status $relmioStatus."
+    }
+  } catch {
+    throw "Relmio installer: $($_.Exception.Message)"
+  } finally {
+    try {
+      if ($null -ne $temporaryDirectory -and (Test-Path -LiteralPath $temporaryDirectory)) {
+        Remove-Item -LiteralPath $temporaryDirectory -Recurse -Force
+      }
+    } finally {
+      if ($securityProtocolChanged) {
+        [Net.ServicePointManager]::SecurityProtocol = $previousSecurityProtocol
+      }
+    }
+  }
+}

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -64,9 +64,10 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
   const response = await requestApp("/install");
   assert.equal(response.status, 200);
 
-  const [html, installScript] = await Promise.all([
+  const [html, installScript, powerShellInstallScript] = await Promise.all([
     response.text(),
     readFile(new URL("../dist/client/install.sh", import.meta.url), "utf8"),
+    readFile(new URL("../dist/client/install.ps1", import.meta.url), "utf8"),
   ]);
   assert.match(html, /Install Relmio for n8n/);
   assert.match(html, /Hostinger VPS/);
@@ -74,19 +75,33 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
     html,
     /curl -fsSL https:\/\/relmio\.vercel\.app\/install\.sh \| sh/,
   );
+  assert.match(
+    html,
+    /irm https:\/\/relmio\.vercel\.app\/install\.ps1 \| iex/,
+  );
+  assert.match(
+    html,
+    /powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;irm https:\/\/relmio\.vercel\.app\/install\.ps1 \| iex&quot;/,
+  );
   assert.match(html, /npx --yes --ignore-scripts relmio@latest/);
-  assert.match(html, /role="tablist"[^>]*aria-label="Installation method"/);
-  assert.match(html, /role="tab"[^>]*aria-selected="true"[^>]*>[^<]*Curl/);
+  assert.match(html, /role="tablist"[^>]*aria-label="Local terminal"/);
+  assert.match(html, /role="tab"[^>]*aria-selected="true"[^>]*>[^<]*macOS \/ Linux/);
+  assert.match(html, /role="tab"[^>]*aria-selected="false"[^>]*>[^<]*PowerShell/);
+  assert.match(html, /role="tab"[^>]*aria-selected="false"[^>]*>[^<]*CMD/);
   assert.match(html, /role="tab"[^>]*aria-selected="false"[^>]*>[^<]*NPX/);
-  assert.match(html, /Curl works without a Node\.js install/);
-  assert.match(html, /NPX requires Node\.js 22 or newer/);
   assert.match(html, /macOS, Linux, WSL, or Git Bash/);
+  assert.match(html, /No Git Bash or preinstalled Node\.js required/);
+  assert.match(html, /Open Command Prompt, not PowerShell/);
+  assert.match(html, /NPX requires Node\.js 22 or newer/);
   assert.match(html, /Copy installation command/);
   assert.match(html, /Run this on your own computer/);
   assert.doesNotMatch(html, /href="https:\/\/www\.npmjs\.com/);
   assert.match(installScript, /^#!\/bin\/sh/m);
   assert.match(installScript, /Node\.js download checksum did not match/);
   assert.match(installScript, /--ignore-scripts relmio@latest/);
+  assert.match(powerShellInstallScript, /Get-FileHash/);
+  assert.match(powerShellInstallScript, /Node\.js download checksum did not match/);
+  assert.match(powerShellInstallScript, /--ignore-scripts/);
 });
 
 test("returns current repository stars and npm version for the GitHub control", async (t) => {


### PR DESCRIPTION
## What changed

- add a native Windows PowerShell bootstrap that works from PowerShell or Command Prompt without Git Bash or a preinstalled Node.js runtime
- validate the exact official Node.js 22 Windows x64/ARM64 archive against the published SHA-256 manifest before execution
- replace the two-option install control with accessible macOS/Linux, PowerShell, CMD, and NPX tabs
- synchronize the GitHub README, npm README source, changelog, security notes, maintenance guide, troubleshooting guide, and video outline
- add a Windows CI job that parses the script with Windows PowerShell 5.1 and runs its bootstrap tests

## Why

The previous curl bootstrap required a POSIX shell on Windows, which meant native Windows users still needed Git Bash or WSL. This adds a built-in Windows path and makes the hosted install steps terminal-first.

## Verification

- `npm run check` (75/75)
- `web: npm run lint`
- `web: npm run typecheck`
- `web: npm test` (14/14)
- `web: npm run build:vercel`
- PowerShell HTTPS manifest request with TLS/no-redirect flags
- npm package build and dry-run inspection
- Opera GX desktop, keyboard, copy-feedback, and 300% narrow-layout checks

Local npm advisory egress was policy-blocked, so the existing root/web audit commands remain required in GitHub CI before merge.
