### PR TITLE
Use an icon-only theme control

### DIFF
--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -201,9 +201,9 @@ a:focus-visible {
   min-width: 0;
   margin: 0;
   padding: 0.1875rem;
-  border: 1px solid var(--border);
-  border-radius: 0.625rem;
-  background: var(--surface-muted);
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text) 88%, var(--border));
 }
 
 .theme-picker label {
@@ -218,15 +218,15 @@ a:focus-visible {
 }
 
 .theme-picker span {
-  min-height: 2rem;
+  min-height: 1.75rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0 0.625rem;
-  border-radius: 0.4375rem;
-  color: var(--text-muted);
+  padding: 0 0.5rem;
+  border-radius: 999px;
+  color: rgb(255 255 255 / 72%);
   font-size: 0.6875rem;
-  font-weight: 700;
+  font-weight: 600;
   transition:
     color 160ms var(--ease),
     background 160ms var(--ease),

--- a/web/app/components/ThemeModeControl.tsx
+++ b/web/app/components/ThemeModeControl.tsx
@@ -20,31 +20,17 @@ export function ThemeModeControl() {
   }
 
   return (
-    <section className="theme-mode-control" aria-label="Appearance">
-      <span className="theme-mode-desktop">
-        <SegmentedControl
-          value={mode}
-          onChange={changeMode}
-          label="Color theme"
-          size="sm"
-        >
-          <SegmentedControlItem value="system" label="System" />
-          <SegmentedControlItem value="light" label="Light" />
-          <SegmentedControlItem value="dark" label="Dark" />
-        </SegmentedControl>
-      </span>
-      <label className="theme-mode-mobile">
-        <span className="visually-hidden">Color theme</span>
-        <select
-          aria-label="Color theme"
-          value={mode}
-          onChange={(event) => changeMode(event.target.value)}
-        >
-          <option value="system">System</option>
-          <option value="light">Light</option>
-          <option value="dark">Dark</option>
-        </select>
-      </label>
-    </section>
+    <SegmentedControl
+      className="theme-mode-control"
+      value={mode}
+      onChange={changeMode}
+      label="Color theme"
+      size="sm"
+      layout="hug"
+    >
+      <SegmentedControlItem value="system" label="System" />
+      <SegmentedControlItem value="light" label="Light" />
+      <SegmentedControlItem value="dark" label="Dark" />
+    </SegmentedControl>
   );
 }

--- a/web/app/components/ThemeModeControl.tsx
+++ b/web/app/components/ThemeModeControl.tsx
@@ -4,6 +4,7 @@ import {
   SegmentedControl,
   SegmentedControlItem,
 } from "@astryxdesign/core/SegmentedControl";
+import { Monitor, Moon, Sun } from "lucide-react";
 import { type ThemeMode, useThemePreference } from "../providers";
 
 function isThemeMode(value: string): value is ThemeMode {
@@ -28,9 +29,24 @@ export function ThemeModeControl() {
       size="sm"
       layout="hug"
     >
-      <SegmentedControlItem value="system" label="System" />
-      <SegmentedControlItem value="light" label="Light" />
-      <SegmentedControlItem value="dark" label="Dark" />
+      <SegmentedControlItem
+        value="system"
+        label="System"
+        isLabelHidden
+        icon={<Monitor size="1rem" strokeWidth={1.75} aria-hidden="true" />}
+      />
+      <SegmentedControlItem
+        value="light"
+        label="Light"
+        isLabelHidden
+        icon={<Sun size="1rem" strokeWidth={1.75} aria-hidden="true" />}
+      />
+      <SegmentedControlItem
+        value="dark"
+        label="Dark"
+        isLabelHidden
+        icon={<Moon size="1rem" strokeWidth={1.75} aria-hidden="true" />}
+      />
     </SegmentedControl>
   );
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -206,13 +206,21 @@ main {
 }
 
 .theme-mode-control [role="radio"] {
-  padding-inline: var(--spacing-2);
+  width: var(--size-element-sm);
+  min-width: var(--size-element-sm);
+  padding-inline: var(--spacing-1);
   border-radius: calc(
     var(--_segmented-control-radius) - var(--_segmented-control-padding)
   );
   color: color-mix(in srgb, var(--white) 72%, transparent);
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-medium);
+}
+
+.theme-mode-control [role="radio"] svg {
+  display: block;
+  width: 1rem;
+  height: 1rem;
 }
 
 .theme-mode-control [role="radio"]:hover {
@@ -2124,10 +2132,6 @@ footer > div {
 
   .header-actions {
     gap: 8px;
-  }
-
-  .theme-mode-control [role="radio"] {
-    padding-inline: var(--spacing-1);
   }
 
   .repository-button {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -194,26 +194,37 @@ main {
   gap: 10px;
 }
 
-.theme-mode-control,
-.theme-mode-desktop {
+.theme-mode-control {
   display: inline-flex;
   align-items: center;
+  gap: var(--spacing-0-5);
+  --_segmented-control-padding: var(--spacing-0-5);
+  --_segmented-control-radius: var(--radius-full);
+  padding: var(--spacing-0-5);
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--dark) 88%, var(--line));
 }
 
-.theme-mode-mobile {
-  display: none;
+.theme-mode-control [role="radio"] {
+  padding-inline: var(--spacing-2);
+  border-radius: calc(
+    var(--_segmented-control-radius) - var(--_segmented-control-padding)
+  );
+  color: color-mix(in srgb, var(--white) 72%, transparent);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
 }
 
-.theme-mode-mobile select {
-  min-height: 40px;
-  padding: 0 30px 0 12px;
-  border: 1px solid var(--line);
-  border-radius: 10px;
+.theme-mode-control [role="radio"]:hover {
+  background: color-mix(in srgb, var(--white) 12%, transparent);
+}
+
+.theme-mode-control [role="radio"][aria-checked="true"],
+.theme-mode-control [role="radio"][aria-checked="true"]:hover {
   background: var(--surface);
   color: var(--ink);
-  font: inherit;
-  font-size: 0.75rem;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
+  box-shadow: var(--shadow-sm);
 }
 
 .visually-hidden {
@@ -2115,12 +2126,8 @@ footer > div {
     gap: 8px;
   }
 
-  .theme-mode-desktop {
-    display: none;
-  }
-
-  .theme-mode-mobile {
-    display: inline-flex;
+  .theme-mode-control [role="radio"] {
+    padding-inline: var(--spacing-1);
   }
 
   .repository-button {
@@ -2296,6 +2303,12 @@ footer > div {
 
   footer > div {
     justify-self: start;
+  }
+}
+
+@media (max-width: 360px) {
+  .brand > span {
+    display: none;
   }
 }
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,6 +14,7 @@
         "@openai-oauth/ai-sdk": "2.0.0",
         "@openai-oauth/react": "2.0.0",
         "ai": "6.0.237",
+        "lucide-react": "1.28.0",
         "next": "16.2.12",
         "react": "19.2.8",
         "react-dom": "19.2.8"

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "@openai-oauth/ai-sdk": "2.0.0",
     "@openai-oauth/react": "2.0.0",
     "ai": "6.0.237",
+    "lucide-react": "1.28.0",
     "next": "16.2.12",
     "react": "19.2.8",
     "react-dom": "19.2.8"

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -44,9 +44,12 @@ test("server-renders the Relmio product page", async () => {
   assert.match(html, /data-astryx-theme="relmio"/);
   assert.match(html, /aria-label="Color theme"/);
   assert.match(html, /class="[^"]*\btheme-mode-control\b/);
-  assert.match(html, />System<\/span>/);
-  assert.match(html, />Light<\/span>/);
-  assert.match(html, />Dark<\/span>/);
+  assert.match(html, /aria-label="System"/);
+  assert.match(html, /aria-label="Light"/);
+  assert.match(html, /aria-label="Dark"/);
+  assert.match(html, /lucide-monitor/);
+  assert.match(html, /lucide-sun/);
+  assert.match(html, /lucide-moon/);
   assert.doesNotMatch(html, /theme-mode-mobile|<select/u);
   assert.match(html, /class="relay-visual"/);
   assert.match(html, /Connect, then ask\./);
@@ -82,6 +85,9 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
   assert.match(html, /data-astryx-theme="relmio"/);
   assert.match(html, /aria-label="Color theme"/);
   assert.match(html, /class="[^"]*\btheme-mode-control\b/);
+  assert.match(html, /lucide-monitor/);
+  assert.match(html, /lucide-sun/);
+  assert.match(html, /lucide-moon/);
   assert.doesNotMatch(html, /theme-mode-mobile|<select/u);
   assert.match(html, /Hostinger VPS/);
   assert.match(

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -43,9 +43,11 @@ test("server-renders the Relmio product page", async () => {
   assert.match(html, /href="\/install"[^>]*>Install wizard<\/a>/);
   assert.match(html, /data-astryx-theme="relmio"/);
   assert.match(html, /aria-label="Color theme"/);
+  assert.match(html, /class="[^"]*\btheme-mode-control\b/);
   assert.match(html, />System<\/span>/);
   assert.match(html, />Light<\/span>/);
   assert.match(html, />Dark<\/span>/);
+  assert.doesNotMatch(html, /theme-mode-mobile|<select/u);
   assert.match(html, /class="relay-visual"/);
   assert.match(html, /Connect, then ask\./);
   assert.match(html, /Before you connect: install the browser extension/);
@@ -79,6 +81,8 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
   assert.match(html, /Install Relmio for n8n/);
   assert.match(html, /data-astryx-theme="relmio"/);
   assert.match(html, /aria-label="Color theme"/);
+  assert.match(html, /class="[^"]*\btheme-mode-control\b/);
+  assert.doesNotMatch(html, /theme-mode-mobile|<select/u);
   assert.match(html, /Hostinger VPS/);
   assert.match(
     html,


### PR DESCRIPTION
## What changed
- Replace the hosted System / Light / Dark text segments with monitor, sun, and moon icons.
- Preserve accessible radio labels, keyboard navigation, theme persistence, and the GitHub star tracker.
- Keep the compact control responsive at 320px through desktop widths.
- Declare lucide-react explicitly for the icon family.

## Validation
- Web lint, typecheck, build, and 14 rendered/API tests
- Root release checks and 78 tests
- Astryx doctor and npm audits
- Opera GX QA at 320, 768, 1024, and 1440px, including arrow-key selection

The root npm package remains at 0.2.7 because this is a web-only UI change.