### PR TITLE
Fix Windows installer browser launch and ChatGPT sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+## [0.2.11] - 2026-08-04
+
 ### Fixed
 
 - Open the private Windows wizard URL through the documented default-browser
@@ -17,6 +19,11 @@ checks the registry separately after publication.
 - Parse the supported `openai-oauth@2.0.0` login line across Windows terminal
   control sequences and chunk boundaries, and report a sanitized, actionable
   callback-port conflict instead of a generic missing-link error.
+
+### Security
+
+- Pin the hosted web tooling to `brace-expansion` 5.0.9, which includes the
+  upstream denial-of-service fix required by the release audit.
 
 ## [0.2.10] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+### Fixed
+
+- Open the private Windows wizard URL through the documented default-browser
+  association instead of asking Explorer to treat the URL as a folder, while
+  retaining the printed URL and Enter-to-retry fallback.
+- Make the Command Prompt installer copy call the system Windows PowerShell
+  executable directly, avoiding ambiguous `powershell` command resolution.
+- Parse the supported `openai-oauth@2.0.0` login line across Windows terminal
+  control sequences and chunk boundaries, and report a sanitized, actionable
+  callback-port conflict instead of a generic missing-link error.
+
 ## [0.2.10] - 2026-08-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ irm https://relmio.vercel.app/install.ps1 | iex
 ### Windows Command Prompt
 
 ```bat
-powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
+"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
 ```
 
 These commands start the wizard without installing Node.js or Git Bash first.
@@ -383,7 +383,7 @@ irm https://relmio.vercel.app/install.ps1 | iex
 #### Windows Command Prompt
 
 ```bat
-powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
+"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
 ```
 
 The POSIX and native Windows bootstraps use a supported Node.js installation

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,7 +49,7 @@ irm https://relmio.vercel.app/install.ps1 | iex
 Windows Command Prompt:
 
 ```bat
-powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
+"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
 ```
 
 These commands do not require Node.js to be installed. The Windows options do
@@ -70,6 +70,11 @@ Keep the terminal open. If the running wizard accepts terminal input, press
 Enter to ask it to open the browser again. Otherwise, copy the newest printed
 `http://127.0.0.1:...` URL into the browser. That URL contains a temporary setup
 token: do not post it in an issue or screenshot.
+
+The local wizard may be displayed in a VS Code embedded browser. Its validated
+manual link, **Open fresh ChatGPT sign-in**, remains available if that embedded
+browser blocks the popup or no new tab opens. Use that link only from the active
+wizard attempt; it points to the fresh `auth.openai.com` authorization URL.
 
 You do not need to sign in to npm, configure npm 2FA, or own this package to
 run any public command. npm authentication is required only for the
@@ -112,7 +117,7 @@ bypassed.
 | Symptom | Meaning | Fix |
 |---|---|---|
 | `node: command not found`, `node is not recognized`, or Node is older than 22 | The NPX fallback cannot use the local runtime. | Use the macOS/Linux curl command or the native Windows PowerShell/Command Prompt command above. Either can run with a verified temporary runtime. Do not install Node.js on the VPS for the wizard. |
-| `curl` or `sh` is not recognized on Windows | The macOS/Linux command was pasted into a native Windows terminal. | Use the PowerShell command in PowerShell, or the longer `powershell -NoProfile ...` command in Command Prompt. Git Bash is not required. |
+| `curl` or `sh` is not recognized on Windows | The macOS/Linux command was pasted into a native Windows terminal. | Use the PowerShell command in PowerShell, or the `"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile ...` command in Command Prompt. Git Bash is not required. |
 | A bootstrap reports a checksum mismatch | The Node.js download did not match the official SHA-256 manifest, so it was not executed. | Retry on a trusted connection. Do not bypass the check. If it repeats, use an existing Node.js 22+ installation and report the sanitized error. |
 | Windows PowerShell shows `[eval]:1` before the wizard starts | An older bootstrap passed a JavaScript expression through `node -p`; PowerShell native-argument handling can alter that expression. | Update to the latest `relmio@latest` and rerun the same PowerShell or Command Prompt command. The current bootstrap parses the literal `node --version` output and reuses Node.js 22 or newer. |
 | Windows reports `spawn EINVAL` when starting ChatGPT sign-in | An older wizard tried to execute `npx.cmd` directly; Windows requires the current Node runtime to launch npm's JavaScript CLI. | Update to the latest `relmio@latest` release and restart the setup command. The current wizard keeps the macOS/Linux/WSL/Git Bash `npx` path unchanged. |

--- a/npm/README.md
+++ b/npm/README.md
@@ -105,7 +105,7 @@ irm https://relmio.vercel.app/install.ps1 | iex
 ### Windows Command Prompt
 
 ```bat
-powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
+"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
 ```
 
 No Node.js or Git Bash installation is required first. The

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relmio",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relmio",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "Apache-2.0",
       "dependencies": {
         "ssh2": "1.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relmio",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Turn a supported ChatGPT/Codex OAuth sign-in into a private OpenAI-compatible endpoint, starting with self-hosted n8n.",
   "keywords": [
     "relmio",

--- a/src/browser.js
+++ b/src/browser.js
@@ -6,8 +6,8 @@ export function browserCommand(url, platform = process.platform) {
   }
   if (platform === "win32") {
     return {
-      file: "rundll32.exe",
-      args: ["url.dll,FileProtocolHandler", url],
+      file: "cmd.exe",
+      args: ["/d", "/c", "start", "Relmio local wizard", url],
     };
   }
   return { file: "xdg-open", args: [url] };
@@ -20,13 +20,19 @@ function isPrivateWizardUrl(value) {
 
   try {
     const url = new URL(value);
+    const session = url.searchParams.get("session");
     return (
       url.protocol === "http:" &&
       url.hostname === "127.0.0.1" &&
       url.port !== "" &&
+      Number(url.port) > 0 &&
       url.pathname === "/" &&
-      url.searchParams.get("session") !== null &&
-      url.searchParams.get("session") !== ""
+      url.username === "" &&
+      url.password === "" &&
+      url.hash === "" &&
+      typeof session === "string" &&
+      /^[A-Za-z0-9_-]{43}$/u.test(session) &&
+      url.search === `?session=${session}`
     );
   } catch {
     return false;

--- a/src/browser.js
+++ b/src/browser.js
@@ -5,15 +5,41 @@ export function browserCommand(url, platform = process.platform) {
     return { file: "open", args: [url] };
   }
   if (platform === "win32") {
-    return { file: "explorer.exe", args: [url] };
+    return {
+      file: "rundll32.exe",
+      args: ["url.dll,FileProtocolHandler", url],
+    };
   }
   return { file: "xdg-open", args: [url] };
+}
+
+function isPrivateWizardUrl(value) {
+  if (typeof value !== "string" || /[\u0000-\u001F\u007F]/u.test(value)) {
+    return false;
+  }
+
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "http:" &&
+      url.hostname === "127.0.0.1" &&
+      url.port !== "" &&
+      url.pathname === "/" &&
+      url.searchParams.get("session") !== null &&
+      url.searchParams.get("session") !== ""
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function openBrowser(
   url,
   { platform = process.platform, spawnProcess = spawn } = {},
 ) {
+  if (!isPrivateWizardUrl(url)) {
+    return false;
+  }
   const command = browserCommand(url, platform);
   let child;
   try {

--- a/src/services/oauth.js
+++ b/src/services/oauth.js
@@ -12,6 +12,11 @@ const PROCESS_TIMEOUT_MS = LOGIN_TIMEOUT_MS + 15_000;
 const CREDENTIAL_POLL_INTERVAL_MS = 100;
 const LOGIN_URL_PREFIX = "OpenAI OAuth login URL: ";
 const OPENAI_AUTH_ORIGIN = "https://auth.openai.com";
+const SUPPORTED_LOOPBACK_REDIRECT_HOSTNAMES = new Set([
+  "localhost",
+  "127.0.0.1",
+  "[::1]",
+]);
 
 const wait = (milliseconds) =>
   new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
@@ -124,6 +129,10 @@ function validateAuthorizationUrl(value) {
 
   if (
     url.origin !== OPENAI_AUTH_ORIGIN ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.hash !== "" ||
+    url.href.includes("#") ||
     url.pathname !== "/oauth/authorize" ||
     url.searchParams.get("response_type") !== "code" ||
     !url.searchParams.get("state") ||
@@ -139,7 +148,14 @@ function validateAuthorizationUrl(value) {
     throw new Error("The sign-in command returned an invalid callback.");
   }
   if (
-    !["localhost", "127.0.0.1", "::1"].includes(redirect.hostname) ||
+    redirect.protocol !== "http:" ||
+    redirect.username !== "" ||
+    redirect.password !== "" ||
+    redirect.search !== "" ||
+    redirect.hash !== "" ||
+    redirect.href.includes("?") ||
+    redirect.href.includes("#") ||
+    !SUPPORTED_LOOPBACK_REDIRECT_HOSTNAMES.has(redirect.hostname) ||
     redirect.port !== "1455" ||
     redirect.pathname !== "/auth/callback"
   ) {
@@ -156,8 +172,10 @@ function stripTerminalControlSequences(value) {
     .replace(/[\u0000-\u0009\u000B-\u001F\u007F-\u009F]/gu, "");
 }
 
-function extractAuthorizationUrl(output) {
-  for (const line of stripTerminalControlSequences(output).split("\n")) {
+function extractAuthorizationUrl(output, { includeFinalLine = false } = {}) {
+  const lines = stripTerminalControlSequences(output).split("\n");
+  const lineCount = includeFinalLine ? lines.length : lines.length - 1;
+  for (const line of lines.slice(0, lineCount)) {
     const markerIndex = line.indexOf(LOGIN_URL_PREFIX);
     if (markerIndex >= 0) {
       return validateAuthorizationUrl(
@@ -278,22 +296,22 @@ export async function startOAuthLogin({
   child.stdout?.on?.("data", (chunk) => captureLoginOutput("stdout", chunk));
   child.stderr?.on?.("data", (chunk) => captureLoginOutput("stderr", chunk));
 
-  let resolveExit;
-  let rejectExit;
-  let exitSettled = false;
-  const exitPromise = new Promise((resolvePromise, rejectPromise) => {
-    resolveExit = resolvePromise;
-    rejectExit = rejectPromise;
+  let resolveProcessClose;
+  let rejectProcessClose;
+  let processCloseSettled = false;
+  const processClosePromise = new Promise((resolvePromise, rejectPromise) => {
+    resolveProcessClose = resolvePromise;
+    rejectProcessClose = rejectPromise;
   });
-  const settleExit = (error, code) => {
-    if (exitSettled) {
+  const settleProcessClose = (error, code) => {
+    if (processCloseSettled) {
       return;
     }
-    exitSettled = true;
+    processCloseSettled = true;
     if (error) {
-      rejectExit(error);
+      rejectProcessClose(error);
     } else {
-      resolveExit(code);
+      resolveProcessClose(code);
     }
   };
 
@@ -302,13 +320,24 @@ export async function startOAuthLogin({
       "The local sign-in command could not start. Install Node.js 22 and try again.",
     );
     settleAuthorizationUrl(error);
-    settleExit(error);
+    settleProcessClose(error);
   });
-  child.once("exit", (code) => {
+  child.once("close", (code) => {
     if (!authorizationUrlSettled) {
-      settleAuthorizationUrl(loginStartupError(loginOutput.stderr));
+      try {
+        const authorizationUrl = extractAuthorizationUrl(loginOutput.stdout, {
+          includeFinalLine: true,
+        });
+        if (authorizationUrl) {
+          settleAuthorizationUrl(null, authorizationUrl);
+        } else {
+          settleAuthorizationUrl(loginStartupError(loginOutput.stderr));
+        }
+      } catch (error) {
+        settleAuthorizationUrl(error);
+      }
     }
-    settleExit(null, code);
+    settleProcessClose(null, code);
   });
 
   const loginUrlTimeout = setTimeout(() => {
@@ -352,7 +381,7 @@ export async function startOAuthLogin({
     try {
       return await Promise.race([
         pendingCredentialPromise,
-        exitPromise.then(async (code) => {
+        processClosePromise.then(async (code) => {
           if (code !== 0) {
             throw new Error(
               "ChatGPT sign-in did not finish. Start a fresh login.",
@@ -374,7 +403,7 @@ export async function startOAuthLogin({
       keepPollingForCredential = false;
       clearTimeout(processTimeout);
       clearTimeout(loginUrlTimeout);
-      if (!exitSettled) {
+      if (!processCloseSettled) {
         child.kill?.("SIGTERM");
       }
       try {

--- a/src/services/oauth.js
+++ b/src/services/oauth.js
@@ -149,13 +149,34 @@ function validateAuthorizationUrl(value) {
   return url.toString();
 }
 
+function stripTerminalControlSequences(value) {
+  return value
+    .replace(/\u001B\][^\u0007]*(?:\u0007|\u001B\\)/gu, "")
+    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/gu, "")
+    .replace(/[\u0000-\u0009\u000B-\u001F\u007F-\u009F]/gu, "");
+}
+
 function extractAuthorizationUrl(output) {
-  for (const line of output.split(/\r?\n/u)) {
-    if (line.startsWith(LOGIN_URL_PREFIX)) {
-      return validateAuthorizationUrl(line.slice(LOGIN_URL_PREFIX.length));
+  for (const line of stripTerminalControlSequences(output).split("\n")) {
+    const markerIndex = line.indexOf(LOGIN_URL_PREFIX);
+    if (markerIndex >= 0) {
+      return validateAuthorizationUrl(
+        line.slice(markerIndex + LOGIN_URL_PREFIX.length).trim(),
+      );
     }
   }
   return null;
+}
+
+function loginStartupError(stderr) {
+  const callbackPortConflict =
+    "OpenAI OAuth login needs http://localhost:1455/auth/callback, but port 1455 is already in use.";
+  if (stripTerminalControlSequences(stderr).includes(callbackPortConflict)) {
+    return new Error(
+      `${callbackPortConflict} Stop the process using that port and try again.`,
+    );
+  }
+  return new Error("The sign-in command did not return an authorization URL.");
 }
 
 export async function startOAuthLogin({
@@ -205,9 +226,8 @@ export async function startOAuthLogin({
       { cause: error },
     );
   }
-  child.stderr?.resume();
-
-  let loginOutput = "";
+  const loginOutput = { stdout: "", stderr: "" };
+  let loginOutputBytes = 0;
   let resolveAuthorizationUrl;
   let rejectAuthorizationUrl;
   let authorizationUrlSettled = false;
@@ -227,20 +247,25 @@ export async function startOAuthLogin({
     }
   };
 
-  child.stdout?.on("data", (chunk) => {
+  const captureLoginOutput = (stream, chunk) => {
     if (authorizationUrlSettled) {
       return;
     }
-    loginOutput += Buffer.from(chunk).toString("utf8");
-    if (Buffer.byteLength(loginOutput) > MAX_LOGIN_OUTPUT_BYTES) {
+    const output = Buffer.from(chunk).toString("utf8");
+    loginOutputBytes += Buffer.byteLength(output);
+    if (loginOutputBytes > MAX_LOGIN_OUTPUT_BYTES) {
       settleAuthorizationUrl(
         new Error("The sign-in command returned too much output."),
       );
       child.kill?.("SIGTERM");
       return;
     }
+    loginOutput[stream] += output;
+    if (stream !== "stdout") {
+      return;
+    }
     try {
-      const authorizationUrl = extractAuthorizationUrl(loginOutput);
+      const authorizationUrl = extractAuthorizationUrl(loginOutput.stdout);
       if (authorizationUrl) {
         settleAuthorizationUrl(null, authorizationUrl);
       }
@@ -248,7 +273,10 @@ export async function startOAuthLogin({
       settleAuthorizationUrl(error);
       child.kill?.("SIGTERM");
     }
-  });
+  };
+
+  child.stdout?.on?.("data", (chunk) => captureLoginOutput("stdout", chunk));
+  child.stderr?.on?.("data", (chunk) => captureLoginOutput("stderr", chunk));
 
   let resolveExit;
   let rejectExit;
@@ -278,9 +306,7 @@ export async function startOAuthLogin({
   });
   child.once("exit", (code) => {
     if (!authorizationUrlSettled) {
-      settleAuthorizationUrl(
-        new Error("The sign-in command did not return an authorization URL."),
-      );
+      settleAuthorizationUrl(loginStartupError(loginOutput.stderr));
     }
     settleExit(null, code);
   });

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -9,12 +9,12 @@ import {
 } from "../src/browser.js";
 
 test("Windows browser launching invokes the default URL handler with the local URL as a literal argument", () => {
-  const url = "http://127.0.0.1:4567/?session=literal&next=%26whoami";
+  const url = `http://127.0.0.1:4567/?session=${"a".repeat(43)}`;
   const command = browserCommand(url, "win32");
 
   assert.deepEqual(command, {
-    file: "rundll32.exe",
-    args: ["url.dll,FileProtocolHandler", url],
+    file: "cmd.exe",
+    args: ["/d", "/c", "start", "Relmio local wizard", url],
   });
 
   const calls = [];
@@ -29,22 +29,25 @@ test("Windows browser launching invokes the default URL handler with the local U
   });
 
   assert.deepEqual(calls, [
-    ["rundll32.exe", command.args, { detached: true, stdio: "ignore", shell: false }],
+    ["cmd.exe", command.args, { detached: true, stdio: "ignore", shell: false }],
   ]);
 });
 
-test("browser launching refuses URLs outside the private local wizard", () => {
+test("browser launching refuses URLs outside the exact private local wizard", () => {
   const calls = [];
 
-  const opened = openBrowser("https://example.test/?session=not-local", {
-    platform: "win32",
-    spawnProcess(...args) {
-      calls.push(args);
-      const child = new EventEmitter();
-      child.unref = () => {};
-      return child;
+  const opened = openBrowser(
+    `http://127.0.0.1:4567/?session=${"a".repeat(43)}&next=%26whoami`,
+    {
+      platform: "win32",
+      spawnProcess(...args) {
+        calls.push(args);
+        const child = new EventEmitter();
+        child.unref = () => {};
+        return child;
+      },
     },
-  });
+  );
 
   assert.equal(opened, false);
   assert.deepEqual(calls, []);

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -8,21 +8,19 @@ import {
   openBrowser,
 } from "../src/browser.js";
 
-test("Windows browser launching passes the local URL as a literal argument", () => {
-  const command = browserCommand(
-    "http://127.0.0.1:4567/?session=literal&next=%26whoami",
-    "win32",
-  );
+test("Windows browser launching invokes the default URL handler with the local URL as a literal argument", () => {
+  const url = "http://127.0.0.1:4567/?session=literal&next=%26whoami";
+  const command = browserCommand(url, "win32");
 
   assert.deepEqual(command, {
-    file: "explorer.exe",
-    args: ["http://127.0.0.1:4567/?session=literal&next=%26whoami"],
+    file: "rundll32.exe",
+    args: ["url.dll,FileProtocolHandler", url],
   });
 
   const calls = [];
   const child = new EventEmitter();
   child.unref = () => {};
-  openBrowser(command.args[0], {
+  openBrowser(url, {
     platform: "win32",
     spawnProcess(...args) {
       calls.push(args);
@@ -31,8 +29,25 @@ test("Windows browser launching passes the local URL as a literal argument", () 
   });
 
   assert.deepEqual(calls, [
-    ["explorer.exe", command.args, { detached: true, stdio: "ignore", shell: false }],
+    ["rundll32.exe", command.args, { detached: true, stdio: "ignore", shell: false }],
   ]);
+});
+
+test("browser launching refuses URLs outside the private local wizard", () => {
+  const calls = [];
+
+  const opened = openBrowser("https://example.test/?session=not-local", {
+    platform: "win32",
+    spawnProcess(...args) {
+      calls.push(args);
+      const child = new EventEmitter();
+      child.unref = () => {};
+      return child;
+    },
+  });
+
+  assert.equal(opened, false);
+  assert.deepEqual(calls, []);
 });
 
 test("macOS and Linux retain their native browser launchers", () => {

--- a/test/documentation.test.js
+++ b/test/documentation.test.js
@@ -100,6 +100,22 @@ test("release guidance covers the Windows probe, browser relaunch, and blank OAu
   assert.match(troubleshooting, /white `about:blank` tab/u);
 });
 
+test("Windows Command Prompt documentation calls the system PowerShell executable", async () => {
+  const [readme, npmReadme, troubleshooting] = await Promise.all([
+    readFile("README.md", "utf8"),
+    readFile("npm/README.md", "utf8"),
+    readFile("docs/troubleshooting.md", "utf8"),
+  ]);
+  const command =
+    '"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"';
+
+  for (const guide of [readme, npmReadme, troubleshooting]) {
+    assert.ok(guide.includes(command));
+  }
+  assert.match(troubleshooting, /VS Code embedded browser/u);
+  assert.match(troubleshooting, /validated manual link/u);
+});
+
 test("n8n configuration guide provides copy-paste model and HTTP recipes", async () => {
   const guide = await readFile("docs/n8n-configuration.md", "utf8");
 

--- a/test/oauth.test.js
+++ b/test/oauth.test.js
@@ -170,6 +170,98 @@ test("startOAuthLogin returns one validated link and stores the credential after
   );
 });
 
+test("startOAuthLogin reads the supported CLI login line across ANSI, CRLF, and chunks", async () => {
+  const files = {};
+  const fileSystem = createMemoryFileSystem(files);
+  const spawnProcess = (_command, args) => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stderr.resume = () => {};
+    child.kill = () => {};
+    queueMicrotask(() => {
+      const authorizationUrl = new URL(
+        "https://auth.openai.com/oauth/authorize",
+      );
+      authorizationUrl.searchParams.set("response_type", "code");
+      authorizationUrl.searchParams.set(
+        "redirect_uri",
+        "http://localhost:1455/auth/callback",
+      );
+      authorizationUrl.searchParams.set("state", "windows-state");
+      authorizationUrl.searchParams.set("code_challenge", "windows-challenge");
+      child.stderr.emit("data", Buffer.from("\u001B[90mnpm notice\u001B[0m\r\n"));
+      child.stdout.emit("data", Buffer.from("\u001B[2"));
+      child.stdout.emit(
+        "data",
+        Buffer.from(`KOpenAI OAuth login URL: ${authorizationUrl}\r`),
+      );
+      child.stdout.emit("data", Buffer.from("\n"));
+      const oauthFileIndex = args.indexOf("--oauth-file");
+      files[args[oauthFileIndex + 1]] = '{"windows":true}';
+      child.emit("exit", 0);
+    });
+    return child;
+  };
+
+  const login = await startOAuthLogin({
+    fileSystem,
+    env: {},
+    homeDirectory: "/home/user",
+    platform: "win32",
+    execPath: "C:\\portable\\node.exe",
+    spawnProcess,
+    createPendingId: () => "windows-output",
+  });
+
+  assert.match(
+    login.authorizationUrl,
+    /^https:\/\/auth\.openai\.com\/oauth\/authorize\?/u,
+  );
+  assert.deepEqual(await login.completion, { success: true });
+});
+
+test("startOAuthLogin surfaces a sanitized callback port conflict from stderr", async () => {
+  const spawnProcess = () => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stderr.resume = () => {};
+    child.kill = () => {};
+    queueMicrotask(() => {
+      child.stderr.emit(
+        "data",
+        Buffer.from(
+          "\u001B[31mOpenAI OAuth login needs http://localhost:1455/auth/callback, but port 1455 is already in use. Stop the process using that port and try again. token=not-for-users\u001B[0m\r\n",
+        ),
+      );
+      child.emit("exit", 1);
+    });
+    return child;
+  };
+
+  await assert.rejects(
+    () =>
+      startOAuthLogin({
+        fileSystem: createMemoryFileSystem({}),
+        env: {},
+        homeDirectory: "/home/user",
+        platform: "win32",
+        execPath: "C:\\portable\\node.exe",
+        spawnProcess,
+        createPendingId: () => "port-conflict",
+      }),
+    (error) => {
+      assert.equal(
+        error.message,
+        "OpenAI OAuth login needs http://localhost:1455/auth/callback, but port 1455 is already in use. Stop the process using that port and try again.",
+      );
+      assert.doesNotMatch(error.message, /not-for-users|token=/u);
+      return true;
+    },
+  );
+});
+
 test("startOAuthLogin uses the current Node runtime for Windows npm launchers", async () => {
   const calls = [];
   const files = {};

--- a/test/oauth.test.js
+++ b/test/oauth.test.js
@@ -48,6 +48,22 @@ function createMemoryFileSystem(files) {
   };
 }
 
+function finishChild(child, code) {
+  child.emit("exit", code);
+  child.emit("close", code);
+}
+
+function createAuthorizationUrl({
+  redirectUri = "http://localhost:1455/auth/callback",
+} = {}) {
+  const authorizationUrl = new URL("https://auth.openai.com/oauth/authorize");
+  authorizationUrl.searchParams.set("response_type", "code");
+  authorizationUrl.searchParams.set("redirect_uri", redirectUri);
+  authorizationUrl.searchParams.set("state", "fixture-state");
+  authorizationUrl.searchParams.set("code_challenge", "fixture-challenge");
+  return authorizationUrl;
+}
+
 test("resolveAuthPath uses wizard-only storage without exposing file contents", () => {
   assert.equal(
     resolveAuthPath({
@@ -127,7 +143,7 @@ test("startOAuthLogin returns one validated link and stores the credential after
       );
       const oauthFileIndex = args.indexOf("--oauth-file");
       files[args[oauthFileIndex + 1]] = '{"fixture":true}';
-      child.emit("exit", 0);
+      finishChild(child, 0);
     });
     return child;
   };
@@ -199,7 +215,7 @@ test("startOAuthLogin reads the supported CLI login line across ANSI, CRLF, and 
       child.stdout.emit("data", Buffer.from("\n"));
       const oauthFileIndex = args.indexOf("--oauth-file");
       files[args[oauthFileIndex + 1]] = '{"windows":true}';
-      child.emit("exit", 0);
+      finishChild(child, 0);
     });
     return child;
   };
@@ -221,6 +237,168 @@ test("startOAuthLogin reads the supported CLI login line across ANSI, CRLF, and 
   assert.deepEqual(await login.completion, { success: true });
 });
 
+test("startOAuthLogin waits for every byte boundary of the supported CRLF login line", async () => {
+  const authorizationUrl = new URL("https://auth.openai.com/oauth/authorize");
+  authorizationUrl.searchParams.set("response_type", "code");
+  authorizationUrl.searchParams.set(
+    "redirect_uri",
+    "http://localhost:1455/auth/callback",
+  );
+  authorizationUrl.searchParams.set("state", "split-state");
+  authorizationUrl.searchParams.set("code_challenge", "split-challenge");
+  const loginLine = Buffer.from(
+    `OpenAI OAuth login URL: ${authorizationUrl}\r\n`,
+  );
+
+  for (let splitAt = 1; splitAt < loginLine.length; splitAt += 1) {
+    const files = {};
+    let child;
+    let pendingAuthPath;
+    const spawnProcess = (_command, args) => {
+      child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stderr.resume = () => {};
+      child.kill = () => finishChild(child, 1);
+      pendingAuthPath = args[args.indexOf("--oauth-file") + 1];
+      queueMicrotask(() => {
+        child.stdout.emit("data", loginLine.subarray(0, splitAt));
+      });
+      return child;
+    };
+
+    const loginPromise = startOAuthLogin({
+      fileSystem: createMemoryFileSystem(files),
+      env: {},
+      homeDirectory: "/home/user",
+      platform: "win32",
+      execPath: "C:\\portable\\node.exe",
+      spawnProcess,
+      createPendingId: () => `split-${splitAt}`,
+    });
+    let earlyOutcome;
+    loginPromise.then(
+      () => {
+        earlyOutcome = "resolved";
+      },
+      () => {
+        earlyOutcome = "rejected";
+      },
+    );
+    await new Promise((resolvePromise) => setImmediate(resolvePromise));
+
+    assert.equal(
+      earlyOutcome,
+      undefined,
+      `split at byte ${splitAt} settled before the complete CRLF line`,
+    );
+
+    child.stdout.emit("data", loginLine.subarray(splitAt));
+    files[pendingAuthPath] = '{"split":true}';
+    finishChild(child, 0);
+
+    const login = await loginPromise;
+    assert.equal(login.authorizationUrl, authorizationUrl.toString());
+    assert.deepEqual(await login.completion, { success: true });
+  }
+});
+
+test("startOAuthLogin accepts a complete supported login line without a final newline on exit", async () => {
+  const files = {};
+  let child;
+  let pendingAuthPath;
+  const authorizationUrl = new URL("https://auth.openai.com/oauth/authorize");
+  authorizationUrl.searchParams.set("response_type", "code");
+  authorizationUrl.searchParams.set(
+    "redirect_uri",
+    "http://localhost:1455/auth/callback",
+  );
+  authorizationUrl.searchParams.set("state", "unterminated-state");
+  authorizationUrl.searchParams.set("code_challenge", "unterminated-challenge");
+  const loginLine = `OpenAI OAuth login URL: ${authorizationUrl}`;
+  const spawnProcess = (_command, args) => {
+    child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stderr.resume = () => {};
+    child.kill = () => finishChild(child, 1);
+    pendingAuthPath = args[args.indexOf("--oauth-file") + 1];
+    queueMicrotask(() => {
+      child.stdout.emit("data", Buffer.from(loginLine));
+    });
+    return child;
+  };
+
+  const loginPromise = startOAuthLogin({
+    fileSystem: createMemoryFileSystem(files),
+    env: {},
+    homeDirectory: "/home/user",
+    platform: "win32",
+    execPath: "C:\\portable\\node.exe",
+    spawnProcess,
+    createPendingId: () => "unterminated",
+  });
+  let earlyOutcome;
+  loginPromise.then(
+    () => {
+      earlyOutcome = "resolved";
+    },
+    () => {
+      earlyOutcome = "rejected";
+    },
+  );
+  await new Promise((resolvePromise) => setImmediate(resolvePromise));
+
+  assert.equal(earlyOutcome, undefined);
+
+  files[pendingAuthPath] = '{"unterminated":true}';
+  finishChild(child, 0);
+
+  const login = await loginPromise;
+  assert.equal(login.authorizationUrl, authorizationUrl.toString());
+  assert.deepEqual(await login.completion, { success: true });
+});
+
+test("startOAuthLogin waits for close after exit before finalizing stdout", async () => {
+  const files = {};
+  let child;
+  let pendingAuthPath;
+  const authorizationUrl = createAuthorizationUrl({
+    redirectUri: "http://localhost:1455/auth/callback",
+  });
+  const spawnProcess = (_command, args) => {
+    child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stderr.resume = () => {};
+    child.kill = () => {};
+    pendingAuthPath = args[args.indexOf("--oauth-file") + 1];
+    queueMicrotask(() => {
+      child.emit("exit", 0);
+      child.stdout.emit(
+        "data",
+        Buffer.from(`OpenAI OAuth login URL: ${authorizationUrl}`),
+      );
+      files[pendingAuthPath] = '{"drained":true}';
+      child.emit("close", 0);
+    });
+    return child;
+  };
+
+  const login = await startOAuthLogin({
+    fileSystem: createMemoryFileSystem(files),
+    env: {},
+    homeDirectory: "/home/user",
+    platform: "win32",
+    execPath: "C:\\portable\\node.exe",
+    spawnProcess,
+    createPendingId: () => "drained-output",
+  });
+
+  assert.equal(login.authorizationUrl, authorizationUrl.toString());
+  assert.deepEqual(await login.completion, { success: true });
+});
+
 test("startOAuthLogin surfaces a sanitized callback port conflict from stderr", async () => {
   const spawnProcess = () => {
     const child = new EventEmitter();
@@ -229,13 +407,14 @@ test("startOAuthLogin surfaces a sanitized callback port conflict from stderr", 
     child.stderr.resume = () => {};
     child.kill = () => {};
     queueMicrotask(() => {
+      child.emit("exit", 1);
       child.stderr.emit(
         "data",
         Buffer.from(
           "\u001B[31mOpenAI OAuth login needs http://localhost:1455/auth/callback, but port 1455 is already in use. Stop the process using that port and try again. token=not-for-users\u001B[0m\r\n",
         ),
       );
-      child.emit("exit", 1);
+      child.emit("close", 1);
     });
     return child;
   };
@@ -297,7 +476,7 @@ test("startOAuthLogin uses the current Node runtime for Windows npm launchers", 
       );
       const oauthFileIndex = args.indexOf("--oauth-file");
       files[args[oauthFileIndex + 1]] = '{"windows":true}';
-      child.emit("exit", 0);
+      finishChild(child, 0);
     });
     return child;
   };
@@ -436,7 +615,7 @@ test("startOAuthLogin saves a valid pending credential before the helper exits",
       '{"fresh":true}',
     );
   } finally {
-    child.emit("exit", 1);
+    finishChild(child, 1);
     login.cancel();
   }
 });
@@ -447,7 +626,7 @@ test("startOAuthLogin rejects an unexpected authorization destination", async ()
     const child = new EventEmitter();
     child.stdout = new EventEmitter();
     child.stderr = { resume() {} };
-    child.kill = () => queueMicrotask(() => child.emit("exit", 1));
+    child.kill = () => queueMicrotask(() => finishChild(child, 1));
     queueMicrotask(() => {
       child.stdout.emit(
         "data",
@@ -471,4 +650,69 @@ test("startOAuthLogin rejects an unexpected authorization destination", async ()
       }),
     /unexpected destination/i,
   );
+});
+
+test("startOAuthLogin only accepts exact supported authorization and callback URLs", async () => {
+  const startWithAuthorizationUrl = (authorizationUrl) => {
+    const files = {};
+    const spawnProcess = (_command, args) => {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stderr.resume = () => {};
+      child.kill = () => {};
+      queueMicrotask(() => {
+        child.stdout.emit(
+          "data",
+          Buffer.from(`OpenAI OAuth login URL: ${authorizationUrl}\n`),
+        );
+        files[args[args.indexOf("--oauth-file") + 1]] = '{"valid":true}';
+        finishChild(child, 0);
+      });
+      return child;
+    };
+
+    return startOAuthLogin({
+      fileSystem: createMemoryFileSystem(files),
+      env: {},
+      homeDirectory: "/home/user",
+      platform: "win32",
+      execPath: "C:\\portable\\node.exe",
+      spawnProcess,
+      createPendingId: () => "exact-url-shape",
+    });
+  };
+
+  for (const redirectUri of [
+    "https://localhost:1455/auth/callback",
+    "http://user@localhost:1455/auth/callback",
+    "http://localhost:1455/auth/callback?unexpected=value",
+    "http://localhost:1455/auth/callback#unexpected",
+  ]) {
+    await assert.rejects(
+      () => startWithAuthorizationUrl(createAuthorizationUrl({ redirectUri })),
+      /unexpected callback/i,
+    );
+  }
+
+  const authorizationUrlWithCredentials = createAuthorizationUrl();
+  authorizationUrlWithCredentials.username = "unexpected";
+  await assert.rejects(
+    () => startWithAuthorizationUrl(authorizationUrlWithCredentials),
+    /unexpected destination/i,
+  );
+
+  const authorizationUrlWithFragment = createAuthorizationUrl();
+  authorizationUrlWithFragment.hash = "unexpected";
+  await assert.rejects(
+    () => startWithAuthorizationUrl(authorizationUrlWithFragment),
+    /unexpected destination/i,
+  );
+
+  const ipv6AuthorizationUrl = createAuthorizationUrl({
+    redirectUri: "http://[::1]:1455/auth/callback",
+  });
+  const ipv6Login = await startWithAuthorizationUrl(ipv6AuthorizationUrl);
+  assert.equal(ipv6Login.authorizationUrl, ipv6AuthorizationUrl.toString());
+  assert.deepEqual(await ipv6Login.completion, { success: true });
 });

--- a/web/app/components/CopyCommand.tsx
+++ b/web/app/components/CopyCommand.tsx
@@ -26,7 +26,7 @@ const installMethods = [
     id: "cmd",
     label: "CMD",
     command:
-      'powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"',
+      '"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"',
     note: "Open Command Prompt, not PowerShell. This launches the same verified Windows installer.",
     prompt: ">",
   },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4842,9 +4842,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -45,7 +45,7 @@
     "wrangler": "4.115.0"
   },
   "overrides": {
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "minimatch": "10.2.6",
     "postcss": "8.5.25",
     "sharp": "0.35.0"

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -100,7 +100,7 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
   );
   assert.match(
     html,
-    /powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;irm https:\/\/relmio\.vercel\.app\/install\.ps1 \| iex&quot;/,
+    /&quot;%SystemRoot%\\System32\\WindowsPowerShell\\v1\.0\\powershell\.exe&quot; -NoProfile -ExecutionPolicy Bypass -Command &quot;irm https:\/\/relmio\.vercel\.app\/install\.ps1 \| iex&quot;/,
   );
   assert.match(html, /npx --yes --ignore-scripts relmio@latest/);
   assert.match(html, /role="tablist"[^>]*aria-label="Local terminal"/);


### PR DESCRIPTION
## Summary

- launch the private Windows wizard through the default URL handler and keep Enter-to-retry
- make the CMD installer invoke the system Windows PowerShell executable explicitly
- parse the supported OpenAI OAuth login line safely across Windows terminal chunks and process close
- synchronize GitHub/npm documentation and the Vercel install selector
- release as `0.2.11` and pin audited `brace-expansion@5.0.9`

## Verification

- root `npm run check`: 96/96
- web lint, typecheck, tests: 14/14
- Vercel production build passed
- root and web npm audits: 0 vulnerabilities
- `npm pack --dry-run` and reviewed release tarball passed
- Opera GX keyboard/copy/200% zoom QA passed
- fresh Astral Sol review: ship

## Safety

- no n8n/VPS deployment files or containers changed
- npm publication uses the existing trusted-publisher OIDC workflow only; no npm token
