### PR TITLE
fix: restore Windows ChatGPT sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+## [0.2.12] - 2026-08-04
+
+### Fixed
+
+- Install the pinned `openai-oauth@2.0.0` helper with its exact compatible
+  `zod@4.1.8` peer even when inherited npm settings omit peer dependencies,
+  preventing the Windows sign-in helper from exiting before it prints a URL.
+- Accept the same strictly validated authorization line from either helper
+  output stream, including Windows terminal framing and final drained output.
+- Run npm package builds through the current Node.js runtime on Windows instead
+  of executing `npm.cmd` directly with `shell: false`.
+
 ## [0.2.11] - 2026-08-04
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relmio",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relmio",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "license": "Apache-2.0",
       "dependencies": {
         "ssh2": "1.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relmio",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Turn a supported ChatGPT/Codex OAuth sign-in into a private OpenAI-compatible endpoint, starting with self-hosted n8n.",
   "keywords": [
     "relmio",

--- a/scripts/build-npm-package.js
+++ b/scripts/build-npm-package.js
@@ -10,14 +10,47 @@ import {
   rm,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const sourceRoot = fileURLToPath(new URL("..", import.meta.url));
 const defaultOutputDirectory = join(sourceRoot, "dist", "npm");
+
+export function resolveNpmInvocation({
+  env = process.env,
+  execPath = process.execPath,
+  platform = process.platform,
+} = {}) {
+  if (platform !== "win32") {
+    return { command: "npm", prefixArgs: [] };
+  }
+
+  const npmExecPathKey = Object.keys(env ?? {}).find(
+    (key) => key.toLowerCase() === "npm_execpath",
+  );
+  const npmExecPath =
+    npmExecPathKey === undefined ? undefined : env[npmExecPathKey];
+  let npmCliPath;
+
+  if (typeof npmExecPath === "string") {
+    if (/(?:^|[\\/])npm-cli\.js$/iu.test(npmExecPath)) {
+      npmCliPath = resolve(npmExecPath);
+    } else if (/(?:^|[\\/])npx-cli\.js$/iu.test(npmExecPath)) {
+      npmCliPath = resolve(dirname(npmExecPath), "npm-cli.js");
+    }
+  }
+
+  return {
+    command: execPath,
+    // Windows cannot execute npm.cmd directly with shell:false.
+    prefixArgs: [
+      npmCliPath ??
+        resolve(dirname(execPath), "node_modules", "npm", "bin", "npm-cli.js"),
+    ],
+  };
+}
 
 async function copyPublishEntry({ entry, stagingDirectory }) {
   const source = join(sourceRoot, entry);
@@ -61,9 +94,11 @@ export async function buildNpmPackage({
     const expectedPath = join(outputDirectory, expectedFilename);
     await rm(expectedPath, { force: true });
 
+    const npmInvocation = resolveNpmInvocation();
     const { stdout } = await execFileAsync(
-      npmCommand,
+      npmInvocation.command,
       [
+        ...npmInvocation.prefixArgs,
         "pack",
         stagingDirectory,
         "--json",

--- a/src/services/oauth.js
+++ b/src/services/oauth.js
@@ -214,7 +214,12 @@ export async function startOAuthLogin({
   const args = [
     "--yes",
     "--ignore-scripts",
-    "openai-oauth@2.0.0",
+    "--legacy-peer-deps=false",
+    "--include=peer",
+    "--package=openai-oauth@2.0.0",
+    "--package=zod@4.1.8",
+    "--",
+    "openai-oauth",
     "login",
     "--no-open",
     "--login-timeout-ms",
@@ -279,11 +284,8 @@ export async function startOAuthLogin({
       return;
     }
     loginOutput[stream] += output;
-    if (stream !== "stdout") {
-      return;
-    }
     try {
-      const authorizationUrl = extractAuthorizationUrl(loginOutput.stdout);
+      const authorizationUrl = extractAuthorizationUrl(loginOutput[stream]);
       if (authorizationUrl) {
         settleAuthorizationUrl(null, authorizationUrl);
       }
@@ -325,9 +327,13 @@ export async function startOAuthLogin({
   child.once("close", (code) => {
     if (!authorizationUrlSettled) {
       try {
-        const authorizationUrl = extractAuthorizationUrl(loginOutput.stdout, {
-          includeFinalLine: true,
-        });
+        const authorizationUrl =
+          extractAuthorizationUrl(loginOutput.stdout, {
+            includeFinalLine: true,
+          }) ??
+          extractAuthorizationUrl(loginOutput.stderr, {
+            includeFinalLine: true,
+          });
         if (authorizationUrl) {
           settleAuthorizationUrl(null, authorizationUrl);
         } else {

--- a/test/documentation.test.js
+++ b/test/documentation.test.js
@@ -27,9 +27,12 @@ test("README and manual guide copy the generated sidecar files exactly", async (
   );
 
   for (const guide of guides) {
-    assert.ok(guide.includes(createDockerfile().trim()));
+    const normalizedGuide = guide.replaceAll("\r\n", "\n");
+    assert.ok(normalizedGuide.includes(createDockerfile().trim()));
     assert.ok(
-      guide.includes(createComposeFile({ networkName: "proxy" }).trim()),
+      normalizedGuide.includes(
+        createComposeFile({ networkName: "proxy" }).trim(),
+      ),
     );
     assert.match(
       guide,

--- a/test/install-powershell-script.test.js
+++ b/test/install-powershell-script.test.js
@@ -143,7 +143,7 @@ test(
 
     const { stdout } = await execFileAsync(
       powershell,
-      ["-NoLogo", "-NoProfile", "-File", wrapper],
+      ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", wrapper],
       {
         env: {
           ...process.env,

--- a/test/install-script.test.js
+++ b/test/install-script.test.js
@@ -26,6 +26,24 @@ const gitBashShell =
     ? process.env.RELMIO_TEST_POSIX_SHELL
     : "/bin/sh";
 
+function toGitBashPath(value) {
+  if (process.platform !== "win32") {
+    return value;
+  }
+
+  const normalized = value.replaceAll("\\", "/");
+  const drive = normalized.match(/^([A-Za-z]):\/?(.*)$/u);
+  return drive ? `/${drive[1].toLowerCase()}/${drive[2]}` : normalized;
+}
+
+function toGitBashPathList(value) {
+  if (process.platform !== "win32") {
+    return value;
+  }
+
+  return value.split(delimiter).map(toGitBashPath).join(":");
+}
+
 async function writeExecutable(path, contents) {
   await writeFile(path, contents, "utf8");
   await chmod(path, 0o755);
@@ -103,10 +121,18 @@ async function createGitBashBootstrapEnvironment() {
   const fakeBin = join(root, "bin");
   const bootstrapTemp = join(root, "tmp");
   const log = join(root, "invocation.log");
+  const bashEnvironment = join(root, "bash-environment");
   const fixture = await createWindowsNodeFixture(root);
 
   await mkdir(fakeBin);
   await mkdir(bootstrapTemp);
+  if (process.platform === "win32") {
+    await writeFile(
+      bashEnvironment,
+      `PATH="${toGitBashPath(fakeBin)}:$PATH"\nexport PATH\n`,
+      "utf8",
+    );
+  }
   await writeExecutable(join(fakeBin, "node"), '#!/bin/sh\nprintf "18\\n"\n');
   await writeExecutable(
     join(fakeBin, "uname"),
@@ -180,8 +206,11 @@ cp -R "$RELMIO_TEST_WINDOWS_ROOT" "$destination/"
     root,
     env: {
       ...process.env,
-      PATH: `${fakeBin}${delimiter}${process.env.PATH}`,
-      TMPDIR: bootstrapTemp,
+      PATH: `${toGitBashPath(fakeBin)}:${toGitBashPathList(process.env.PATH)}`,
+      TMPDIR: toGitBashPath(bootstrapTemp),
+      ...(process.platform === "win32"
+        ? { BASH_ENV: toGitBashPath(bashEnvironment) }
+        : {}),
       RELMIO_TEST_ARCHIVE: fixture.archive,
       RELMIO_TEST_LOG: log,
       RELMIO_TEST_MANIFEST: fixture.manifest,

--- a/test/install-script.test.js
+++ b/test/install-script.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+  access,
   chmod,
   copyFile,
   mkdir,
@@ -12,7 +13,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { delimiter, join } from "node:path";
+import { delimiter, isAbsolute, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import test from "node:test";
 
@@ -25,6 +26,22 @@ const gitBashShell =
   process.platform === "win32"
     ? process.env.RELMIO_TEST_POSIX_SHELL
     : "/bin/sh";
+
+async function resolveGitBashShell() {
+  if (
+    process.platform !== "win32" ||
+    !gitBashShell ||
+    isAbsolute(gitBashShell)
+  ) {
+    return gitBashShell;
+  }
+
+  const { stdout } = await execFileAsync("git", ["--exec-path"]);
+  const gitRoot = resolve(stdout.trim(), "..", "..", "..");
+  const shellPath = join(gitRoot, "bin", `${gitBashShell}.exe`);
+  await access(shellPath);
+  return shellPath;
+}
 
 function toGitBashPath(value) {
   if (process.platform !== "win32") {
@@ -355,9 +372,10 @@ test(
   { skip: !gitBashShell },
   async (t) => {
     const setup = await createGitBashBootstrapEnvironment();
+    const shell = await resolveGitBashShell();
     t.after(() => rm(setup.root, { recursive: true, force: true }));
 
-    const { stdout } = await execFileAsync(gitBashShell, [installScript], {
+    const { stdout } = await execFileAsync(shell, [installScript], {
       env: setup.env,
     });
     const invocation = (await readFile(setup.log, "utf8")).trim().split("\n");

--- a/test/oauth.test.js
+++ b/test/oauth.test.js
@@ -65,36 +65,40 @@ function createAuthorizationUrl({
 }
 
 test("resolveAuthPath uses wizard-only storage without exposing file contents", () => {
+  const configuredHomeDirectory = resolve("oauth-configured-home");
+  const defaultHomeDirectory = resolve("oauth-default-home");
   assert.equal(
     resolveAuthPath({
-      env: { N8N_OPENAI_OAUTH_HOME: "/safe/wizard" },
-      homeDirectory: "/home/user",
+      env: { N8N_OPENAI_OAUTH_HOME: configuredHomeDirectory },
+      homeDirectory: defaultHomeDirectory,
     }),
-    "/safe/wizard/auth.json",
+    resolve(configuredHomeDirectory, "auth.json"),
   );
   assert.equal(
     resolveAuthPath({
       env: { CODEX_HOME: "/must/not/be/reused" },
-      homeDirectory: "/home/user",
+      homeDirectory: defaultHomeDirectory,
     }),
-    "/home/user/.n8n-openai-oauth/auth.json",
+    resolve(defaultHomeDirectory, ".n8n-openai-oauth", "auth.json"),
   );
 });
 
 test("getAuthStatus reports the credential update time without its contents", async () => {
+  const homeDirectory = resolve("oauth-status-home");
+  const authPath = resolve(homeDirectory, ".n8n-openai-oauth", "auth.json");
   const fileSystem = createMemoryFileSystem({
-    "/home/user/.n8n-openai-oauth/auth.json": '{"fixture":true}',
+    [authPath]: '{"fixture":true}',
   });
 
   const status = await getAuthStatus({
     fileSystem,
     env: {},
-    homeDirectory: "/home/user",
+    homeDirectory,
   });
 
   assert.deepEqual(status, {
     exists: true,
-    path: "/home/user/.n8n-openai-oauth/auth.json",
+    path: authPath,
     updatedAt: "2026-07-28T01:11:01.000Z",
   });
   assert.equal(JSON.stringify(status).includes("fixture"), false);
@@ -118,6 +122,8 @@ test("readAuthContents rejects invalid or oversized credential files", async () 
 test("startOAuthLogin returns one validated link and stores the credential after completion", async () => {
   const calls = [];
   const files = {};
+  const homeDirectory = resolve("oauth-login-home");
+  const authPath = resolve(homeDirectory, ".n8n-openai-oauth", "auth.json");
   const fileSystem = createMemoryFileSystem(files);
   const spawnProcess = (command, args, options) => {
     const call = { command, args, options };
@@ -151,7 +157,7 @@ test("startOAuthLogin returns one validated link and stores the credential after
   const login = await startOAuthLogin({
     fileSystem,
     env: {},
-    homeDirectory: "/home/user",
+    homeDirectory,
     platform: "darwin",
     spawnProcess,
     createPendingId: () => "fixture",
@@ -166,22 +172,27 @@ test("startOAuthLogin returns one validated link and stores the credential after
   assert.deepEqual(calls[0].args, [
     "--yes",
     "--ignore-scripts",
-    "openai-oauth@2.0.0",
+    "--legacy-peer-deps=false",
+    "--include=peer",
+    "--package=openai-oauth@2.0.0",
+    "--package=zod@4.1.8",
+    "--",
+    "openai-oauth",
     "login",
     "--no-open",
     "--login-timeout-ms",
     "300000",
     "--oauth-file",
-    "/home/user/.n8n-openai-oauth/auth.json.pending-fixture",
+    `${authPath}.pending-fixture`,
   ]);
   assert.equal(calls[0].options.shell, false);
   assert.deepEqual(calls[0].options.stdio, ["ignore", "pipe", "pipe"]);
   assert.equal(
-    files["/home/user/.n8n-openai-oauth/auth.json"],
+    files[authPath],
     '{"fixture":true}',
   );
   assert.equal(
-    "/home/user/.n8n-openai-oauth/auth.json.pending-fixture" in files,
+    `${authPath}.pending-fixture` in files,
     false,
   );
 });
@@ -234,6 +245,43 @@ test("startOAuthLogin reads the supported CLI login line across ANSI, CRLF, and 
     login.authorizationUrl,
     /^https:\/\/auth\.openai\.com\/oauth\/authorize\?/u,
   );
+  assert.deepEqual(await login.completion, { success: true });
+});
+
+test("startOAuthLogin reads the supported Windows login line from stderr", async () => {
+  const files = {};
+  const fileSystem = createMemoryFileSystem(files);
+  const authorizationUrl = createAuthorizationUrl();
+  const spawnProcess = (_command, args) => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {};
+    queueMicrotask(() => {
+      child.stderr.emit("data", Buffer.from("\u001B[2"));
+      child.stderr.emit(
+        "data",
+        Buffer.from(`KOpenAI OAuth login URL: ${authorizationUrl}\r`),
+      );
+      child.stderr.emit("data", Buffer.from("\n"));
+      const oauthFileIndex = args.indexOf("--oauth-file");
+      files[args[oauthFileIndex + 1]] = '{"stderr":true}';
+      finishChild(child, 0);
+    });
+    return child;
+  };
+
+  const login = await startOAuthLogin({
+    fileSystem,
+    env: {},
+    homeDirectory: "/home/user",
+    platform: "win32",
+    execPath: "C:\\portable\\node.exe",
+    spawnProcess,
+    createPendingId: () => "windows-stderr",
+  });
+
+  assert.equal(login.authorizationUrl, authorizationUrl.toString());
   assert.deepEqual(await login.completion, { success: true });
 });
 
@@ -483,7 +531,11 @@ test("startOAuthLogin uses the current Node runtime for Windows npm launchers", 
 
   const login = await startOAuthLogin({
     fileSystem,
-    env: { npm_execpath: npmExecPath },
+    env: {
+      npm_execpath: npmExecPath,
+      NPM_CONFIG_LEGACY_PEER_DEPS: "true",
+      NPM_CONFIG_OMIT: "peer",
+    },
     homeDirectory,
     platform: "win32",
     execPath,
@@ -496,7 +548,12 @@ test("startOAuthLogin uses the current Node runtime for Windows npm launchers", 
   assert.deepEqual(calls[0].args.slice(1), [
     "--yes",
     "--ignore-scripts",
-    "openai-oauth@2.0.0",
+    "--legacy-peer-deps=false",
+    "--include=peer",
+    "--package=openai-oauth@2.0.0",
+    "--package=zod@4.1.8",
+    "--",
+    "openai-oauth",
     "login",
     "--no-open",
     "--login-timeout-ms",
@@ -505,6 +562,8 @@ test("startOAuthLogin uses the current Node runtime for Windows npm launchers", 
     `${authPath}.pending-windows-fixture`,
   ]);
   assert.equal(calls[0].options.shell, false);
+  assert.equal(calls[0].options.env.NPM_CONFIG_LEGACY_PEER_DEPS, "true");
+  assert.equal(calls[0].options.env.NPM_CONFIG_OMIT, "peer");
   assert.deepEqual(await login.completion, { success: true });
   assert.equal(
     files[authPath],
@@ -559,6 +618,8 @@ test("startOAuthLogin saves a valid pending credential before the helper exits",
   let child;
   let pendingAuthPath;
   let pollCount = 0;
+  const homeDirectory = resolve("oauth-fresh-home");
+  const authPath = resolve(homeDirectory, ".n8n-openai-oauth", "auth.json");
   const spawnProcess = (_command, args) => {
     child = new EventEmitter();
     child.stdout = new EventEmitter();
@@ -587,7 +648,7 @@ test("startOAuthLogin saves a valid pending credential before the helper exits",
   const login = await startOAuthLogin({
     fileSystem: createMemoryFileSystem(files),
     env: {},
-    homeDirectory: "/home/user",
+    homeDirectory,
     platform: "darwin",
     spawnProcess,
     createPendingId: () => "fresh",
@@ -611,7 +672,7 @@ test("startOAuthLogin saves a valid pending credential before the helper exits",
     assert.deepEqual(result, { success: true });
     assert.equal(pollCount, 2);
     assert.equal(
-      files["/home/user/.n8n-openai-oauth/auth.json"],
+      files[authPath],
       '{"fresh":true}',
     );
   } finally {

--- a/test/package-contents.test.js
+++ b/test/package-contents.test.js
@@ -2,18 +2,18 @@ import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, extname, join } from "node:path";
+import { basename, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import test from "node:test";
 
 import {
   buildNpmPackage,
+  resolveNpmInvocation,
   stageNpmPackage,
 } from "../scripts/build-npm-package.js";
 
 const execFileAsync = promisify(execFile);
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const projectRoot = fileURLToPath(new URL("..", import.meta.url));
 const expectedPackedFiles = new Set([
   "CHANGELOG.md",
@@ -113,6 +113,55 @@ const forbiddenContent = [
   },
 ];
 
+test("resolveNpmInvocation uses Node with npm-cli.js on Windows", () => {
+  assert.deepEqual(
+    resolveNpmInvocation({
+      env: {},
+      execPath: "/portable/node.exe",
+      platform: "darwin",
+    }),
+    { command: "npm", prefixArgs: [] },
+  );
+
+  assert.deepEqual(
+    resolveNpmInvocation({
+      env: { NPM_EXECPATH: "/custom/npm-cli.js" },
+      execPath: "/portable/node.exe",
+      platform: "win32",
+    }),
+    {
+      command: "/portable/node.exe",
+      prefixArgs: [resolve("/custom/npm-cli.js")],
+    },
+  );
+
+  assert.deepEqual(
+    resolveNpmInvocation({
+      env: { npm_execpath: "/custom/npx-cli.js" },
+      execPath: "/portable/node.exe",
+      platform: "win32",
+    }),
+    {
+      command: "/portable/node.exe",
+      prefixArgs: [resolve("/custom/npm-cli.js")],
+    },
+  );
+
+  assert.deepEqual(
+    resolveNpmInvocation({
+      env: {},
+      execPath: "/portable/node.exe",
+      platform: "win32",
+    }),
+    {
+      command: "/portable/node.exe",
+      prefixArgs: [
+        resolve("/portable", "node_modules", "npm", "bin", "npm-cli.js"),
+      ],
+    },
+  );
+});
+
 test("npm package contains only allowed files and every advertised local script", async (t) => {
   const workspaceDirectory = await mkdtemp(join(tmpdir(), "npm-pack-test-"));
   const cacheDirectory = join(workspaceDirectory, "cache");
@@ -121,9 +170,16 @@ test("npm package contains only allowed files and every advertised local script"
 
   await stageNpmPackage(stagingDirectory);
 
+  const npmInvocation = resolveNpmInvocation();
   const { stdout } = await execFileAsync(
-    npmCommand,
-    ["pack", "--dry-run", "--json", "--ignore-scripts"],
+    npmInvocation.command,
+    [
+      ...npmInvocation.prefixArgs,
+      "pack",
+      "--dry-run",
+      "--json",
+      "--ignore-scripts",
+    ],
     {
       cwd: stagingDirectory,
       env: { ...process.env, npm_config_cache: cacheDirectory },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6192,9 +6192,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -9972,9 +9972,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,10 +6,10 @@
     "node": "22.x"
   },
   "scripts": {
-    "dev": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext dev",
-    "build": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext build",
+    "dev": "vinext dev",
+    "build": "vinext build",
     "build:vercel": "next build",
-    "start": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext start",
+    "start": "vinext start",
     "test": "npm run build && node --test tests/*.test.mjs",
     "lint": "eslint . --ignore-pattern dist --ignore-pattern .next",
     "typecheck": "tsc --noEmit"
@@ -46,9 +46,11 @@
   },
   "overrides": {
     "brace-expansion": "5.0.9",
+    "fast-uri": "3.1.5",
     "minimatch": "10.2.6",
     "postcss": "8.5.25",
-    "sharp": "0.35.0"
+    "sharp": "0.35.0",
+    "undici": "7.29.0"
   },
   "astryx": {
     "theme": "./app/relmio.js"


### PR DESCRIPTION
## Summary

Windows users can complete the local ChatGPT sign-in again instead of seeing the wizard fail before returning an authorization URL. The OAuth helper now receives its pinned peer dependency even when inherited npm settings omit peers, and the wizard accepts the same strictly validated OpenAI authorization line from either process output stream.

The Windows package builder also invokes npm through the active Node.js runtime, avoiding the `npm.cmd` process-launch failure while preserving the existing POSIX path. Release metadata is synchronized for `relmio@0.2.12`.

## Safety

Authorization URLs still require the exact OpenAI origin and loopback callback shape. The helper remains a non-shell argument-array launch, no credentials are logged, and no VPS or existing n8n deployment was contacted or changed.

## Validation

- `npm run check`: 98 tests, 94 passed, 0 failed, 4 expected platform skips; lint and release metadata checks passed.
- Explicit Git Bash/curl-style installer harness passed on Windows.
- CMD-launched PowerShell installer tests passed 3/3.
- Direct npx and CMD npx tarball wizard smokes returned HTTP 200 for the page, API, and sign-in endpoint; each produced a strictly validated authorization URL without the missing-peer crash.
- `npm audit --audit-level=high`: 0 vulnerabilities.
- `npm pack --dry-run` and the `relmio-0.2.12.tgz` package build passed.
- Fresh Sol/high review ran in an observed read-only sandbox and returned `ship` with no findings.

## Follow-up

Live VPS validation remains intentionally deferred until the maintainer supplies a test target and confirms the final remote-write step.
