### PR TITLE
release: v0.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+## [0.2.13] - 2026-08-04
+
+### Changed
+
+- Compact the local setup wizard so its active step stays near the top, move
+  safety and status notices into dismissible toasts, and collapse the optional
+  AI Agent and HTTP Request recipes until users choose to open them.
+- Complete the HTTP Request recipe with authorization, content type, and a
+  copyable sample Responses API JSON payload.
+
+### Fixed
+
+- Copy credential values reliably in Opera GX on Windows by preserving the
+  synchronous user gesture for the selection-based clipboard path before
+  falling back to the modern Clipboard API.
+
 ## [0.2.12] - 2026-08-04
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relmio",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relmio",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "Apache-2.0",
       "dependencies": {
         "ssh2": "1.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relmio",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Turn a supported ChatGPT/Codex OAuth sign-in into a private OpenAI-compatible endpoint, starting with self-hosted n8n.",
   "keywords": [
     "relmio",

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -13,8 +13,16 @@ const state = {
 };
 
 const element = (id) => document.getElementById(id);
-const message = element("global-message");
+const messageToast = element("global-message");
+const message = element("global-message-text");
 const errorBox = element("global-error");
+const errorMessage = element("global-error-text");
+const toastTimers = new WeakMap();
+
+function dismissToast(toast) {
+  window.clearTimeout(toastTimers.get(toast));
+  toast.hidden = true;
+}
 
 function resetFingerprint() {
   state.fingerprint = null;
@@ -26,18 +34,24 @@ function resetFingerprint() {
 }
 
 function setMessage(text) {
+  messageToast.hidden = false;
   message.textContent = text;
+  window.clearTimeout(toastTimers.get(messageToast));
+  toastTimers.set(
+    messageToast,
+    window.setTimeout(() => dismissToast(messageToast), 6_000),
+  );
 }
 
 function showError(error) {
-  errorBox.textContent = error.message ?? "Something went wrong.";
+  errorMessage.textContent = error.message ?? "Something went wrong.";
   errorBox.hidden = false;
   errorBox.focus();
 }
 
 function clearError() {
   errorBox.hidden = true;
-  errorBox.textContent = "";
+  errorMessage.textContent = "";
 }
 
 function setBusy(button, busy, busyText) {
@@ -68,31 +82,123 @@ function flashCopied(button) {
 }
 
 async function copyText(value) {
+  const previouslyFocused = document.activeElement;
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  textarea.readOnly = true;
+  textarea.setAttribute("aria-hidden", "true");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+
+  let copied = false;
   try {
-    await navigator.clipboard.writeText(value);
-    return;
-  } catch {
-    const previouslyFocused = document.activeElement;
-    const textarea = document.createElement("textarea");
-    textarea.value = value;
-    textarea.readOnly = true;
-    textarea.setAttribute("aria-hidden", "true");
-    textarea.style.position = "fixed";
-    textarea.style.opacity = "0";
     document.body.append(textarea);
+    textarea.focus();
     textarea.select();
-    let copied = false;
+    textarea.setSelectionRange?.(0, textarea.value.length);
+    copied = document.execCommand("copy");
+  } catch {
+    copied = false;
+  } finally {
+    textarea.remove();
+    previouslyFocused?.focus?.();
+  }
+
+  if (copied) {
+    return;
+  }
+
+  if (navigator.clipboard?.writeText) {
     try {
-      copied = document.execCommand("copy");
-    } finally {
-      textarea.remove();
-      previouslyFocused?.focus?.();
-    }
-    if (!copied) {
-      throw new Error("The browser refused clipboard access.");
+      await navigator.clipboard.writeText(value);
+      return;
+    } catch {
+      // The generic error below avoids exposing copied configuration values.
     }
   }
+
+  throw new Error("The browser refused clipboard access.");
 }
+
+function renderHttpRequestBody(model) {
+  element("result-http-body").textContent = JSON.stringify(
+    {
+      model,
+      input: "Reply with exactly: bridge works",
+    },
+    null,
+    2,
+  );
+}
+
+function copyCredentialSettings() {
+  return [
+    `Base URL: ${element("result-url").textContent}`,
+    `API Key: ${element("result-key").textContent}`,
+    "Organization ID: leave empty",
+    "Add Custom Header: off",
+  ].join("\n");
+}
+
+function copyHttpRecipe() {
+  return [
+    "Method: POST",
+    `URL: ${element("result-http-url").textContent}`,
+    "Authorization: Bearer local-only",
+    "Content-Type: application/json",
+    "Authentication: None",
+    "JSON body:",
+    element("result-http-body").textContent,
+  ].join("\n");
+}
+
+function copyValueFor(button) {
+  if (button.dataset.copyTarget) {
+    return element(button.dataset.copyTarget).textContent;
+  }
+  if (button.dataset.copyGroup === "credential") {
+    return copyCredentialSettings();
+  }
+  if (button.dataset.copyGroup === "http") {
+    return copyHttpRecipe();
+  }
+  return "";
+}
+
+function createCopyClickHandler({
+  copyValueFor,
+  clearError,
+  copyText,
+  flashCopied,
+  setMessage,
+  showError,
+}) {
+  return async function handleCopyClick(event) {
+    const button = event.currentTarget;
+    const label = button.dataset.copyLabel;
+    const value = copyValueFor(button);
+    clearError();
+    try {
+      if (!value) {
+        throw new Error("No displayed value is available to copy.");
+      }
+      await copyText(value);
+      flashCopied(button);
+      setMessage(`${label} copied.`);
+    } catch {
+      showError(new Error(`Copy failed. Select the ${label} manually.`));
+    }
+  };
+}
+
+const handleCopyClick = createCopyClickHandler({
+  copyValueFor,
+  clearError,
+  copyText,
+  flashCopied,
+  setMessage,
+  showError,
+});
 
 const delay = (milliseconds) =>
   new Promise((resolve) => window.setTimeout(resolve, milliseconds));
@@ -126,6 +232,11 @@ async function waitForOAuthCompletion() {
 
 function showStep(step) {
   state.step = step;
+  document.body.dataset.currentStep = String(step);
+  if (step === 5) {
+    dismissToast(element("global-safety"));
+    dismissToast(element("global-backup"));
+  }
   for (const panel of document.querySelectorAll("[data-step]")) {
     const active = Number(panel.dataset.step) === step;
     panel.hidden = !active;
@@ -483,10 +594,12 @@ element("install-button").addEventListener("click", async (event) => {
     });
     element("result-url").textContent = result.baseUrl;
     element("result-key").textContent = result.apiKeyPlaceholder;
-    element("result-model").textContent = result.models[0] ?? "";
+    const firstModel = result.models[0] ?? "Not detected";
+    element("result-model").textContent = firstModel;
     element("result-models").textContent = result.models.join(", ");
     element("result-http-url").textContent =
       `${result.baseUrl.replace(/\/$/u, "")}/responses`;
+    renderHttpRequestBody(firstModel);
     showStep(5);
     setMessage(
       result.deploymentMode === "updated"
@@ -500,36 +613,15 @@ element("install-button").addEventListener("click", async (event) => {
   }
 });
 
-element("copy-settings").addEventListener("click", async (event) => {
-  const settings = [
-    `Base URL: ${element("result-url").textContent}`,
-    `API Key: ${element("result-key").textContent}`,
-    "Organization ID: leave empty",
-    "Add Custom Header: off",
-  ].join("\n");
-  clearError();
-  try {
-    await copyText(settings);
-    flashCopied(event.currentTarget);
-    setMessage("OpenAI credential settings copied.");
-  } catch {
-    showError(new Error("Copy failed. Select the values manually."));
-  }
-});
+for (const button of document.querySelectorAll(
+  "[data-copy-target], [data-copy-group]",
+)) {
+  button.addEventListener("click", handleCopyClick);
+}
 
-for (const button of document.querySelectorAll("[data-copy-target]")) {
-  button.addEventListener("click", async (event) => {
-    const target = element(event.currentTarget.dataset.copyTarget);
-    const label = event.currentTarget.dataset.copyLabel;
-    const value = target.textContent;
-    clearError();
-    try {
-      await copyText(value);
-      flashCopied(event.currentTarget);
-      setMessage(`${label} copied.`);
-    } catch {
-      showError(new Error(`Copy failed. Select the ${label} manually.`));
-    }
+for (const button of document.querySelectorAll("[data-dismiss-toast]")) {
+  button.addEventListener("click", (event) => {
+    dismissToast(element(event.currentTarget.dataset.dismissToast));
   });
 }
 
@@ -545,4 +637,5 @@ for (const button of document.querySelectorAll(".back-button")) {
   });
 }
 
+renderHttpRequestBody(element("result-model").textContent);
 refreshAuthStatus().catch(showError);

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -16,7 +16,7 @@
     <script src="/theme.js" type="module"></script>
     <script src="/app.js" type="module"></script>
   </head>
-  <body>
+  <body data-current-step="1">
     <a class="skip-link" href="#main-content">Skip to setup</a>
 
     <header class="site-header">
@@ -55,6 +55,83 @@
       </div>
     </header>
 
+    <div class="toast-stack" aria-label="Wizard notifications">
+      <aside
+        id="global-safety"
+        class="toast safety-note"
+        aria-label="Safety guarantee"
+      >
+        <strong>Sidecar-only guarantee</strong>
+        <span>
+          No n8n restart. No n8n rebuild. No public port. You approve the exact
+          plan before anything is written.
+        </span>
+        <button
+          class="toast-close"
+          type="button"
+          data-dismiss-toast="global-safety"
+          aria-label="Dismiss safety guarantee"
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      </aside>
+
+      <aside
+        id="global-backup"
+        class="toast safety-note backup-note"
+        aria-label="Backup reminder"
+      >
+        <strong>Back up first</strong>
+        <span>
+          Export your n8n workflows before connecting. This wizard uses
+          sidecar-only commands, but it still writes to your VPS.
+        </span>
+        <button
+          class="toast-close"
+          type="button"
+          data-dismiss-toast="global-backup"
+          aria-label="Dismiss backup reminder"
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      </aside>
+
+      <div
+        id="global-message"
+        class="toast message"
+        role="status"
+        aria-live="polite"
+      >
+        <span id="global-message-text">Checking your local sign-in…</span>
+        <button
+          class="toast-close"
+          type="button"
+          data-dismiss-toast="global-message"
+          aria-label="Dismiss status message"
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      </div>
+
+      <div
+        id="global-error"
+        class="toast error"
+        role="alert"
+        tabindex="-1"
+        hidden
+      >
+        <span id="global-error-text"></span>
+        <button
+          class="toast-close"
+          type="button"
+          data-dismiss-toast="global-error"
+          aria-label="Dismiss error"
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      </div>
+    </div>
+
     <main id="main-content" class="shell">
       <section class="intro" aria-labelledby="page-title">
         <p class="eyebrow">Guided VPS setup</p>
@@ -64,22 +141,6 @@
           image, Compose file, container, and workflows stay untouched.
         </p>
       </section>
-
-      <aside class="safety-note" aria-label="Safety guarantee">
-        <strong>Sidecar-only guarantee</strong>
-        <span>
-          No n8n restart. No n8n rebuild. No public port. You approve the exact
-          plan before anything is written.
-        </span>
-      </aside>
-
-      <aside class="safety-note backup-note" aria-label="Backup reminder">
-        <strong>Back up first</strong>
-        <span>
-          Export your n8n workflows before connecting. This wizard uses
-          sidecar-only commands, but it still writes to your VPS.
-        </span>
-      </aside>
 
       <nav class="steps" aria-label="Setup progress">
         <ol>
@@ -92,11 +153,6 @@
           <li data-step-marker="5"><span>5</span><em>Done</em></li>
         </ol>
       </nav>
-
-      <div id="global-message" class="message" role="status" aria-live="polite">
-        Checking your local sign-in…
-      </div>
-      <div id="global-error" class="error" role="alert" tabindex="-1" hidden></div>
 
       <section class="panel" data-step="1" aria-labelledby="signin-title">
         <div class="panel-heading">
@@ -377,70 +433,112 @@
           </div>
         </dl>
 
-        <button id="copy-settings" class="button secondary" type="button">
+        <button
+          id="copy-settings"
+          class="button secondary"
+          type="button"
+          data-copy-group="credential"
+          data-copy-label="OpenAI credential settings"
+        >
           Copy credential settings
         </button>
 
-        <div class="model-box">
-          <h3>2. OpenAI Chat Model for AI Agent or Basic LLM Chain</h3>
-          <dl class="result-list">
-            <div>
-              <dt>Model ID</dt>
-              <dd class="result-value">
-                <code id="result-model">Not detected</code>
-                <button
-                  class="button secondary copy-value"
-                  type="button"
-                  data-copy-target="result-model"
-                  data-copy-label="model ID"
-                  aria-label="Copy model ID"
-                >
-                  Copy
-                </button>
-              </dd>
-            </div>
-            <div>
-              <dt>Responses API</dt>
-              <dd><strong>On</strong> for Chat Model node version 1.3</dd>
-            </div>
-          </dl>
-          <p>All models detected: <span id="result-models">Not detected</span></p>
-          <p>
-            If the Responses API switch is absent, keep the node's default
-            Chat Completions behavior; the bridge supports that route too.
-          </p>
-        </div>
+        <details class="recipe-disclosure">
+          <summary>
+            <span>2. OpenAI Chat Model for AI Agent or Basic LLM Chain</span>
+          </summary>
+          <div class="model-box recipe-content">
+            <dl class="result-list">
+              <div>
+                <dt>Model ID</dt>
+                <dd class="result-value">
+                  <code id="result-model">Not detected</code>
+                  <button
+                    class="button secondary copy-value"
+                    type="button"
+                    data-copy-target="result-model"
+                    data-copy-label="model ID"
+                    aria-label="Copy model ID"
+                  >
+                    Copy
+                  </button>
+                </dd>
+              </div>
+              <div>
+                <dt>Responses API</dt>
+                <dd><strong>On</strong> for Chat Model node version 1.3</dd>
+              </div>
+            </dl>
+            <p>All models detected: <span id="result-models">Not detected</span></p>
+            <p>
+              If the Responses API switch is absent, keep the node's default
+              Chat Completions behavior; the bridge supports that route too.
+            </p>
+          </div>
+        </details>
 
-        <div class="model-box">
-          <h3>3. HTTP Request node</h3>
-          <dl class="result-list">
-            <div>
-              <dt>Method</dt>
-              <dd><code>POST</code></dd>
-            </div>
-            <div>
-              <dt>URL</dt>
-              <dd class="result-value">
-                <code id="result-http-url">
-                  http://n8n-openai-oauth:10531/v1/responses
-                </code>
-                <button
-                  class="button secondary copy-value"
-                  type="button"
-                  data-copy-target="result-http-url"
-                  data-copy-label="HTTP endpoint"
-                  aria-label="Copy HTTP endpoint"
-                >
-                  Copy
-                </button>
-              </dd>
-            </div>
-            <div>
-              <dt>Authentication</dt>
-              <dd>None</dd>
-            </div>
-          </dl>
-        </div>
+        <details class="recipe-disclosure">
+          <summary><span>3. HTTP Request node</span></summary>
+          <div class="model-box recipe-content">
+            <dl class="result-list">
+              <div>
+                <dt>Method</dt>
+                <dd><code>POST</code></dd>
+              </div>
+              <div>
+                <dt>URL</dt>
+                <dd class="result-value">
+                  <code id="result-http-url">http://n8n-openai-oauth:10531/v1/responses</code>
+                  <button
+                    class="button secondary copy-value"
+                    type="button"
+                    data-copy-target="result-http-url"
+                    data-copy-label="HTTP endpoint"
+                    aria-label="Copy HTTP endpoint"
+                  >
+                    Copy
+                  </button>
+                </dd>
+              </div>
+              <div>
+                <dt>Authorization</dt>
+                <dd><code>Bearer local-only</code></dd>
+              </div>
+              <div>
+                <dt>Content-Type</dt>
+                <dd><code>application/json</code></dd>
+              </div>
+              <div>
+                <dt>Authentication</dt>
+                <dd>None</dd>
+              </div>
+              <div class="sample-body-row">
+                <dt>JSON body</dt>
+                <dd class="result-value">
+                  <pre class="sample-json"><code id="result-http-body"></code></pre>
+                  <button
+                    class="button secondary copy-value"
+                    type="button"
+                    data-copy-target="result-http-body"
+                    data-copy-label="HTTP JSON body"
+                    aria-label="Copy HTTP JSON body"
+                  >
+                    Copy
+                  </button>
+                </dd>
+              </div>
+            </dl>
+            <button
+              id="copy-http-recipe"
+              class="button secondary"
+              type="button"
+              data-copy-group="http"
+              data-copy-label="HTTP request recipe"
+            >
+              Copy HTTP request recipe
+            </button>
+          </div>
+        </details>
 
         <p class="final-note">
           The README includes complete AI Agent, Basic LLM Chain, JSON, and

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -29,6 +29,7 @@
   --radius-sm: 0.5rem;
   --radius: 0.875rem;
   --radius-lg: 1.25rem;
+  --header-height: 3.75rem;
 }
 
 :root[data-theme="dark"] {
@@ -160,8 +161,8 @@ a:focus-visible {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: 4.25rem;
-  padding: 0.75rem clamp(1rem, 4vw, 3rem);
+  min-height: var(--header-height);
+  padding: 0.5rem clamp(1rem, 4vw, 3rem);
   border-bottom: 1px solid rgb(221 227 223 / 75%);
   background: color-mix(in srgb, var(--background) 82%, transparent);
   backdrop-filter: blur(14px) saturate(1.4);
@@ -179,8 +180,8 @@ a:focus-visible {
 
 .brand-mark {
   display: block;
-  width: 2rem;
-  height: 2rem;
+  width: 1.75rem;
+  height: 1.75rem;
   flex: none;
   border-radius: 0.4375rem;
   transition:
@@ -302,13 +303,21 @@ a:focus-visible {
 /* ---------- Shell & intro ---------- */
 
 .shell {
-  width: min(100% - 2rem, 54rem);
+  width: min(100% - 2rem, 62rem);
   margin: 0 auto;
-  padding: 3.5rem 0 5rem;
+  padding: 1.75rem 0 3.5rem;
 }
 
 .intro {
   max-width: 44rem;
+}
+
+body:not([data-current-step="1"]) .intro {
+  display: none;
+}
+
+body:not([data-current-step="1"]) .shell {
+  padding-top: 1rem;
 }
 
 .eyebrow,
@@ -330,8 +339,8 @@ p {
 
 h1 {
   max-width: 42rem;
-  margin-bottom: 1rem;
-  font-size: clamp(2.1rem, 6.5vw, 3.4rem);
+  margin-bottom: 0.75rem;
+  font-size: clamp(1.9rem, 5vw, 3rem);
   line-height: 1.04;
   letter-spacing: -0.045em;
 }
@@ -355,19 +364,37 @@ h3 {
 
 .lede {
   max-width: 42rem;
-  font-size: 1.0625rem;
+  margin-bottom: 0;
+  font-size: 1rem;
 }
 
-/* ---------- Safety notes ---------- */
+/* ---------- Toasts ---------- */
+
+.toast-stack {
+  position: fixed;
+  top: calc(var(--header-height) + 0.5rem);
+  right: clamp(0.75rem, 3vw, 2rem);
+  z-index: 15;
+  display: grid;
+  gap: 0.5rem;
+  width: min(25rem, calc(100vw - 1.5rem));
+  max-height: calc(100svh - var(--header-height) - 1rem);
+  overflow-y: auto;
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+}
 
 .safety-note {
   position: relative;
   display: grid;
-  grid-template-columns: 2.25rem 1fr;
+  grid-template-columns: 2rem minmax(0, 1fr) auto;
   gap: 0.25rem 0.875rem;
   align-items: start;
-  margin: 1.25rem 0 0;
-  padding: 1rem 1.125rem;
+  margin: 0;
+  padding: 0.875rem 0.875rem 0.875rem 1rem;
   border: 1px solid var(--accent-border);
   border-radius: var(--radius);
   background: var(--accent-soft);
@@ -376,8 +403,8 @@ h3 {
 
 .safety-note::before {
   display: grid;
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 2rem;
+  height: 2rem;
   grid-row: span 2;
   place-items: center;
   border-radius: 0.625rem;
@@ -394,6 +421,7 @@ h3 {
 
 .safety-note span {
   color: var(--accent-copy);
+  font-size: 0.875rem;
 }
 
 .backup-note {
@@ -411,10 +439,41 @@ h3 {
   color: var(--warning);
 }
 
+.toast-close {
+  display: inline-grid;
+  width: 1.75rem;
+  min-height: 1.75rem;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  color: var(--text-muted);
+  background: transparent;
+  box-shadow: none;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.toast-close:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--text) 9%, transparent);
+}
+
+.toast-close:focus-visible {
+  outline: 3px solid #f2a94a;
+  outline-offset: 1px;
+}
+
+.safety-note .toast-close {
+  grid-column: 3;
+  grid-row: 1;
+}
+
 /* ---------- Stepper ---------- */
 
 .steps {
-  margin: 2.5rem 0 1.25rem;
+  margin: 1.5rem 0 0.75rem;
 }
 
 .steps ol {
@@ -509,12 +568,13 @@ h3 {
 
 .message,
 .error {
-  display: flex;
-  align-items: center;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: start;
   gap: 0.625rem;
-  min-height: 2.875rem;
-  margin: 1rem 0;
-  padding: 0.75rem 1rem;
+  min-height: 3rem;
+  margin: 0;
+  padding: 0.75rem;
   border-radius: var(--radius-sm);
   font-size: 0.9375rem;
 }
@@ -527,6 +587,7 @@ h3 {
 }
 
 .message::before {
+  align-self: center;
   flex: 0 0 auto;
   width: 0.4375rem;
   height: 0.4375rem;
@@ -536,6 +597,7 @@ h3 {
 }
 
 .error {
+  grid-template-columns: minmax(0, 1fr) auto;
   border: 1px solid var(--danger-border);
   color: var(--danger);
   background: var(--danger-soft);
@@ -546,7 +608,7 @@ h3 {
 /* ---------- Panels ---------- */
 
 .panel {
-  padding: clamp(1.5rem, 4vw, 2.25rem);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--surface);
@@ -555,7 +617,7 @@ h3 {
 }
 
 .panel-heading {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.125rem;
 }
 
 .panel-heading p {
@@ -955,7 +1017,7 @@ code {
 
 .model-box,
 .final-note {
-  margin-top: 1.5rem;
+  margin-top: 1rem;
   padding: 1.125rem;
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -969,6 +1031,71 @@ code {
 
 .model-box p {
   color: var(--text-muted);
+}
+
+.recipe-disclosure {
+  margin-top: 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-muted);
+}
+
+.recipe-disclosure summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  cursor: pointer;
+  font-weight: 750;
+  list-style: none;
+}
+
+.recipe-disclosure summary::-webkit-details-marker {
+  display: none;
+}
+
+.recipe-disclosure summary::after {
+  flex: none;
+  color: var(--accent);
+  content: "+";
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.recipe-disclosure[open] summary::after {
+  content: "−";
+}
+
+.recipe-disclosure summary:focus-visible {
+  outline: 3px solid #f2a94a;
+  outline-offset: -3px;
+}
+
+.recipe-content {
+  margin: 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+}
+
+.sample-body-row {
+  align-items: start !important;
+}
+
+.sample-json {
+  max-width: 100%;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+
+.sample-json code {
+  display: block;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  line-height: 1.45;
 }
 
 footer {
@@ -1072,8 +1199,15 @@ footer p {
   }
 
   .shell {
-    width: min(100% - 1rem, 54rem);
-    padding-top: 2rem;
+    width: min(100% - 1rem, 62rem);
+    padding: 1.25rem 0 2.5rem;
+  }
+
+  .toast-stack {
+    top: calc(var(--header-height) + 0.375rem);
+    right: 0.5rem;
+    width: calc(100vw - 1rem);
+    gap: 0.375rem;
   }
 
   .safety-note,
@@ -1084,6 +1218,19 @@ footer p {
 
   .safety-note::before {
     grid-row: auto;
+  }
+
+  .toast-stack .safety-note {
+    grid-template-columns: 2rem minmax(0, 1fr) auto;
+    align-items: center;
+  }
+
+  .toast-stack .safety-note::before {
+    grid-row: auto;
+  }
+
+  .toast-stack .safety-note > span {
+    display: none;
   }
 
   .steps li em {
@@ -1107,6 +1254,10 @@ footer p {
   .result-list div {
     grid-template-columns: 1fr;
     gap: 0.25rem;
+  }
+
+  .sample-body-row dd.result-value {
+    align-items: stretch;
   }
 }
 

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import vm from "node:vm";
 
 import { formatAuthUpdatedAt } from "../src/ui/time.js";
 
@@ -19,6 +20,7 @@ test("wizard HTML has accessible landmarks, labels, and no inline scripts", asyn
   const html = await readFile("src/ui/index.html", "utf8");
 
   assert.match(html, /<html lang="en">/);
+  assert.match(html, /<body data-current-step="1">/u);
   assert.match(html, /<title>Relmio \| n8n Setup<\/title>/u);
   assert.match(html, /class="brand-mark"[\s\S]*<span>Relmio<\/span>/u);
   assert.match(html, /class="theme-picker"/u);
@@ -38,8 +40,20 @@ test("wizard HTML has accessible landmarks, labels, and no inline scripts", asyn
   assert.match(html, /class="skip-link"/);
   assert.match(html, /Back up first/);
   assert.match(html, /Export your n8n workflows before connecting/);
-  assert.match(html, /role="status"/);
-  assert.match(html, /role="alert" tabindex="-1"/);
+  assert.match(
+    html,
+    /class="toast-stack" aria-label="Wizard notifications"[\s\S]*id="global-safety"[\s\S]*id="global-backup"[\s\S]*id="global-message"[\s\S]*id="global-error"/u,
+  );
+  assert.match(html, /id="global-message"[\s\S]*role="status"/u);
+  assert.match(html, /id="global-error"[\s\S]*role="alert"\s+tabindex="-1"/u);
+  assert.equal(
+    (html.match(/class="toast-close"/gu) ?? []).length,
+    4,
+  );
+  assert.match(html, /data-dismiss-toast="global-safety"/u);
+  assert.match(html, /data-dismiss-toast="global-backup"/u);
+  assert.match(html, /data-dismiss-toast="global-message"/u);
+  assert.match(html, /data-dismiss-toast="global-error"/u);
   assert.match(
     html,
     /id="auth-updated"[^>]*hidden[\s\S]*<time id="auth-updated-time"><\/time>/,
@@ -66,6 +80,29 @@ test("wizard HTML has accessible landmarks, labels, and no inline scripts", asyn
     html,
     /data-copy-target="result-http-url"[\s\S]*aria-label="Copy HTTP endpoint"/,
   );
+  assert.match(
+    html,
+    /data-copy-target="result-http-body"[\s\S]*aria-label="Copy HTTP JSON body"/,
+  );
+  assert.match(html, /id="copy-settings"[\s\S]*data-copy-group="credential"/u);
+  assert.match(html, /id="copy-http-recipe"[\s\S]*data-copy-group="http"/u);
+  assert.equal(
+    (html.match(/<details class="recipe-disclosure">/gu) ?? []).length,
+    2,
+  );
+  assert.match(
+    html,
+    /<details class="recipe-disclosure">[\s\S]*<summary>[\s\S]*AI Agent or Basic LLM Chain/u,
+  );
+  assert.match(
+    html,
+    /<details class="recipe-disclosure">[\s\S]*<summary>[\s\S]*HTTP Request node/u,
+  );
+  assert.match(html, /<dt>Method<\/dt>[\s\S]*<code>POST<\/code>/u);
+  assert.match(html, /Authorization[\s\S]*Bearer local-only/u);
+  assert.match(html, /Content-Type[\s\S]*application\/json/u);
+  assert.match(html, /Authentication[\s\S]*None/u);
+  assert.match(html, /id="result-http-body"/u);
   assert.match(html, /OpenAI credential[\s\S]*OpenAI Chat Model/u);
   assert.doesNotMatch(html, /<script(?![^>]*\bsrc=)/);
   assert.doesNotMatch(html, /\sonclick=/i);
@@ -89,15 +126,82 @@ test("browser code never uses innerHTML or web storage for credentials", async (
   assert.match(app, /installAttempted/);
   assert.match(app, /status\.previewMode/);
   assert.match(app, /Preview sign-in disabled/);
-  assert.match(app, /querySelectorAll\("\[data-copy-target\]"\)/);
+  assert.match(
+    app,
+    /querySelectorAll\(\s*"\[data-copy-target\], \[data-copy-group\]",?\s*\)/u,
+  );
   assert.match(app, /async function copyText\(value\)/);
-  assert.match(app, /navigator\.clipboard\.writeText\(value\)/);
+  assert.match(app, /textarea\.focus\(\)/);
+  assert.match(app, /textarea\.select\(\)/);
+  assert.match(app, /textarea\.setSelectionRange\?\.\(0, textarea\.value\.length\)/);
   assert.match(app, /document\.execCommand\("copy"\)/);
   assert.match(
     app,
-    /try \{[\s\S]*document\.execCommand\("copy"\)[\s\S]*finally \{[\s\S]*textarea\.remove\(\)[\s\S]*previouslyFocused\?\.focus\?\.\(\)/u,
+    /const textarea = document\.createElement\("textarea"\);[\s\S]*textarea\.focus\(\);[\s\S]*textarea\.select\(\);[\s\S]*textarea\.setSelectionRange\?\.\(0, textarea\.value\.length\);[\s\S]*document\.execCommand\("copy"\)[\s\S]*finally \{[\s\S]*textarea\.remove\(\);[\s\S]*previouslyFocused\?\.focus\?\.\(\);[\s\S]*if \(copied\) \{[\s\S]*navigator\.clipboard\.writeText\(value\)/u,
   );
+  assert.match(
+    app,
+    /JSON\.stringify\(\s*\{[\s\S]*input: "Reply with exactly: bridge works"/u,
+  );
+  assert.match(app, /function dismissToast\(toast\)/u);
+  assert.match(app, /document\.body\.dataset\.currentStep = String\(step\)/u);
+  assert.match(
+    app,
+    /if \(step === 5\) \{[\s\S]*dismissToast\(element\("global-safety"\)\);[\s\S]*dismissToast\(element\("global-backup"\)\);/u,
+  );
+  assert.match(app, /window\.setTimeout\([\s\S]*dismissToast\(messageToast\)/u);
+  assert.match(app, /data-dismiss-toast/u);
   assert.doesNotMatch(app, /"Use Responses API: on"/u);
+});
+
+test("copy success survives the browser clearing event.currentTarget", async () => {
+  const app = await readFile("src/ui/app.js", "utf8");
+  const functionStart = app.indexOf("function createCopyClickHandler(");
+  const functionEnd = app.indexOf("\n}\n\nconst handleCopyClick", functionStart);
+
+  assert.notEqual(functionStart, -1);
+  assert.notEqual(functionEnd, -1);
+
+  const functionSource = app.slice(functionStart, functionEnd + 2);
+  const createCopyClickHandler = vm.runInNewContext(
+    `${functionSource}; createCopyClickHandler`,
+  );
+  const button = { dataset: { copyLabel: "Base URL" } };
+  const event = { currentTarget: button };
+  const calls = [];
+  const handler = createCopyClickHandler({
+    copyValueFor(copyButton) {
+      assert.equal(copyButton, button);
+      return "http://n8n-openai-oauth:10531/v1";
+    },
+    clearError() {
+      calls.push("clear-error");
+    },
+    async copyText(value) {
+      calls.push(["copy", value]);
+      await Promise.resolve();
+    },
+    flashCopied(copyButton) {
+      calls.push(["flash", copyButton]);
+    },
+    setMessage(message) {
+      calls.push(["message", message]);
+    },
+    showError(error) {
+      calls.push(["error", error.message]);
+    },
+  });
+
+  const completion = handler(event);
+  event.currentTarget = null;
+  await completion;
+
+  assert.deepEqual(calls, [
+    "clear-error",
+    ["copy", "http://n8n-openai-oauth:10531/v1"],
+    ["flash", button],
+    ["message", "Base URL copied."],
+  ]);
 });
 
 test("local OAuth prepares and navigates its popup before severing opener access", async () => {


### PR DESCRIPTION
## What changed

- make copy actions reliable in Opera GX on Windows by capturing the clicked button before asynchronous clipboard completion
- compact the local wizard and move safety, status, warning, and error messages into dismissible top toasts
- collapse the optional AI Agent/Basic LLM Chain and HTTP Request recipes
- add a complete copyable HTTP POST recipe and sample Responses API JSON body
- release the reviewed changes as `relmio@0.2.13`

## Why

The selection-based clipboard path successfully populated the clipboard in Opera GX, but the asynchronous event handler could read `event.currentTarget` after the browser cleared it. That produced a false copy failure after a successful copy. The final layout also kept too much persistent guidance above the active wizard step and exposed every optional recipe at once.

## Impact

Windows users can copy credential and node-recipe values without manually selecting text. The active setup step stays near the top, notifications are dismissible, and optional n8n recipes remain compact until opened.

## Validation

- `npm ci --ignore-scripts`
- `npm run check` — 99 tests, 95 passed and 4 expected platform skips
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm run package:build -- .release`
- full sanitized Opera GX flow at 1440×900 and 390×844
- post-fix Opera GX regression: exact clipboard value, no error toast, success toast, and `Copied` button state
- two fresh Sol/high reviews; final verdict: `ship`
