### PR TITLE
Relmio 0.2.14: native CMD, Homebrew and WinGet packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+web/public/install.cmd text eol=crlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,11 @@ jobs:
             throw "Windows PowerShell 5.1 could not parse install.ps1."
           }
 
-      - name: Test the native Windows bootstrap
+      - name: Test the native Windows PowerShell bootstrap
         run: node --test test/install-powershell-script.test.js
+
+      - name: Test the native Windows Command Prompt bootstrap
+        run: node --test test/install-cmd-script.test.js
 
       - name: Test the native Windows browser launcher
         run: node --test test/browser.test.js

--- a/.github/workflows/package-manager-candidates.yml
+++ b/.github/workflows/package-manager-candidates.yml
@@ -111,7 +111,7 @@ jobs:
             $archivePath = Join-Path $workspace $archiveName
             $expected = [regex]::Match(
               $checksums,
-              "(?m)^(?<hash>[a-f0-9]{64})\s+$([regex]::Escape($archiveName))\r?$",
+              "(?m)^(?<hash>[a-f0-9]{64})\s+$([regex]::Escape($archiveName))\r?$"
             )
             if (-not $expected.Success) {
               throw "No official checksum was found for $archiveName."

--- a/.github/workflows/package-manager-candidates.yml
+++ b/.github/workflows/package-manager-candidates.yml
@@ -220,6 +220,7 @@ jobs:
           path: |
             .package-manager/candidates/
             .package-manager/relmio-*-windows-*.zip
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 7
 
@@ -278,6 +279,7 @@ jobs:
         with:
           name: homebrew-release-candidate-${{ github.run_id }}
           path: .homebrew-release-candidate/homebrew-tap/Formula/relmio.rb
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/package-manager-candidates.yml
+++ b/.github/workflows/package-manager-candidates.yml
@@ -235,7 +235,7 @@ jobs:
           }
           winget --version
           $version = "${{ steps.portable.outputs.version }}"
-          winget validate --disable-interactivity ".package-manager\candidates\winget-pkgs\manifests\d\Demonbane18\Relmio\$version"
+          winget validate --disable-interactivity --ignore-warnings ".package-manager\candidates\winget-pkgs\manifests\d\Demonbane18\Relmio\$version"
 
   homebrew-release-candidate:
     name: Generate Homebrew formula from the published npm artifact

--- a/.github/workflows/package-manager-candidates.yml
+++ b/.github/workflows/package-manager-candidates.yml
@@ -1,0 +1,313 @@
+name: Validate package-manager candidates
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/package-manager-candidates.yml"
+      - ".github/workflows/publish.yml"
+      - "package-lock.json"
+      - "package.json"
+      - "packaging/**"
+      - "src/**"
+      - "docs/**"
+      - "npm/README.md"
+      - "README.md"
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - "NOTICE"
+      - "SPEC.md"
+      - "scripts/build-npm-package.js"
+      - "scripts/build-winget-portable-package.js"
+      - "scripts/generate-package-manager-manifests.js"
+      - "test/package-manager.test.js"
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Release tag whose npm publication already succeeded
+        required: false
+        type: string
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate local package-manager candidates
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out the candidate
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 22.14.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22.14.0"
+          package-manager-cache: false
+
+      - name: Install the repository npm version
+        shell: bash
+        run: |
+          npm install --global --ignore-scripts npm@10.9.8
+          test "$(npm --version)" = "10.9.8"
+
+      - name: Install pinned dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts
+
+      - name: Check package-manager scripts and candidates
+        run: |
+          npm run lint
+          npm run release:check
+          node --test test/package-manager.test.js
+
+  windows-candidates:
+    name: Build Windows package-manager candidates
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out the candidate
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 22.14.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22.14.0"
+          package-manager-cache: false
+
+      - name: Install the repository npm version
+        shell: pwsh
+        run: |
+          npm.cmd install --global --ignore-scripts npm@10.9.8
+          if ((npm.cmd --version) -ne "10.9.8") {
+            throw "The required npm version was not installed."
+          }
+
+      - name: Install pinned dependencies without lifecycle scripts
+        shell: pwsh
+        run: npm.cmd ci --ignore-scripts
+
+      - name: Download checksum-verified official Node.js Windows runtimes
+        id: node-runtimes
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $nodeVersion = "22.14.0"
+          $baseUrl = "https://nodejs.org/dist/v$nodeVersion"
+          $workspace = Join-Path $PWD ".package-manager"
+          New-Item -ItemType Directory -Force -Path $workspace | Out-Null
+          $checksumPath = Join-Path $workspace "SHASUMS256.txt"
+          Invoke-WebRequest -Uri "$baseUrl/SHASUMS256.txt" -OutFile $checksumPath
+          $checksums = Get-Content -LiteralPath $checksumPath -Raw
+
+          foreach ($architecture in @("x64", "arm64")) {
+            $archiveName = "node-v$nodeVersion-win-$architecture.zip"
+            $archivePath = Join-Path $workspace $archiveName
+            $expected = [regex]::Match(
+              $checksums,
+              "(?m)^(?<hash>[a-f0-9]{64})\s+$([regex]::Escape($archiveName))\r?$",
+            )
+            if (-not $expected.Success) {
+              throw "No official checksum was found for $archiveName."
+            }
+            Invoke-WebRequest -Uri "$baseUrl/$archiveName" -OutFile $archivePath
+            $actualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $archivePath).Hash.ToLowerInvariant()
+            if ($actualHash -ne $expected.Groups["hash"].Value.ToLowerInvariant()) {
+              throw "The SHA-256 checksum did not match for $archiveName."
+            }
+            $destination = Join-Path $workspace "node-v$nodeVersion-win-$architecture"
+            Expand-Archive -LiteralPath $archivePath -DestinationPath $destination
+            "node_$architecture=$destination\node-v$nodeVersion-win-$architecture" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Compile x64 and ARM64 portable launchers
+        id: launchers
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $workspace = Join-Path $PWD ".package-manager"
+          $launcherSource = Join-Path $PWD "packaging\winget\relmio-launcher.c"
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          if (-not (Test-Path -LiteralPath $vswhere)) {
+            throw "Visual Studio discovery is unavailable on this hosted runner."
+          }
+          $visualStudio = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $visualStudio) {
+            throw "The hosted runner does not include the required MSVC toolchain."
+          }
+          $vcvarsall = Join-Path $visualStudio "VC\Auxiliary\Build\vcvarsall.bat"
+          if (-not (Test-Path -LiteralPath $vcvarsall)) {
+            throw "The hosted runner does not include vcvarsall.bat."
+          }
+
+          foreach ($target in @(
+            @{ Architecture = "x64"; VcvarsTarget = "x64" },
+            @{ Architecture = "arm64"; VcvarsTarget = "x64_arm64" }
+          )) {
+            $objectPath = Join-Path $workspace "relmio-launcher-$($target.Architecture).obj"
+            $launcherPath = Join-Path $workspace "relmio-launcher-$($target.Architecture).exe"
+            $command = "call `"$vcvarsall`" $($target.VcvarsTarget) && cl.exe /nologo /std:c17 /W4 /WX /O2 /DUNICODE /D_UNICODE /Fo`"$objectPath`" /Fe`"$launcherPath`" `"$launcherSource`" /link /SUBSYSTEM:CONSOLE Shell32.lib"
+            & cmd.exe /d /s /c $command
+            if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $launcherPath)) {
+              throw "The hosted toolchain could not compile the $($target.Architecture) launcher."
+            }
+            "$($target.Architecture)_launcher=$launcherPath" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Build deterministic portable ZIP candidates
+        id: portable
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $version = node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version"
+          if ($LASTEXITCODE -ne 0) {
+            throw "The release version could not be read."
+          }
+          $workspace = Join-Path $PWD ".package-manager"
+          foreach ($architecture in @("x64", "arm64")) {
+            $output = Join-Path $workspace "relmio-$version-windows-$architecture.zip"
+            if ($architecture -eq "x64") {
+              $launcher = "${{ steps.launchers.outputs.x64_launcher }}"
+              $runtime = "${{ steps.node-runtimes.outputs.node_x64 }}"
+            } else {
+              $launcher = "${{ steps.launchers.outputs.arm64_launcher }}"
+              $runtime = "${{ steps.node-runtimes.outputs.node_arm64 }}"
+            }
+            node scripts/build-winget-portable-package.js `
+              --architecture $architecture `
+              --launcher $launcher `
+              --node-runtime-dir $runtime `
+              --output $output
+            if ($LASTEXITCODE -ne 0) {
+              throw "The $architecture portable ZIP build failed."
+            }
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Generate staged WinGet candidates
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $workspace = Join-Path $PWD ".package-manager"
+          $version = "${{ steps.portable.outputs.version }}"
+          node scripts/generate-package-manager-manifests.js `
+            --winget-x64 (Join-Path $workspace "relmio-$version-windows-x64.zip") `
+            --winget-arm64 (Join-Path $workspace "relmio-$version-windows-arm64.zip") `
+            --output-dir (Join-Path $workspace "candidates")
+
+      - name: Smoke-test the installed x64 portable command
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $version = "${{ steps.portable.outputs.version }}"
+          $smokeDirectory = Join-Path $PWD ".package-manager\smoke-x64"
+          Expand-Archive -LiteralPath ".package-manager\relmio-$version-windows-x64.zip" -DestinationPath $smokeDirectory
+          $output = & (Join-Path $smokeDirectory "relmio.exe") --version
+          if ($LASTEXITCODE -ne 0 -or $output -notmatch [regex]::Escape($version)) {
+            throw "The installed x64 relmio.exe --version smoke test failed."
+          }
+
+      - name: Seal reviewed package-manager candidates
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: package-manager-candidates-${{ github.run_id }}
+          path: |
+            .package-manager/candidates/
+            .package-manager/relmio-*-windows-*.zip
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Validate generated WinGet manifests
+        shell: pwsh
+        run: |
+          $moduleVersion = "1.12.440"
+          if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+            Install-Module -Name Microsoft.WinGet.Client -RequiredVersion $moduleVersion -Force -Repository PSGallery -Scope CurrentUser
+            Import-Module Microsoft.WinGet.Client -RequiredVersion $moduleVersion
+            Repair-WinGetPackageManager -Force -Latest
+          }
+          winget --version
+          $version = "${{ steps.portable.outputs.version }}"
+          winget validate --disable-interactivity ".package-manager\candidates\winget-pkgs\manifests\d\Demonbane18\Relmio\$version"
+
+  homebrew-release-candidate:
+    name: Generate Homebrew formula from the published npm artifact
+    if: inputs.release_tag != ''
+    needs:
+      - validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out the release tag
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.release_tag }}
+
+      - name: Download the exact published npm tarball
+        shell: bash
+        run: |
+          set -eu
+          version="$(node -p "require('./package.json').version")"
+          tarball="relmio-${version}.tgz"
+          url="https://registry.npmjs.org/relmio/-/${tarball}"
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent --show-error --location "$url" --output "$tarball"; then
+              break
+            fi
+            if [ "$attempt" -eq 60 ]; then
+              echo "The published npm tarball did not become available in time." >&2
+              exit 1
+            fi
+            sleep 10
+          done
+          test -s "$tarball"
+          node scripts/generate-package-manager-manifests.js \
+            --npm-tarball "$tarball" \
+            --output-dir .homebrew-release-candidate
+
+      - name: Upload the registry-derived formula candidate
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: homebrew-release-candidate-${{ github.run_id }}
+          path: .homebrew-release-candidate/homebrew-tap/Formula/relmio.rb
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-release-assets:
+    name: Attach verified Windows packages to the release
+    if: inputs.release_tag != ''
+    needs:
+      - validate
+      - windows-candidates
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download the reviewed package artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: package-manager-candidates-${{ github.run_id }}
+          path: release-artifacts
+
+      - name: Attach immutable x64 and ARM64 packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -eu
+          test -f release-artifacts/relmio-*-windows-x64.zip
+          test -f release-artifacts/relmio-*-windows-arm64.zip
+          gh release upload "$RELEASE_TAG" \
+            release-artifacts/relmio-*-windows-x64.zip \
+            release-artifacts/relmio-*-windows-arm64.zip \
+            --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   publish:
@@ -15,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: npm
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Check out the release tag
@@ -65,3 +67,13 @@ jobs:
       - name: Report an already-published release
         if: steps.registry.outputs.published == 'true'
         run: echo "relmio@${{ steps.registry.outputs.version }} is already present on npm; no publish was attempted."
+
+  package-managers:
+    name: Build package-manager release artifacts
+    needs:
+      - publish
+    permissions:
+      contents: write
+    uses: ./.github/workflows/package-manager-candidates.yml
+    with:
+      release_tag: ${{ github.event.release.tag_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+## [0.2.14] - 2026-08-04
+
+### Added
+
+- Add staged Homebrew formula and WinGet portable-package generation with
+  x64/ARM64 manifests, installed-command smoke tests, and review-only CI
+  artifacts for package-manager publication.
+- Add `relmio --version` and `relmio -v` for noninteractive installer and
+  package-manager verification.
+
+### Changed
+
+- Report Homebrew and WinGet publication status in the hosted install page and
+  documentation, while keeping unapproved commands out of the primary picker.
+
+### Fixed
+
+- Replace the hosted Command Prompt installer route's PowerShell launch with a
+  PowerShell-free, non-admin native batch bootstrap that reuses Node.js 22+
+  when available or verifies a pinned official Windows runtime before use.
+- Keep downloaded checksum-manifest text out of CMD evaluation and use reviewed
+  Node.js 22.23.2 x64/ARM64 digests embedded in the release.
+- Download the CMD bootstrap to a collision-resistant temporary name without
+  overwriting an existing `install.cmd`, then clean it after execution.
+- Show deterministic download, checksum-verification, and extraction stages in
+  every bootstrap so temporary Node.js runtime setup does not appear stalled.
+
 ## [0.2.13] - 2026-08-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -59,17 +59,26 @@ irm https://relmio.vercel.app/install.ps1 | iex
 ### Windows Command Prompt
 
 ```bat
-"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
+for /f "delims=" %F in ("%TEMP%\relmio-install-%RANDOM%-%RANDOM%-%RANDOM%.cmd") do @if exist "%~F" (exit /b 80) else curl -fsSL --remove-on-error https://relmio.vercel.app/install.cmd -o "%~F" && set "RELMIO_SELF_DELETE=%~F" && call "%~F"
 ```
 
 These commands start the wizard without installing Node.js or Git Bash first.
-The open-source [POSIX](web/public/install.sh) and
-[Windows PowerShell](web/public/install.ps1) bootstraps reuse Node.js 22 or
-newer when it is already available. Otherwise they download the matching
-current official Node.js 22 runtime to a private temporary directory, verify
-its SHA-256 checksum, run Relmio with npm lifecycle scripts disabled, and
-remove the temporary runtime when the wizard closes. They do not install
-Node.js system-wide.
+The open-source [POSIX](web/public/install.sh), [Windows PowerShell](web/public/install.ps1),
+and [Command Prompt](web/public/install.cmd) bootstraps reuse Node.js 22 or
+newer when it is already available. Otherwise they show staged download,
+verification, and extraction messages while they download the matching current
+official Node.js 22 runtime to a private temporary directory, verify its
+SHA-256 checksum, run Relmio with npm lifecycle scripts disabled, and remove
+the temporary runtime when the wizard closes. They do not install Node.js
+system-wide.
+
+Homebrew tap publication and WinGet catalog approval are pending. Their install
+commands will be added here only after each public package passes a real
+package-manager installation test. Use a direct installer above today.
+
+The Command Prompt route is PowerShell-free, runs as the current user, and
+does not request administrator access or change Windows security policy. Keep
+the terminal open while its temporary-runtime stages say **Please wait**.
 
 Already have Node.js 22 or newer? You can use NPX instead:
 
@@ -346,8 +355,9 @@ you want to inspect, reproduce, improve, or debug the method, use
 - A local macOS, Linux, or Windows computer
 - On macOS/Linux/WSL/Git Bash: `curl`, `awk`, `tar`, and a SHA-256 tool
   (`sha256sum` or `shasum`); Git Bash also needs `unzip`
-- On native Windows: Windows PowerShell 5.1 or PowerShell 7; Command Prompt can
-  launch the included PowerShell bootstrap
+- On native Windows: Command Prompt uses its built-in `curl`, `certutil`, and
+  `tar` tools; Windows PowerShell 5.1 or PowerShell 7 remains an alternative
+  bootstrap
 - A browser and a ChatGPT account eligible to use the upstream Codex flow
 - A self-hosted n8n Docker container on a VPS
 - Docker Engine and Docker Compose v2 on the VPS
@@ -366,7 +376,7 @@ you will complete the browser sign-in.
 
 ### 1. Start the newest published wizard
 
-Choose the terminal already installed on your computer.
+Choose a terminal already installed on your computer.
 
 #### macOS, Linux, WSL, or Git Bash
 
@@ -383,13 +393,16 @@ irm https://relmio.vercel.app/install.ps1 | iex
 #### Windows Command Prompt
 
 ```bat
-"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
+for /f "delims=" %F in ("%TEMP%\relmio-install-%RANDOM%-%RANDOM%-%RANDOM%.cmd") do @if exist "%~F" (exit /b 80) else curl -fsSL --remove-on-error https://relmio.vercel.app/install.cmd -o "%~F" && set "RELMIO_SELF_DELETE=%~F" && call "%~F"
 ```
 
 The POSIX and native Windows bootstraps use a supported Node.js installation
-when present. If Node.js is missing or older than 22, they download and verify
-a temporary official Node.js 22 runtime without installing it system-wide.
-Native Windows does not require Git Bash.
+when present. If Node.js is missing or older than 22, they show staged
+**Please wait** messages while they download and verify a temporary official
+Node.js 22 runtime without installing it system-wide. Native Windows does not
+require Git Bash; Command Prompt uses a PowerShell-free, non-admin bootstrap.
+Homebrew and WinGet release candidates are prepared separately. Their public
+commands remain hidden until the tap and catalog packages pass real installs.
 
 Anyone who already has [Node.js 22 or newer](https://nodejs.org/en/download)
 can run the npm package directly instead:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,13 +49,19 @@ irm https://relmio.vercel.app/install.ps1 | iex
 Windows Command Prompt:
 
 ```bat
-"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
+for /f "delims=" %F in ("%TEMP%\relmio-install-%RANDOM%-%RANDOM%-%RANDOM%.cmd") do @if exist "%~F" (exit /b 80) else curl -fsSL --remove-on-error https://relmio.vercel.app/install.cmd -o "%~F" && set "RELMIO_SELF_DELETE=%~F" && call "%~F"
 ```
 
 These commands do not require Node.js to be installed. The Windows options do
 not require Git Bash. Each bootstrap reuses Node.js 22 or newer when available,
-or downloads an official temporary runtime and verifies its SHA-256 checksum
-before execution.
+or shows staged **Please wait** messages while it downloads an official
+temporary runtime and verifies its SHA-256 checksum before execution. The
+Command Prompt route is PowerShell-free, non-admin, and does not change Windows
+security policy.
+
+Homebrew tap publication and WinGet catalog approval are pending. Until each
+public package passes its real install test, use one of the direct bootstrap
+commands on this page.
 
 If you choose the existing-Node fallback, confirm Node is version 22 or newer
 and check the published package version first:
@@ -117,8 +123,10 @@ bypassed.
 | Symptom | Meaning | Fix |
 |---|---|---|
 | `node: command not found`, `node is not recognized`, or Node is older than 22 | The NPX fallback cannot use the local runtime. | Use the macOS/Linux curl command or the native Windows PowerShell/Command Prompt command above. Either can run with a verified temporary runtime. Do not install Node.js on the VPS for the wizard. |
-| `curl` or `sh` is not recognized on Windows | The macOS/Linux command was pasted into a native Windows terminal. | Use the PowerShell command in PowerShell, or the `"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile ...` command in Command Prompt. Git Bash is not required. |
-| A bootstrap reports a checksum mismatch | The Node.js download did not match the official SHA-256 manifest, so it was not executed. | Retry on a trusted connection. Do not bypass the check. If it repeats, use an existing Node.js 22+ installation and report the sanitized error. |
+| `curl` or `sh` is not recognized on Windows | The macOS/Linux command was pasted into a native Windows terminal. | Use the PowerShell command in PowerShell or the collision-safe temporary-file command shown above in Command Prompt. Git Bash is not required. If Command Prompt does not have `curl`, update Windows or use the PowerShell route. |
+| Command Prompt says it cannot create `powershell.exe` | A Windows policy denied PowerShell before the old CMD route could start its installer. | Use the current PowerShell-free Command Prompt command above. It downloads `install.cmd`, runs as your current user, and does not request elevation or change execution policy. |
+| The bootstrap stays on a `Please wait` stage | Node.js is missing or older than 22, so the bootstrap is downloading, checking, or extracting a temporary Node.js 22 runtime. | Keep the terminal open while the deterministic stage messages advance. The runtime is verified before it runs, is removed after the wizard exits, and is not installed system-wide. |
+| A bootstrap reports a checksum mismatch | The Node.js download did not match its reviewed official SHA-256 checksum, so it was not executed. | Retry on a trusted connection. Do not bypass the check. If it repeats, use an existing Node.js 22+ installation and report the sanitized error. |
 | Windows PowerShell shows `[eval]:1` before the wizard starts | An older bootstrap passed a JavaScript expression through `node -p`; PowerShell native-argument handling can alter that expression. | Update to the latest `relmio@latest` and rerun the same PowerShell or Command Prompt command. The current bootstrap parses the literal `node --version` output and reuses Node.js 22 or newer. |
 | Windows reports `spawn EINVAL` when starting ChatGPT sign-in | An older wizard tried to execute `npx.cmd` directly; Windows requires the current Node runtime to launch npm's JavaScript CLI. | Update to the latest `relmio@latest` release and restart the setup command. The current wizard keeps the macOS/Linux/WSL/Git Bash `npx` path unchanged. |
 | The browser did not open | The automatic browser launch failed, but the local server may still be running. | Keep the newest terminal open and press Enter to ask an interactive wizard terminal to open it again. If the terminal is noninteractive or the launcher still fails, copy its newest `127.0.0.1` setup URL into the browser. Do not reuse a URL from a closed terminal. |

--- a/npm/README.md
+++ b/npm/README.md
@@ -105,16 +105,24 @@ irm https://relmio.vercel.app/install.ps1 | iex
 ### Windows Command Prompt
 
 ```bat
-"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"
+for /f "delims=" %F in ("%TEMP%\relmio-install-%RANDOM%-%RANDOM%-%RANDOM%.cmd") do @if exist "%~F" (exit /b 80) else curl -fsSL --remove-on-error https://relmio.vercel.app/install.cmd -o "%~F" && set "RELMIO_SELF_DELETE=%~F" && call "%~F"
 ```
 
 No Node.js or Git Bash installation is required first. The
 [POSIX](https://github.com/Demonbane18/relmio/blob/main/web/public/install.sh)
 and [Windows PowerShell](https://github.com/Demonbane18/relmio/blob/main/web/public/install.ps1)
-bootstraps reuse Node.js 22 or newer when available. Otherwise they download
-the matching current official Node.js 22 runtime to a private temporary
-directory, verify its SHA-256 checksum, run Relmio with npm lifecycle scripts
-disabled, and remove the temporary runtime when the wizard closes.
+bootstraps, plus the PowerShell-free [Command Prompt](https://github.com/Demonbane18/relmio/blob/main/web/public/install.cmd)
+bootstrap, reuse Node.js 22 or newer when available. Otherwise they show
+staged **Please wait** messages while they download the matching current
+official Node.js 22 runtime to a private temporary directory, verify its
+SHA-256 checksum, run Relmio with npm lifecycle scripts disabled, and remove
+the temporary runtime when the wizard closes. The Command Prompt path runs as
+the current user and does not request administrator access or change Windows
+security policy.
+
+Homebrew tap publication and WinGet catalog approval are pending. Their install
+commands will be added only after each public package passes a real
+package-manager installation test. Use a direct installer above today.
 
 Users who already have Node.js 22 or newer can run the npm package directly:
 
@@ -137,8 +145,9 @@ a browser.
 
 - On macOS/Linux/WSL/Git Bash: `curl`, `awk`, `tar`, and either `sha256sum` or
   `shasum`; Git Bash also needs `unzip`
-- On native Windows: Windows PowerShell 5.1 or PowerShell 7; Command Prompt can
-  launch the included PowerShell bootstrap
+- On native Windows: Command Prompt uses its built-in `curl`, `certutil`, and
+  `tar` tools; Windows PowerShell 5.1 or PowerShell 7 remains an alternative
+  bootstrap
 - A browser and an eligible ChatGPT/Codex account
 - A self-hosted n8n Docker deployment on a VPS
 - Docker Compose v2, SSH access, and a Docker network shared with n8n

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relmio",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relmio",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "license": "Apache-2.0",
       "dependencies": {
         "ssh2": "1.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relmio",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Turn a supported ChatGPT/Codex OAuth sign-in into a private OpenAI-compatible endpoint, starting with self-hosted n8n.",
   "keywords": [
     "relmio",
@@ -37,7 +37,10 @@
   },
   "files": [
     "src",
-    "scripts",
+    "scripts/build-npm-package.js",
+    "scripts/check-release-metadata.js",
+    "scripts/check-syntax.js",
+    "scripts/preview.js",
     "docs",
     "README.md",
     "SPEC.md",

--- a/packaging/package-managers.md
+++ b/packaging/package-managers.md
@@ -1,0 +1,84 @@
+# Package-manager release candidates
+
+This directory prepares reviewable candidates. It does not publish a Homebrew
+formula, upload a GitHub Release asset, create a WinGet pull request, or make
+`brew install relmio` / `winget install Demonbane18.Relmio` available.
+
+## Homebrew
+
+`scripts/generate-package-manager-manifests.js` produces a formula candidate
+from the exact `relmio-<version>.tgz` that is about to be, or has just been,
+published to npm. Its URL is the immutable npm registry tarball URL and its
+SHA-256 is calculated from the supplied local tarball.
+
+The formula follows Homebrew's Node guidance: it depends on `node`, uses
+`std_npm_args`, installs to `libexec`, and symlinks the resulting executables.
+Relmio's dependency tree has an optional native Node addon, so the formula
+also has a build dependency on `python` as Homebrew requires for `node-gyp`.
+
+Before a public tap submission, download the published npm tarball from the
+registry and confirm its SHA-256 matches the generated formula. Then validate
+the candidate in the separate tap repository with Homebrew's current audit and
+source-install commands. There is no tap in this repository and no assumption
+that `homebrew/core` accepts the formula.
+
+## WinGet
+
+WinGet does not accept script installers. The staged ZIP contains an actual
+`relmio.exe` portable launcher, an official Node.js Windows runtime (including
+npm/npx), the npm-package contents, and the production dependency tree. The
+launcher always invokes the bundled `runtime\node.exe`, preserving Relmio's
+Windows `npx` resolution relative to `process.execPath`.
+
+Build one ZIP per architecture from checksum-verified official Node.js runtime
+archives. The output names are fixed:
+
+```
+relmio-<version>-windows-x64.zip
+relmio-<version>-windows-arm64.zip
+```
+
+The generated manifests use WinGet's current 1.12 multi-file format and the
+portable ZIP pattern: `InstallerType: zip`, `NestedInstallerType: portable`,
+and `relmio.exe` as the command alias. They point only to versioned GitHub
+Release asset URLs. Generate the manifests only from the exact ZIPs uploaded to
+that release.
+
+The proposed identifier, `Demonbane18.Relmio`, must be checked for uniqueness
+in `microsoft/winget-pkgs` before a submission. A maintainer must run `winget
+validate` and the repository's Sandbox test against the generated directory,
+then submit exactly one version through a separate `winget-pkgs` pull request.
+The package is not available through WinGet until that pull request is merged
+and the catalog has updated.
+
+## Generate candidates
+
+Generate the Homebrew formula only after npm publishing, from the exact
+immutable tarball downloaded back from the registry. Never use a separately
+built local or Windows tarball for the tap checksum:
+
+```powershell
+curl.exe -fsSL https://registry.npmjs.org/relmio/-/relmio-<version>.tgz -o relmio-<version>.tgz
+node scripts/generate-package-manager-manifests.js `
+  --npm-tarball relmio-<version>.tgz `
+  --output-dir .release/homebrew-candidate
+```
+
+The WinGet candidates are generated independently from the exact release ZIPs:
+
+```powershell
+node scripts/generate-package-manager-manifests.js `
+  --winget-x64 .release/relmio-<version>-windows-x64.zip `
+  --winget-arm64 .release/relmio-<version>-windows-arm64.zip `
+  --output-dir .release/package-manager-candidates
+```
+
+The command intentionally refuses to overwrite an existing output directory.
+It makes no network request and prints an explicit non-publication notice.
+
+## Primary references checked on 2026-08-04
+
+- [Homebrew: Node for Formula Authors](https://docs.brew.sh/Node-for-Formula-Authors)
+- [Homebrew: Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
+- [Microsoft Learn: Create your package manifest](https://learn.microsoft.com/windows/package-manager/package/manifest)
+- [Microsoft Learn: Submit your manifest to the repository](https://learn.microsoft.com/windows/package-manager/package/repository)

--- a/packaging/winget/relmio-launcher.c
+++ b/packaging/winget/relmio-launcher.c
@@ -1,0 +1,123 @@
+#include <windows.h>
+#include <shellapi.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+
+static bool append_text(wchar_t **cursor, const wchar_t *value) {
+  const size_t length = wcslen(value);
+  memcpy(*cursor, value, length * sizeof(wchar_t));
+  *cursor += length;
+  return true;
+}
+
+static bool append_quoted_argument(wchar_t **cursor, const wchar_t *argument) {
+  size_t backslashes = 0;
+  append_text(cursor, L"\"");
+
+  for (const wchar_t *character = argument; *character != L'\0'; character += 1) {
+    if (*character == L'\\') {
+      backslashes += 1;
+      continue;
+    }
+
+    if (*character == L'\"') {
+      for (size_t index = 0; index < backslashes * 2 + 1; index += 1) {
+        append_text(cursor, L"\\");
+      }
+    } else {
+      for (size_t index = 0; index < backslashes; index += 1) {
+        append_text(cursor, L"\\");
+      }
+    }
+    backslashes = 0;
+    **cursor = *character;
+    *cursor += 1;
+  }
+
+  for (size_t index = 0; index < backslashes * 2; index += 1) {
+    append_text(cursor, L"\\");
+  }
+  append_text(cursor, L"\"");
+  return true;
+}
+
+int wmain(void) {
+  wchar_t launcher_path[MAX_PATH];
+  wchar_t runtime_path[MAX_PATH];
+  wchar_t script_path[MAX_PATH];
+  DWORD launcher_length;
+  int argument_count = 0;
+  wchar_t **arguments;
+  wchar_t *command_line;
+  wchar_t *cursor;
+  size_t command_capacity = 0;
+  STARTUPINFOW startup_info = { .cb = sizeof(STARTUPINFOW) };
+  PROCESS_INFORMATION process_info = { 0 };
+  DWORD exit_code = 1;
+
+  launcher_length = GetModuleFileNameW(NULL, launcher_path, MAX_PATH);
+  if (launcher_length == 0 || launcher_length >= MAX_PATH) {
+    fputws(L"Relmio could not resolve its installation folder.\n", stderr);
+    return 1;
+  }
+
+  wchar_t *directory_separator = wcsrchr(launcher_path, L'\\');
+  if (directory_separator == NULL) {
+    fputws(L"Relmio could not resolve its installation folder.\n", stderr);
+    return 1;
+  }
+  *directory_separator = L'\0';
+
+  if (swprintf_s(runtime_path, MAX_PATH, L"%s\\runtime\\node.exe", launcher_path) < 0 ||
+      swprintf_s(script_path, MAX_PATH, L"%s\\app\\node_modules\\relmio\\src\\cli.js", launcher_path) < 0) {
+    fputws(L"Relmio installation paths are too long.\n", stderr);
+    return 1;
+  }
+
+  arguments = CommandLineToArgvW(GetCommandLineW(), &argument_count);
+  if (arguments == NULL) {
+    fputws(L"Relmio could not read its command line.\n", stderr);
+    return 1;
+  }
+
+  command_capacity = (wcslen(runtime_path) + wcslen(script_path) + 8) * sizeof(wchar_t);
+  for (int index = 1; index < argument_count; index += 1) {
+    command_capacity += (wcslen(arguments[index]) * 2 + 4) * sizeof(wchar_t);
+  }
+  command_line = calloc(1, command_capacity);
+  if (command_line == NULL) {
+    LocalFree(arguments);
+    fputws(L"Relmio could not allocate a command line.\n", stderr);
+    return 1;
+  }
+
+  cursor = command_line;
+  append_quoted_argument(&cursor, runtime_path);
+  append_text(&cursor, L" ");
+  append_quoted_argument(&cursor, script_path);
+  for (int index = 1; index < argument_count; index += 1) {
+    append_text(&cursor, L" ");
+    append_quoted_argument(&cursor, arguments[index]);
+  }
+
+  if (!CreateProcessW(runtime_path, command_line, NULL, NULL, TRUE, 0, NULL,
+                      launcher_path, &startup_info, &process_info)) {
+    free(command_line);
+    LocalFree(arguments);
+    fputws(L"Relmio could not start its bundled Node.js runtime. Reinstall the package.\n", stderr);
+    return 1;
+  }
+
+  WaitForSingleObject(process_info.hProcess, INFINITE);
+  if (!GetExitCodeProcess(process_info.hProcess, &exit_code)) {
+    exit_code = 1;
+  }
+  CloseHandle(process_info.hThread);
+  CloseHandle(process_info.hProcess);
+  free(command_line);
+  LocalFree(arguments);
+  return (int)exit_code;
+}

--- a/scripts/build-winget-portable-package.js
+++ b/scripts/build-winget-portable-package.js
@@ -1,0 +1,446 @@
+#!/usr/bin/env node
+
+import { deflateRawSync } from "node:zlib";
+import {
+  access,
+  cp,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { stageNpmPackage } from "./build-npm-package.js";
+
+const projectRoot = fileURLToPath(new URL("..", import.meta.url));
+const supportedArchitectures = new Map([
+  ["x64", 0x8664],
+  ["arm64", 0xaa64],
+]);
+const zipDosDate = (1 << 5) | 1;
+const zipDosTime = 0;
+const maxZip32Value = 0xffffffff;
+const semver =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*)|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:(?:0|[1-9]\d*)|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u;
+
+function assertNonEmptyString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function assertArchitecture(architecture) {
+  if (!supportedArchitectures.has(architecture)) {
+    throw new Error(`Unsupported Windows architecture: ${architecture}.`);
+  }
+}
+
+function writeUInt16(buffer, offset, value) {
+  buffer.writeUInt16LE(value, offset);
+}
+
+function writeUInt32(buffer, offset, value) {
+  buffer.writeUInt32LE(value >>> 0, offset);
+}
+
+const crcTable = (() => {
+  const table = new Uint32Array(256);
+  for (let index = 0; index < table.length; index += 1) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    }
+    table[index] = value >>> 0;
+  }
+  return table;
+})();
+
+export function crc32(contents) {
+  let value = 0xffffffff;
+  for (const byte of contents) {
+    value = crcTable[(value ^ byte) & 0xff] ^ (value >>> 8);
+  }
+  return (value ^ 0xffffffff) >>> 0;
+}
+
+function normalizeArchivePath(path) {
+  const normalized = path.split(sep).join("/");
+  if (
+    normalized === "" ||
+    normalized.startsWith("/") ||
+    normalized.split("/").some((part) => part === "" || part === "." || part === "..")
+  ) {
+    throw new Error(`Unsafe ZIP entry path: ${path}`);
+  }
+  return normalized;
+}
+
+export function peMachine(contents, label = "Windows executable") {
+  if (contents.length < 0x40 || contents.toString("ascii", 0, 2) !== "MZ") {
+    throw new Error(`${label} is not a PE executable.`);
+  }
+  const peOffset = contents.readUInt32LE(0x3c);
+  if (
+    peOffset > contents.length - 6 ||
+    contents.toString("ascii", peOffset, peOffset + 4) !== "PE\0\0"
+  ) {
+    throw new Error(`${label} has an invalid PE header.`);
+  }
+  return contents.readUInt16LE(peOffset + 4);
+}
+
+export function validatePeArchitecture({ architecture, contents, label }) {
+  assertArchitecture(architecture);
+  const machine = peMachine(contents, label);
+  if (machine !== supportedArchitectures.get(architecture)) {
+    throw new Error(
+      `${label} is not built for ${architecture}; received PE machine 0x${machine.toString(16)}.`,
+    );
+  }
+}
+
+async function assertRegularFile(path, label) {
+  let metadata;
+  try {
+    metadata = await lstat(path);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      throw new Error(`${label} does not exist: ${path}`);
+    }
+    throw error;
+  }
+  if (!metadata.isFile() || metadata.size === 0) {
+    throw new Error(`${label} must be a non-empty regular file: ${path}`);
+  }
+}
+
+async function assertDirectory(path, label) {
+  let metadata;
+  try {
+    metadata = await lstat(path);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      throw new Error(`${label} does not exist: ${path}`);
+    }
+    throw error;
+  }
+  if (!metadata.isDirectory()) {
+    throw new Error(`${label} must be a directory: ${path}`);
+  }
+}
+
+export async function validateNodeRuntimeDirectory({ architecture, directory }) {
+  assertArchitecture(architecture);
+  const runtimeDirectory = resolve(directory);
+  const nodePath = join(runtimeDirectory, "node.exe");
+  const npxPath = join(
+    runtimeDirectory,
+    "node_modules",
+    "npm",
+    "bin",
+    "npx-cli.js",
+  );
+  await Promise.all([
+    assertRegularFile(nodePath, "Bundled node.exe"),
+    assertRegularFile(npxPath, "Bundled npm npx-cli.js"),
+  ]);
+  validatePeArchitecture({
+    architecture,
+    contents: await readFile(nodePath),
+    label: "Bundled node.exe",
+  });
+  return runtimeDirectory;
+}
+
+export async function collectArchiveFiles(rootDirectory) {
+  const root = resolve(rootDirectory);
+  const files = [];
+
+  async function collect(directory) {
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      if (entry.isSymbolicLink()) {
+        throw new Error(`Symbolic links are not permitted in a portable ZIP: ${path}`);
+      }
+      if (entry.isDirectory()) {
+        await collect(path);
+        continue;
+      }
+      if (!entry.isFile()) {
+        throw new Error(`Unsupported portable ZIP entry: ${path}`);
+      }
+      files.push({
+        contents: await readFile(path),
+        path: normalizeArchivePath(relative(root, path)),
+      });
+    }
+  }
+
+  await collect(root);
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function zipEntry({ contents, path, offset }) {
+  const filename = Buffer.from(path, "utf8");
+  const compressed = deflateRawSync(contents, { level: 9 });
+  if (
+    filename.length > 0xffff ||
+    contents.length > maxZip32Value ||
+    compressed.length > maxZip32Value ||
+    offset > maxZip32Value
+  ) {
+    throw new Error(`Portable ZIP entry exceeds the supported ZIP32 limit: ${path}`);
+  }
+  const checksum = crc32(contents);
+  const localHeader = Buffer.alloc(30);
+  writeUInt32(localHeader, 0, 0x04034b50);
+  writeUInt16(localHeader, 4, 20);
+  writeUInt16(localHeader, 6, 0);
+  writeUInt16(localHeader, 8, 8);
+  writeUInt16(localHeader, 10, zipDosTime);
+  writeUInt16(localHeader, 12, zipDosDate);
+  writeUInt32(localHeader, 14, checksum);
+  writeUInt32(localHeader, 18, compressed.length);
+  writeUInt32(localHeader, 22, contents.length);
+  writeUInt16(localHeader, 26, filename.length);
+  writeUInt16(localHeader, 28, 0);
+
+  const centralDirectoryHeader = Buffer.alloc(46);
+  writeUInt32(centralDirectoryHeader, 0, 0x02014b50);
+  writeUInt16(centralDirectoryHeader, 4, 20);
+  writeUInt16(centralDirectoryHeader, 6, 20);
+  writeUInt16(centralDirectoryHeader, 8, 0);
+  writeUInt16(centralDirectoryHeader, 10, 8);
+  writeUInt16(centralDirectoryHeader, 12, zipDosTime);
+  writeUInt16(centralDirectoryHeader, 14, zipDosDate);
+  writeUInt32(centralDirectoryHeader, 16, checksum);
+  writeUInt32(centralDirectoryHeader, 20, compressed.length);
+  writeUInt32(centralDirectoryHeader, 24, contents.length);
+  writeUInt16(centralDirectoryHeader, 28, filename.length);
+  writeUInt16(centralDirectoryHeader, 30, 0);
+  writeUInt16(centralDirectoryHeader, 32, 0);
+  writeUInt16(centralDirectoryHeader, 34, 0);
+  writeUInt16(centralDirectoryHeader, 36, 0);
+  writeUInt32(centralDirectoryHeader, 38, 0x81a40000);
+  writeUInt32(centralDirectoryHeader, 42, offset);
+
+  return {
+    centralDirectory: Buffer.concat([centralDirectoryHeader, filename]),
+    localContents: Buffer.concat([localHeader, filename, compressed]),
+  };
+}
+
+export function createDeterministicZip(files) {
+  if (!Array.isArray(files) || files.length === 0) {
+    throw new Error("A portable ZIP requires at least one file.");
+  }
+  if (files.length > 0xffff) {
+    throw new Error("Portable ZIP has too many entries for ZIP32.");
+  }
+  const sortedFiles = [...files]
+    .map(({ contents, path }) => ({
+      contents: Buffer.from(contents),
+      path: normalizeArchivePath(assertNonEmptyString(path, "ZIP entry path")),
+    }))
+    .sort((left, right) => left.path.localeCompare(right.path));
+  const duplicate = sortedFiles.find(
+    (entry, index) => index > 0 && entry.path === sortedFiles[index - 1].path,
+  );
+  if (duplicate) {
+    throw new Error(`Portable ZIP has a duplicate entry: ${duplicate.path}`);
+  }
+
+  const locals = [];
+  const centralDirectories = [];
+  let offset = 0;
+  for (const file of sortedFiles) {
+    const entry = zipEntry({ ...file, offset });
+    locals.push(entry.localContents);
+    centralDirectories.push(entry.centralDirectory);
+    offset += entry.localContents.length;
+    if (offset > maxZip32Value) {
+      throw new Error("Portable ZIP exceeds the supported ZIP32 limit.");
+    }
+  }
+  const centralDirectory = Buffer.concat(centralDirectories);
+  const endOfCentralDirectory = Buffer.alloc(22);
+  writeUInt32(endOfCentralDirectory, 0, 0x06054b50);
+  writeUInt16(endOfCentralDirectory, 4, 0);
+  writeUInt16(endOfCentralDirectory, 6, 0);
+  writeUInt16(endOfCentralDirectory, 8, sortedFiles.length);
+  writeUInt16(endOfCentralDirectory, 10, sortedFiles.length);
+  writeUInt32(endOfCentralDirectory, 12, centralDirectory.length);
+  writeUInt32(endOfCentralDirectory, 16, offset);
+  writeUInt16(endOfCentralDirectory, 20, 0);
+  return Buffer.concat([...locals, centralDirectory, endOfCentralDirectory]);
+}
+
+async function copyDirectoryContents(source, target) {
+  await assertDirectory(source, "Production node_modules directory");
+  await mkdir(target, { recursive: true });
+  const entries = await readdir(source, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === ".package-lock.json") {
+      continue;
+    }
+    await cp(join(source, entry.name), join(target, entry.name), {
+      dereference: false,
+      recursive: entry.isDirectory(),
+    });
+  }
+}
+
+async function assertMissing(path) {
+  try {
+    await access(path);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  throw new Error(`Refusing to overwrite existing output: ${path}`);
+}
+
+export async function buildWingetPortablePackage({
+  architecture,
+  launcherPath,
+  nodeRuntimeDirectory,
+  outputPath,
+  productionNodeModulesDirectory = join(projectRoot, "node_modules"),
+  stagePackage = stageNpmPackage,
+}) {
+  assertArchitecture(architecture);
+  const packageJson = JSON.parse(
+    await readFile(join(projectRoot, "package.json"), "utf8"),
+  );
+  const version = packageJson.version;
+  if (typeof version !== "string" || !semver.test(version)) {
+    throw new Error("package.json must contain a valid semantic version.");
+  }
+  const expectedFilename = `relmio-${version}-windows-${architecture}.zip`;
+  const resolvedOutputPath = resolve(outputPath);
+  if (basename(resolvedOutputPath) !== expectedFilename) {
+    throw new Error(
+      `Portable archive must be named ${expectedFilename}; received ${basename(resolvedOutputPath)}.`,
+    );
+  }
+  await assertMissing(resolvedOutputPath);
+
+  const resolvedLauncherPath = resolve(launcherPath);
+  await assertRegularFile(resolvedLauncherPath, "Relmio launcher");
+  validatePeArchitecture({
+    architecture,
+    contents: await readFile(resolvedLauncherPath),
+    label: "Relmio launcher",
+  });
+  const resolvedRuntimeDirectory = await validateNodeRuntimeDirectory({
+    architecture,
+    directory: nodeRuntimeDirectory,
+  });
+
+  const stagingDirectory = await mkdtemp(join(tmpdir(), "relmio-winget-"));
+  try {
+    const archiveRoot = join(stagingDirectory, `relmio-${version}-windows-${architecture}`);
+    const appNodeModules = join(archiveRoot, "app", "node_modules");
+    await mkdir(archiveRoot, { recursive: true });
+    await cp(resolvedLauncherPath, join(archiveRoot, "relmio.exe"));
+    await cp(resolvedRuntimeDirectory, join(archiveRoot, "runtime"), {
+      dereference: false,
+      recursive: true,
+    });
+    await stagePackage(join(appNodeModules, "relmio"));
+    await copyDirectoryContents(productionNodeModulesDirectory, appNodeModules);
+
+    await Promise.all([
+      assertRegularFile(
+        join(archiveRoot, "relmio.exe"),
+        "Packaged Relmio launcher",
+      ),
+      assertRegularFile(
+        join(archiveRoot, "runtime", "node.exe"),
+        "Packaged node.exe",
+      ),
+      assertRegularFile(
+        join(archiveRoot, "runtime", "node_modules", "npm", "bin", "npx-cli.js"),
+        "Packaged npm npx-cli.js",
+      ),
+      assertRegularFile(
+        join(appNodeModules, "relmio", "src", "cli.js"),
+        "Packaged Relmio CLI",
+      ),
+      assertDirectory(join(appNodeModules, "ssh2"), "Packaged ssh2 dependency"),
+    ]);
+
+    await mkdir(dirname(resolvedOutputPath), { recursive: true });
+    const zip = createDeterministicZip(await collectArchiveFiles(archiveRoot));
+    await writeFile(resolvedOutputPath, zip, { flag: "wx" });
+    return {
+      outputPath: resolvedOutputPath,
+      sha256: createHash("sha256").update(zip).digest("hex"),
+      version,
+    };
+  } finally {
+    await rm(stagingDirectory, { force: true, recursive: true });
+  }
+}
+
+function parseArguments(argumentsList) {
+  const options = {};
+  const accepted = new Set([
+    "--architecture",
+    "--launcher",
+    "--node-runtime-dir",
+    "--output",
+  ]);
+  for (let index = 0; index < argumentsList.length; index += 1) {
+    const argument = argumentsList[index];
+    if (!accepted.has(argument)) {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    if (options[argument] !== undefined) {
+      throw new Error(`Argument supplied more than once: ${argument}`);
+    }
+    const value = argumentsList[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`${argument} requires a value.`);
+    }
+    options[argument] = value;
+    index += 1;
+  }
+  for (const required of accepted) {
+    if (options[required] === undefined) {
+      throw new Error(`${required} is required.`);
+    }
+  }
+  return options;
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const result = await buildWingetPortablePackage({
+    architecture: options["--architecture"],
+    launcherPath: options["--launcher"],
+    nodeRuntimeDirectory: options["--node-runtime-dir"],
+    outputPath: options["--output"],
+  });
+  console.log(result.outputPath);
+  console.log(`SHA-256: ${result.sha256}`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/generate-package-manager-manifests.js
+++ b/scripts/generate-package-manager-manifests.js
@@ -1,0 +1,374 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { access, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = fileURLToPath(new URL("..", import.meta.url));
+const packageIdentifier = "Demonbane18.Relmio";
+const packagePublisher = "Demonbane18";
+const packageName = "Relmio";
+const repositoryUrl = "https://github.com/Demonbane18/relmio";
+const manifestVersion = "1.12.0";
+const supportedArchitectures = new Set(["x64", "arm64"]);
+const semver =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*)|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:(?:0|[1-9]\d*)|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u;
+
+function assertString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function assertSha256(value, label = "SHA-256") {
+  if (typeof value !== "string" || !/^[a-f0-9]{64}$/iu.test(value)) {
+    throw new Error(`${label} must be a 64-character hexadecimal digest.`);
+  }
+  return value.toLowerCase();
+}
+
+export function validateReleasePackage(packageJson) {
+  if (packageJson?.name !== "relmio") {
+    throw new Error('package.json name must be "relmio".');
+  }
+  if (typeof packageJson?.version !== "string" || !semver.test(packageJson.version)) {
+    throw new Error("package.json must contain a valid semantic version.");
+  }
+  if (packageJson.license !== "Apache-2.0") {
+    throw new Error("package.json license must be Apache-2.0.");
+  }
+  if (packageJson?.repository?.url !== `git+${repositoryUrl}.git`) {
+    throw new Error("package.json repository URL does not match the release source.");
+  }
+
+  return { version: packageJson.version };
+}
+
+export function registryTarballUrl(version) {
+  if (typeof version !== "string" || !semver.test(version)) {
+    throw new Error("A valid semantic version is required for the npm tarball URL.");
+  }
+  return `https://registry.npmjs.org/relmio/-/relmio-${version}.tgz`;
+}
+
+export function wingetInstallerUrl({ architecture, version }) {
+  if (!supportedArchitectures.has(architecture)) {
+    throw new Error(`Unsupported WinGet architecture: ${architecture}.`);
+  }
+  if (typeof version !== "string" || !semver.test(version)) {
+    throw new Error("A valid semantic version is required for the WinGet installer URL.");
+  }
+  return `${repositoryUrl}/releases/download/v${version}/relmio-${version}-windows-${architecture}.zip`;
+}
+
+export function createHomebrewFormula({ sha256, version }) {
+  const digest = assertSha256(sha256, "Homebrew tarball SHA-256");
+  const tarballUrl = registryTarballUrl(version);
+
+  return `class Relmio < Formula
+  desc "Set up a private OpenAI-compatible endpoint for self-hosted n8n"
+  homepage "${repositoryUrl}"
+  url "${tarballUrl}"
+  sha256 "${digest}"
+  license "Apache-2.0"
+
+  depends_on "node"
+  depends_on "python" => :build
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    assert_predicate bin/"relmio", :executable?
+    system bin/"relmio", "--version"
+  end
+end
+`;
+}
+
+function normalizeWingetInstaller({ architecture, sha256, url }) {
+  if (!supportedArchitectures.has(architecture)) {
+    throw new Error(`Unsupported WinGet architecture: ${architecture}.`);
+  }
+  return {
+    architecture,
+    sha256: assertSha256(sha256, `WinGet ${architecture} installer SHA-256`).toUpperCase(),
+    url: assertString(url, `WinGet ${architecture} installer URL`),
+  };
+}
+
+export function createWingetManifestFiles({ installers, version }) {
+  if (typeof version !== "string" || !semver.test(version)) {
+    throw new Error("A valid semantic version is required for WinGet manifests.");
+  }
+  if (!Array.isArray(installers) || installers.length === 0) {
+    throw new Error("At least one WinGet installer is required.");
+  }
+
+  const normalizedInstallers = installers
+    .map(normalizeWingetInstaller)
+    .sort((left, right) => left.architecture.localeCompare(right.architecture));
+  const duplicateArchitecture = normalizedInstallers.find(
+    (installer, index) =>
+      index > 0 && installer.architecture === normalizedInstallers[index - 1].architecture,
+  );
+  if (duplicateArchitecture) {
+    throw new Error(
+      `WinGet installer architecture ${duplicateArchitecture.architecture} was supplied more than once.`,
+    );
+  }
+
+  const schemaPrefix = "https://aka.ms/winget-manifest";
+  const header = (type) =>
+    `# yaml-language-server: $schema=${schemaPrefix}.${type}.${manifestVersion}.schema.json\n`;
+  const installerEntries = normalizedInstallers
+    .map(
+      ({ architecture, sha256, url }) => `- Architecture: ${architecture}
+  NestedInstallerFiles:
+    - RelativeFilePath: relmio.exe
+      PortableCommandAlias: relmio
+  InstallerUrl: ${url}
+  InstallerSha256: ${sha256}`,
+    )
+    .join("\n");
+
+  return new Map([
+    [
+      `${packageIdentifier}.yaml`,
+      `${header("version")}
+PackageIdentifier: ${packageIdentifier}
+PackageVersion: ${version}
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: ${manifestVersion}
+`,
+    ],
+    [
+      `${packageIdentifier}.locale.en-US.yaml`,
+      `${header("defaultLocale")}
+PackageIdentifier: ${packageIdentifier}
+PackageVersion: ${version}
+PackageLocale: en-US
+Publisher: ${packagePublisher}
+PublisherUrl: ${repositoryUrl}
+PublisherSupportUrl: ${repositoryUrl}/issues
+PackageName: ${packageName}
+PackageUrl: ${repositoryUrl}
+License: Apache-2.0
+LicenseUrl: ${repositoryUrl}/blob/main/LICENSE
+ShortDescription: Create a private OpenAI-compatible endpoint beside self-hosted n8n.
+Tags:
+  - n8n
+  - oauth
+  - openai
+ManifestType: defaultLocale
+ManifestVersion: ${manifestVersion}
+`,
+    ],
+    [
+      `${packageIdentifier}.installer.yaml`,
+      `${header("installer")}
+PackageIdentifier: ${packageIdentifier}
+PackageVersion: ${version}
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+Commands:
+  - relmio
+Installers:
+${installerEntries}
+ManifestType: installer
+ManifestVersion: ${manifestVersion}
+`,
+    ],
+  ]);
+}
+
+export async function sha256File(path) {
+  const contents = await readFile(path);
+  return createHash("sha256").update(contents).digest("hex");
+}
+
+async function assertFile(path, label) {
+  let metadata;
+  try {
+    metadata = await stat(path);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      throw new Error(`${label} does not exist: ${path}`);
+    }
+    throw error;
+  }
+  if (!metadata.isFile() || metadata.size === 0) {
+    throw new Error(`${label} must be a non-empty regular file: ${path}`);
+  }
+}
+
+export async function createPackageManagerCandidates({
+  npmTarballPath,
+  outputDirectory,
+  packageJson,
+  wingetInstallers = [],
+}) {
+  const { version } = validateReleasePackage(packageJson);
+  const resolvedOutputDirectory = resolve(outputDirectory);
+  if (npmTarballPath === undefined && wingetInstallers.length === 0) {
+    throw new Error("A published npm tarball or at least one WinGet installer is required.");
+  }
+
+  let resolvedNpmTarballPath;
+  if (npmTarballPath !== undefined) {
+    resolvedNpmTarballPath = resolve(npmTarballPath);
+    const expectedNpmTarball = `relmio-${version}.tgz`;
+    if (basename(resolvedNpmTarballPath) !== expectedNpmTarball) {
+      throw new Error(
+        `npm tarball must be named ${expectedNpmTarball}; received ${basename(resolvedNpmTarballPath)}.`,
+      );
+    }
+    await assertFile(resolvedNpmTarballPath, "npm tarball");
+  }
+
+  for (const installer of wingetInstallers) {
+    if (!supportedArchitectures.has(installer.architecture)) {
+      throw new Error(`Unsupported WinGet architecture: ${installer.architecture}.`);
+    }
+    const path = resolve(installer.path);
+    const expectedName = `relmio-${version}-windows-${installer.architecture}.zip`;
+    if (basename(path) !== expectedName) {
+      throw new Error(
+        `WinGet ${installer.architecture} archive must be named ${expectedName}; received ${basename(path)}.`,
+      );
+    }
+    await assertFile(path, `WinGet ${installer.architecture} archive`);
+  }
+
+  try {
+    await access(resolvedOutputDirectory);
+    throw new Error(
+      `Output directory already exists: ${resolvedOutputDirectory}. Choose a new empty staging directory.`,
+    );
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  const generatedPaths = [];
+  if (resolvedNpmTarballPath !== undefined) {
+    const formulaPath = join(
+      resolvedOutputDirectory,
+      "homebrew-tap",
+      "Formula",
+      "relmio.rb",
+    );
+    const formula = createHomebrewFormula({
+      sha256: await sha256File(resolvedNpmTarballPath),
+      version,
+    });
+
+    await mkdir(dirname(formulaPath), { recursive: true });
+    await writeFile(formulaPath, formula, { encoding: "utf8", flag: "wx" });
+    generatedPaths.push(formulaPath);
+  }
+
+  if (wingetInstallers.length > 0) {
+    const wingetDirectory = join(
+      resolvedOutputDirectory,
+      "winget-pkgs",
+      "manifests",
+      "d",
+      packagePublisher,
+      packageName,
+      version,
+    );
+    const installerMetadata = await Promise.all(
+      wingetInstallers.map(async ({ architecture, path }) => ({
+        architecture,
+        sha256: await sha256File(resolve(path)),
+        url: wingetInstallerUrl({ architecture, version }),
+      })),
+    );
+    const manifests = createWingetManifestFiles({
+      installers: installerMetadata,
+      version,
+    });
+
+    await mkdir(wingetDirectory, { recursive: true });
+    for (const [name, contents] of manifests) {
+      const path = join(wingetDirectory, name);
+      await writeFile(path, contents, { encoding: "utf8", flag: "wx" });
+      generatedPaths.push(path);
+    }
+  }
+
+  return { generatedPaths, outputDirectory: resolvedOutputDirectory, version };
+}
+
+function parseArguments(argumentsList) {
+  const options = {};
+  const accepted = new Set([
+    "--npm-tarball",
+    "--output-dir",
+    "--winget-arm64",
+    "--winget-x64",
+  ]);
+
+  for (let index = 0; index < argumentsList.length; index += 1) {
+    const argument = argumentsList[index];
+    if (!accepted.has(argument)) {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    if (options[argument] !== undefined) {
+      throw new Error(`Argument supplied more than once: ${argument}`);
+    }
+    const value = argumentsList[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`${argument} requires a value.`);
+    }
+    options[argument] = value;
+    index += 1;
+  }
+
+  for (const required of ["--output-dir"]) {
+    if (options[required] === undefined) {
+      throw new Error(`${required} is required.`);
+    }
+  }
+  return options;
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const packageJson = JSON.parse(
+    await readFile(join(projectRoot, "package.json"), "utf8"),
+  );
+  const wingetInstallers = [
+    ["x64", options["--winget-x64"]],
+    ["arm64", options["--winget-arm64"]],
+  ]
+    .filter(([, path]) => path !== undefined)
+    .map(([architecture, path]) => ({ architecture, path }));
+  const result = await createPackageManagerCandidates({
+    npmTarballPath: options["--npm-tarball"],
+    outputDirectory: options["--output-dir"],
+    packageJson,
+    wingetInstallers,
+  });
+
+  console.log(`Generated package-manager candidates for v${result.version}.`);
+  for (const path of result.generatedPaths) {
+    console.log(path);
+  }
+  console.log("No Homebrew tap, GitHub Release asset, or WinGet manifest was published.");
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,40 +1,86 @@
 #!/usr/bin/env node
 
 import { randomBytes } from "node:crypto";
+import { realpathSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 
 import { attachBrowserReopenOnEnter, openBrowser } from "./browser.js";
 import { startWizardServer } from "./web/server.js";
 
-const sessionToken = randomBytes(32).toString("base64url");
-const wizard = await startWizardServer({ sessionToken });
-const url = `${wizard.origin}/?session=${sessionToken}`;
+const cliPath = fileURLToPath(import.meta.url);
+const packageJsonUrl = new URL("../package.json", import.meta.url);
 
-console.log("");
-console.log("Relmio");
-console.log("---------");
-console.log(`Local wizard: ${url}`);
-console.log("");
-console.log("This creates a separate sidecar and never restarts n8n.");
-console.log("Keep this Terminal window open while using the wizard.");
-console.log("Press Control+C to stop.");
-console.log("");
-
-openBrowser(url);
-const detachBrowserReopen = attachBrowserReopenOnEnter({ url });
-
-let closing = false;
-async function close() {
-  if (closing) {
-    return;
+export function isCliEntryPath(entryPath, realpath = realpathSync) {
+  if (typeof entryPath !== "string" || entryPath === "") {
+    return false;
   }
-  closing = true;
-  detachBrowserReopen();
-  await wizard.close();
+  try {
+    return realpath(entryPath) === realpath(cliPath);
+  } catch {
+    return false;
+  }
 }
 
-process.once("SIGINT", async () => {
-  await close();
-});
-process.once("SIGTERM", async () => {
-  await close();
-});
+export function cliMode(argumentsList) {
+  return argumentsList.length === 1 &&
+    (argumentsList[0] === "--version" || argumentsList[0] === "-v")
+    ? "version"
+    : "wizard";
+}
+
+export async function runCli({
+  argumentsList = process.argv.slice(2),
+  log = console.log,
+  readPackage = () => readFile(packageJsonUrl, "utf8"),
+} = {}) {
+  if (cliMode(argumentsList) === "version") {
+    const packageJson = JSON.parse(await readPackage());
+    if (typeof packageJson.version !== "string" || packageJson.version === "") {
+      throw new Error("Relmio package metadata does not contain a version.");
+    }
+    log(packageJson.version);
+    return;
+  }
+
+  const sessionToken = randomBytes(32).toString("base64url");
+  const wizard = await startWizardServer({ sessionToken });
+  const url = `${wizard.origin}/?session=${sessionToken}`;
+
+  log("");
+  log("Relmio");
+  log("---------");
+  log(`Local wizard: ${url}`);
+  log("");
+  log("This creates a separate sidecar and never restarts n8n.");
+  log("Keep this Terminal window open while using the wizard.");
+  log("Press Control+C to stop.");
+  log("");
+
+  openBrowser(url);
+  const detachBrowserReopen = attachBrowserReopenOnEnter({ url });
+
+  let closing = false;
+  async function close() {
+    if (closing) {
+      return;
+    }
+    closing = true;
+    detachBrowserReopen();
+    await wizard.close();
+  }
+
+  process.once("SIGINT", async () => {
+    await close();
+  });
+  process.once("SIGTERM", async () => {
+    await close();
+  });
+}
+
+if (isCliEntryPath(process.argv[1])) {
+  runCli().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+import { cliMode, isCliEntryPath, runCli } from "../src/cli.js";
+
+const execFileAsync = promisify(execFile);
+
+test("CLI recognizes only the explicit version flags", () => {
+  assert.equal(cliMode(["--version"]), "version");
+  assert.equal(cliMode(["-v"]), "version");
+  assert.equal(cliMode([]), "wizard");
+  assert.equal(cliMode(["--version", "extra"]), "wizard");
+});
+
+test("version mode prints package metadata without starting the wizard", async () => {
+  const output = [];
+  await runCli({
+    argumentsList: ["--version"],
+    log: (line) => output.push(line),
+    readPackage: async () => '{"version":"1.2.3"}',
+  });
+  assert.deepEqual(output, ["1.2.3"]);
+});
+
+test("CLI entry detection resolves package-manager symlinks", () => {
+  const sourcePath = resolve("src/cli.js");
+  const aliases = new Map([
+    ["/package-manager/bin/relmio", sourcePath],
+    [sourcePath, sourcePath],
+  ]);
+  assert.equal(isCliEntryPath("/package-manager/bin/relmio", (path) => aliases.get(path)), true);
+  assert.equal(isCliEntryPath("/other/command", (path) => aliases.get(path) ?? path), false);
+});
+
+test("the installed CLI version command exits with the repository version", async () => {
+  const packageJson = JSON.parse(await readFile("package.json", "utf8"));
+  const { stderr, stdout } = await execFileAsync(
+    process.execPath,
+    ["src/cli.js", "--version"],
+    { cwd: process.cwd() },
+  );
+
+  assert.equal(stderr, "");
+  assert.equal(stdout.trim(), packageJson.version);
+});
+
+test(
+  "a symlinked installed CLI runs the version command",
+  { skip: process.platform === "win32" },
+  async () => {
+    const packageJson = JSON.parse(await readFile("package.json", "utf8"));
+    const directory = await mkdtemp(join(tmpdir(), "relmio-cli-"));
+    const commandPath = join(directory, "relmio");
+    try {
+      await symlink(resolve("src/cli.js"), commandPath, "file");
+      const { stderr, stdout } = await execFileAsync(commandPath, ["--version"]);
+      assert.equal(stderr, "");
+      assert.equal(stdout.trim(), packageJson.version);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  },
+);

--- a/test/documentation.test.js
+++ b/test/documentation.test.js
@@ -103,20 +103,41 @@ test("release guidance covers the Windows probe, browser relaunch, and blank OAu
   assert.match(troubleshooting, /white `about:blank` tab/u);
 });
 
-test("Windows Command Prompt documentation calls the system PowerShell executable", async () => {
+test("Windows Command Prompt documentation uses the PowerShell-free native bootstrap", async () => {
   const [readme, npmReadme, troubleshooting] = await Promise.all([
     readFile("README.md", "utf8"),
     readFile("npm/README.md", "utf8"),
     readFile("docs/troubleshooting.md", "utf8"),
   ]);
-  const command =
-    '"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"';
-
   for (const guide of [readme, npmReadme, troubleshooting]) {
-    assert.ok(guide.includes(command));
+    assert.match(guide, /for \/f "delims=" %F/u);
+    assert.match(guide, /relmio-install-%RANDOM%-%RANDOM%-%RANDOM%\.cmd/u);
+    assert.match(guide, /--remove-on-error/u);
+    assert.match(guide, /RELMIO_SELF_DELETE=%~F/u);
+    assert.doesNotMatch(guide, /-o install\.cmd/u);
+    assert.match(guide, /PowerShell-free/u);
+    assert.match(guide, /Please wait/u);
   }
   assert.match(troubleshooting, /VS Code embedded browser/u);
   assert.match(troubleshooting, /validated manual link/u);
+});
+
+test("public guides hide package-manager commands until their catalogs are live", async () => {
+  const [readme, npmReadme, troubleshooting, maintainerGuide] = await Promise.all([
+    readFile("README.md", "utf8"),
+    readFile("npm/README.md", "utf8"),
+    readFile("docs/troubleshooting.md", "utf8"),
+    readFile("packaging/package-managers.md", "utf8"),
+  ]);
+
+  for (const guide of [readme, npmReadme, troubleshooting]) {
+    assert.doesNotMatch(guide, /brew install Demonbane18\/relmio\/relmio/u);
+    assert.doesNotMatch(guide, /winget install --exact --id Demonbane18\.Relmio/u);
+    assert.match(guide, /Homebrew tap publication/iu);
+    assert.match(guide, /WinGet catalog approval/iu);
+  }
+  assert.match(maintainerGuide, /exact\s+immutable tarball downloaded back from the registry/iu);
+  assert.match(maintainerGuide, /Demonbane18\.Relmio/u);
 });
 
 test("n8n configuration guide provides copy-paste model and HTTP recipes", async () => {

--- a/test/install-cmd-script.test.js
+++ b/test/install-cmd-script.test.js
@@ -1,0 +1,485 @@
+import assert from "node:assert/strict";
+import { execFile, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { access, copyFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const installScript = resolve("web/public/install.cmd");
+
+test("CMD installer keeps a native checksum-verified portable Windows runtime path", async () => {
+  const script = await readFile(installScript, "utf8");
+
+  assert.doesNotMatch(script, /powershell|pwsh/iu);
+  assert.doesNotMatch(script, /runas|executionpolicy|uac/iu);
+  assert.doesNotMatch(script, /RELMIO_TEST_SYSTEM32/u);
+  assert.match(script, /set "RELMIO_SYSTEM32=%SystemRoot%\\System32"/u);
+  assert.match(script, /set "RELMIO_CURL=%RELMIO_SYSTEM32%\\curl\.exe"/u);
+  assert.match(script, /set "RELMIO_CERTUTIL=%RELMIO_SYSTEM32%\\certutil\.exe"/u);
+  assert.match(script, /set "RELMIO_TAR=%RELMIO_SYSTEM32%\\tar\.exe"/u);
+  assert.match(script, /RELMIO_NODE_VERSION=v22\.23\.2/u);
+  assert.match(script, /1177b4137ba5adaa56354ae40f1080c7450e8ae09cecb47da459d1c52ac99f97/u);
+  assert.match(script, /fec025a6da31757e3b6af84c5a1628e9d38442ca99a2161091d78f2fcfa35ef3/u);
+  assert.doesNotMatch(script, /SHASUMS256|MANIFEST_MATCH/u);
+  assert.match(script, /:checksum/u);
+  assert.match(script, /Node\.js download checksum did not match; nothing was executed/u);
+  assert.match(script, /rmdir \/s \/q "%RELMIO_TEMPORARY_DIRECTORY%"/u);
+  assert.match(script, /--yes --ignore-scripts relmio@latest/u);
+  assert.match(script, /Installing a temporary Node\.js 22 runtime\. Please wait/u);
+  assert.match(script, /Extracting the verified temporary Node\.js 22 runtime\. Please wait/u);
+});
+
+function writeNativeToolWrapper() {
+  return `using System;
+using System.IO;
+using System.Diagnostics;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text.RegularExpressions;
+
+public static class Program {
+  private static void Log(string variable, string value) {
+    var path = Environment.GetEnvironmentVariable(variable);
+    if (!String.IsNullOrEmpty(path)) File.AppendAllText(path, value + Environment.NewLine);
+  }
+
+  private static void CopyDirectory(string source, string destination) {
+    Directory.CreateDirectory(destination);
+    foreach (var file in Directory.GetFiles(source)) {
+      File.Copy(file, Path.Combine(destination, Path.GetFileName(file)), true);
+    }
+    foreach (var directory in Directory.GetDirectories(source)) {
+      CopyDirectory(directory, Path.Combine(destination, Path.GetFileName(directory)));
+    }
+  }
+
+  private static int FindStr(string[] args) {
+    var patternArgument = args.FirstOrDefault(value => value.StartsWith("/c:", StringComparison.OrdinalIgnoreCase));
+    var pattern = patternArgument == null ? "" : patternArgument.Substring(3);
+    var values = args.Where(value => !value.StartsWith("/")).ToArray();
+    var input = values.Length > 0 ? File.ReadAllText(values[values.Length - 1]) : Console.In.ReadToEnd();
+    var lines = input.Split((char)10).Select(line => line.TrimEnd((char)13)).Where(line => line.Length > 0);
+    if (pattern.Contains("node-v22")) {
+      var architecture = pattern.Contains("arm64") ? "arm64" : "x64";
+      lines = lines.Where(line => line.Length > 64 && line.Substring(0, 64).All(Uri.IsHexDigit) && line.Contains("  node-v22.") && line.EndsWith("-win-" + architecture + ".zip"));
+    } else if (pattern.StartsWith("v")) {
+      lines = lines.Where(line => line.StartsWith("v") && line.Substring(1).Split('.').Length == 3 && line.Substring(1).Split('.').All(part => part.Length > 0 && part.All(Char.IsDigit)));
+    } else {
+      lines = lines.Where(line => line.Length == 64 && line.All(Uri.IsHexDigit));
+    }
+    var matches = lines.ToArray();
+    foreach (var match in matches) Console.WriteLine(match);
+    return matches.Length == 0 ? 1 : 0;
+  }
+
+  public static int Main(string[] args) {
+    var tool = Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName).ToLowerInvariant();
+    if ((tool == "node.exe" || tool == "installed-node.exe") && args.Length == 1 && args[0] == "--version") {
+      Console.WriteLine(Environment.GetEnvironmentVariable("RELMIO_TEST_NODE_VERSION"));
+      return 0;
+    }
+    if (tool == "where.exe") {
+      Log("RELMIO_TEST_TOOL_LOG", "where " + String.Join(" ", args));
+      if (args.Length == 1 && args[0] == "node.exe") Console.WriteLine(Environment.GetEnvironmentVariable("RELMIO_TEST_PORTABLE_OLD_NODE"));
+      if (args.Length == 1 && args[0] == "npx.cmd") Console.WriteLine(Environment.GetEnvironmentVariable("RELMIO_TEST_PORTABLE_NPX"));
+      return 0;
+    }
+    if (tool == "findstr.exe") return FindStr(args);
+    if (tool == "curl.exe") {
+      Log("RELMIO_TEST_NETWORK_TOOL_LOG", "curl");
+      var outputIndex = Array.IndexOf(args, "-o");
+      if (outputIndex < 1 || outputIndex + 1 >= args.Length) return 91;
+      var url = args[outputIndex - 1];
+      var source = url == "https://nodejs.org/download/release/latest-v22.x/SHASUMS256.txt"
+        ? Environment.GetEnvironmentVariable("RELMIO_TEST_MANIFEST")
+        : url == Environment.GetEnvironmentVariable("RELMIO_TEST_ARCHIVE_URL")
+          ? Environment.GetEnvironmentVariable("RELMIO_TEST_ARCHIVE")
+          : null;
+      if (String.IsNullOrEmpty(source)) return 92;
+      File.Copy(source, args[outputIndex + 1], true);
+      return 0;
+    }
+    if (tool == "certutil.exe") {
+      Log("RELMIO_TEST_NETWORK_TOOL_LOG", "certutil");
+      if (args.Length != 3 || args[0] != "-hashfile" || args[2] != "SHA256") return 93;
+      using (var hash = SHA256.Create()) {
+        var digest = BitConverter.ToString(hash.ComputeHash(File.ReadAllBytes(args[1]))).Replace("-", "");
+        Console.WriteLine("SHA256 hash of file:");
+        Console.WriteLine(digest);
+        Console.WriteLine("CertUtil: -hashfile command completed successfully.");
+      }
+      return 0;
+    }
+    if (tool == "tar.exe") {
+      Log("RELMIO_TEST_NETWORK_TOOL_LOG", "tar " + String.Join(" ", args));
+      var destinationIndex = Array.IndexOf(args, "-C");
+      if (args.Length < 4 || args[0] != "-xf" || destinationIndex < 0 || destinationIndex + 1 >= args.Length) return 94;
+      CopyDirectory(Environment.GetEnvironmentVariable("RELMIO_TEST_RUNTIME_DIRECTORY"), args[destinationIndex + 1]);
+      return 0;
+    }
+    return 90;
+  }
+}
+`;
+}
+
+async function buildNativeToolWrapper(root) {
+  const compiler = join(
+    process.env.SystemRoot,
+    "Microsoft.NET",
+    "Framework64",
+    "v4.0.30319",
+    "csc.exe",
+  );
+  await access(compiler);
+  const source = join(root, "node-version-wrapper.cs");
+  const executable = join(root, "node-version-wrapper.exe");
+  await writeFile(source, writeNativeToolWrapper(), "utf8");
+  await execFileAsync(compiler, ["/nologo", `/out:${executable}`, source]);
+  return executable;
+}
+
+async function createInstalledNodeEnvironment({ npxExitCode = 0 } = {}) {
+  const root = await mkdtemp(join(tmpdir(), "relmio-install-cmd-test-"));
+  const fakeBin = join(root, "bin");
+  const temporaryDirectory = join(root, "tmp");
+  const log = join(root, "invocation.log");
+  const wrapper = await buildNativeToolWrapper(root);
+
+  await mkdir(fakeBin);
+  await mkdir(temporaryDirectory);
+  await copyFile(wrapper, join(fakeBin, "node.exe"));
+  await writeFile(
+    join(fakeBin, "npx.cmd"),
+    [
+      "@echo off",
+      '> "%RELMIO_TEST_LOG%" echo %~1',
+      '>> "%RELMIO_TEST_LOG%" echo %~2',
+      '>> "%RELMIO_TEST_LOG%" echo %~3',
+      `exit /b ${npxExitCode}`,
+      "",
+    ].join("\r\n"),
+    "utf8",
+  );
+
+  return {
+    fakeBin,
+    log,
+    root,
+    temporaryDirectory,
+    env: {
+      ...process.env,
+      PATH: `${fakeBin};${process.env.PATH}`,
+      RELMIO_TEST_LOG: log,
+      RELMIO_TEST_NODE_VERSION: "v22.16.0",
+      TEMP: temporaryDirectory,
+      TMP: temporaryDirectory,
+    },
+  };
+}
+
+async function createPortableRuntime(
+  root,
+  { hostileManifest = false, validChecksum = true } = {},
+) {
+  const version = "v22.23.2";
+  const archiveName = `node-${version}-win-x64.zip`;
+  const runtimeParent = join(root, "portable-runtime");
+  const runtimeDirectory = join(runtimeParent, archiveName.slice(0, -4));
+  const npmDirectory = join(runtimeDirectory, "node_modules", "npm", "bin");
+  const archive = join(root, archiveName);
+  const manifest = join(root, "SHASUMS256.txt");
+  const hostileMarker = join(root, "manifest-command-executed.txt");
+  const log = join(root, "portable-invocation.log");
+
+  await mkdir(npmDirectory, { recursive: true });
+  await copyFile(process.execPath, join(runtimeDirectory, "node.exe"));
+  await writeFile(
+    join(npmDirectory, "npx-cli.js"),
+    `const { appendFileSync, writeFileSync } = require("node:fs");
+const { spawnSync } = require("node:child_process");
+
+const log = process.env.RELMIO_TEST_LOG;
+writeFileSync(log, [process.argv[1], ...process.argv.slice(2)].join("\\n") + "\\n");
+const child = spawnSync("node", ["--version"], { encoding: "utf8" });
+if (child.status !== 0) process.exit(child.status || 1);
+appendFileSync(log, "child-node-ok\\n");
+`,
+    "utf8",
+  );
+  await writeFile(archive, "portable Windows Node fixture\n", "utf8");
+  const digest = createHash("sha256").update(await readFile(archive)).digest("hex");
+  await writeFile(
+    manifest,
+    [
+      hostileManifest
+        ? `abc&echo(compromised>${hostileMarker}  ${archiveName}`
+        : null,
+      `${validChecksum ? digest : "0".repeat(64)}  ${archiveName}`,
+      "",
+    ]
+      .filter((line) => line !== null)
+      .join("\n"),
+    "utf8",
+  );
+
+  return {
+    archive,
+    archiveUrl: `https://nodejs.org/download/release/${version}/${archiveName}`,
+    hostileMarker,
+    expectedChecksum: validChecksum ? digest : "0".repeat(64),
+    log,
+    manifest,
+    runtimeParent,
+  };
+}
+
+async function createPortableEnvironment(
+  { hostileManifest = false, validChecksum = true } = {},
+) {
+  const root = await mkdtemp(join(tmpdir(), "relmio-install-cmd-portable-test-"));
+  const system32 = join(root, "System32");
+  const temporaryDirectory = join(root, "tmp");
+  const networkToolLog = join(root, "network-tools.log");
+  const fixture = await createPortableRuntime(root, {
+    hostileManifest,
+    validChecksum,
+  });
+  const wrapper = await buildNativeToolWrapper(root);
+  const oldNode = join(root, "installed-node.exe");
+
+  await mkdir(system32);
+  await mkdir(temporaryDirectory);
+  await Promise.all(
+    ["curl.exe", "certutil.exe", "tar.exe", "where.exe"].map(
+      (tool) => copyFile(wrapper, join(system32, tool)),
+    ),
+  );
+  await copyFile(wrapper, oldNode);
+  const fixtureInstallScript = join(root, "install.cmd");
+  const productionInstallScript = await readFile(installScript, "utf8");
+  const system32Assignment = 'set "RELMIO_SYSTEM32=%SystemRoot%\\System32"';
+  const findstrAssignment =
+    'set "RELMIO_FINDSTR=%RELMIO_SYSTEM32%\\findstr.exe"';
+  const expectedChecksumAssignment =
+    'set "RELMIO_EXPECTED_CHECKSUM=1177b4137ba5adaa56354ae40f1080c7450e8ae09cecb47da459d1c52ac99f97"';
+  assert.ok(productionInstallScript.includes(system32Assignment));
+  await writeFile(
+    fixtureInstallScript,
+    productionInstallScript
+      .replace(/\r?\n/gu, "\r\n")
+      .replace(system32Assignment, `set "RELMIO_SYSTEM32=${system32}"`)
+      .replace(
+        findstrAssignment,
+        `set "RELMIO_FINDSTR=${join(process.env.SystemRoot, "System32", "findstr.exe")}"`,
+      )
+      .replace(
+        expectedChecksumAssignment,
+        `set "RELMIO_EXPECTED_CHECKSUM=${fixture.expectedChecksum}"`,
+      ),
+    "utf8",
+  );
+  assert.match(
+    await readFile(fixtureInstallScript, "utf8"),
+    /RELMIO_FINDSTR=C:\\Windows\\System32\\findstr\.exe/iu,
+  );
+
+  return {
+    fixture,
+    fixtureInstallScript,
+    networkToolLog,
+    root,
+    temporaryDirectory,
+    env: {
+      ...process.env,
+      RELMIO_TEST_ARCHIVE: fixture.archive,
+      RELMIO_TEST_ARCHIVE_URL: fixture.archiveUrl,
+      RELMIO_TEST_LOG: fixture.log,
+      RELMIO_TEST_MANIFEST: fixture.manifest,
+      RELMIO_TEST_NETWORK_TOOL_LOG: networkToolLog,
+      RELMIO_TEST_NODE_VERSION: "v18.20.0",
+      RELMIO_TEST_PORTABLE_OLD_NODE: oldNode,
+      RELMIO_TEST_PORTABLE_NPX: "",
+      RELMIO_TEST_RUNTIME_DIRECTORY: fixture.runtimeParent,
+      TEMP: temporaryDirectory,
+      TMP: temporaryDirectory,
+    },
+  };
+}
+
+async function runCmdInstaller(env, script = installScript) {
+  const commandProcessor = process.env.ComSpec || join(process.env.SystemRoot, "System32", "cmd.exe");
+  return execFileAsync(commandProcessor, ["/d", "/c", script], { env });
+}
+
+async function runCommandPrompt({ command, cwd, env }) {
+  const commandProcessor =
+    process.env.ComSpec || join(process.env.SystemRoot, "System32", "cmd.exe");
+  return new Promise((resolve, reject) => {
+    const child = spawn(commandProcessor, ["/d", "/q"], { cwd, env });
+    let stderr = "";
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) {
+        resolve({ stderr, stdout });
+      } else {
+        reject(new Error(`Command Prompt exited with ${code}: ${stderr || stdout}`));
+      }
+    });
+    child.stdin.end(`${command}\r\nexit /b %errorlevel%\r\n`);
+  });
+}
+
+async function documentedCmdInstallCommand() {
+  const readme = await readFile("README.md", "utf8");
+  const match = readme.match(
+    /### Windows Command Prompt\s+```bat\r?\n(?<command>[^\r\n]+)\r?\n```/u,
+  );
+  assert.ok(match?.groups?.command);
+  return match.groups.command;
+}
+
+test(
+  "CMD installer reuses Node 22 with npx without creating a portable runtime",
+  { skip: process.platform !== "win32" },
+  async (t) => {
+    const setup = await createInstalledNodeEnvironment();
+    t.after(() => rm(setup.root, { recursive: true, force: true }));
+
+    const { stdout } = await runCmdInstaller(setup.env);
+
+    assert.match(stdout, /Using installed Node\.js 22 runtime/u);
+    assert.deepEqual((await readFile(setup.log, "utf8")).trim().split(/\r?\n/u), [
+      "--yes",
+      "--ignore-scripts",
+      "relmio@latest",
+    ]);
+    assert.deepEqual(await readdir(setup.temporaryDirectory), []);
+  },
+);
+
+test(
+  "CMD installer preserves the npx failure status from an installed Node runtime",
+  { skip: process.platform !== "win32" },
+  async (t) => {
+    const setup = await createInstalledNodeEnvironment({ npxExitCode: 23 });
+    t.after(() => rm(setup.root, { recursive: true, force: true }));
+
+    await assert.rejects(runCmdInstaller(setup.env), { code: 23 });
+    assert.deepEqual((await readFile(setup.log, "utf8")).trim().split(/\r?\n/u), [
+      "--yes",
+      "--ignore-scripts",
+      "relmio@latest",
+    ]);
+    assert.deepEqual(await readdir(setup.temporaryDirectory), []);
+  },
+);
+
+test(
+  "documented CMD bootstrap preserves existing files and cleans its temporary script",
+  { skip: process.platform !== "win32" },
+  async (t) => {
+    const setup = await createInstalledNodeEnvironment();
+    t.after(() => rm(setup.root, { recursive: true, force: true }));
+    const workingDirectory = join(setup.root, "working");
+    const existingScript = join(workingDirectory, "install.cmd");
+    await mkdir(workingDirectory);
+    await writeFile(existingScript, "existing user file\r\n", "utf8");
+    await writeFile(
+      join(setup.fakeBin, "curl.cmd"),
+      [
+        "@echo off",
+        'if not "%~4"=="-o" exit /b 91',
+        'copy /y "%RELMIO_TEST_INSTALL_SOURCE%" "%~5" >nul',
+        "exit /b %errorlevel%",
+        "",
+      ].join("\r\n"),
+      "utf8",
+    );
+
+    await runCommandPrompt({
+      command: await documentedCmdInstallCommand(),
+      cwd: workingDirectory,
+      env: {
+        ...setup.env,
+        RELMIO_TEST_INSTALL_SOURCE: installScript,
+      },
+    });
+
+    assert.equal(await readFile(existingScript, "utf8"), "existing user file\r\n");
+    assert.deepEqual(await readdir(setup.temporaryDirectory), []);
+  },
+);
+
+test(
+  "CMD installer downloads, verifies, extracts, and removes a temporary runtime when Node is old",
+  { skip: process.platform !== "win32" },
+  async (t) => {
+    const setup = await createPortableEnvironment();
+    t.after(() => rm(setup.root, { recursive: true, force: true }));
+
+    const { stdout } = await runCmdInstaller(
+      setup.env,
+      setup.fixtureInstallScript,
+    );
+    const invocation = (await readFile(setup.fixture.log, "utf8")).trim().split(/\r?\n/u);
+    const tools = (await readFile(setup.networkToolLog, "utf8")).trim().split(/\r?\n/u);
+
+    assert.match(stdout, /Installing a temporary Node\.js 22 runtime\. Please wait/u);
+    assert.match(stdout, /Verified Node\.js download/u);
+    assert.match(stdout, /Extracting the verified temporary Node\.js 22 runtime\. Please wait/u);
+    assert.match(invocation[0].replaceAll("\\", "/"), /node-v22\.23\.2-win-x64\/node_modules\/npm\/bin\/npx-cli\.js$/u);
+    assert.deepEqual(invocation.slice(1), ["--yes", "--ignore-scripts", "relmio@latest", "child-node-ok"]);
+    assert.deepEqual(tools.slice(0, 2), ["curl", "certutil"]);
+    assert.equal(tools.length, 3);
+    assert.match(tools[2], /^tar -xf .*node-v22\.23\.2-win-x64\.zip -C /u);
+    assert.deepEqual(await readdir(setup.temporaryDirectory), []);
+  },
+);
+
+test(
+  "CMD installer rejects a bad checksum before extraction or Relmio execution",
+  { skip: process.platform !== "win32" },
+  async (t) => {
+    const setup = await createPortableEnvironment({ validChecksum: false });
+    t.after(() => rm(setup.root, { recursive: true, force: true }));
+
+    await assert.rejects(
+      runCmdInstaller(setup.env, setup.fixtureInstallScript),
+      /Node\.js download checksum did not match; nothing was executed/u,
+    );
+    const tools = (await readFile(setup.networkToolLog, "utf8")).trim().split(/\r?\n/u);
+    assert.deepEqual(tools.slice(0, 2), ["curl", "certutil"]);
+    assert.equal(tools.some((tool) => tool.startsWith("tar ")), false);
+    await assert.rejects(readFile(setup.fixture.log, "utf8"), { code: "ENOENT" });
+    assert.deepEqual(await readdir(setup.temporaryDirectory), []);
+  },
+);
+
+test(
+  "CMD installer never consumes remote checksum-manifest text",
+  { skip: process.platform !== "win32" },
+  async (t) => {
+    const setup = await createPortableEnvironment({ hostileManifest: true });
+    t.after(() => rm(setup.root, { recursive: true, force: true }));
+
+    await runCmdInstaller(setup.env, setup.fixtureInstallScript);
+
+    await assert.rejects(readFile(setup.fixture.hostileMarker, "utf8"), {
+      code: "ENOENT",
+    });
+    assert.deepEqual(await readdir(setup.temporaryDirectory), []);
+  },
+);

--- a/test/install-powershell-script.test.js
+++ b/test/install-powershell-script.test.js
@@ -49,6 +49,9 @@ test("PowerShell installer validates the official Windows runtime before executi
   assert.match(script, /Expand-Archive/u);
   assert.match(script, /--ignore-scripts/u);
   assert.match(script, /relmio@latest/u);
+  assert.match(script, /Installing a temporary Node\.js 22 runtime\. Please wait/u);
+  assert.match(script, /Verifying the Node\.js SHA-256 checksum\. Please wait/u);
+  assert.match(script, /Extracting the verified temporary Node\.js 22 runtime\. Please wait/u);
   assert.doesNotMatch(script, /\bexit\b/iu);
 });
 
@@ -77,6 +80,7 @@ test(
 
     const root = await mkdtemp(join(tmpdir(), "relmio-powershell-test-"));
     const fakeBin = join(root, "bin");
+    const downloadLog = join(root, "unexpected-download.log");
     const log = join(root, "invocation.log");
     const wrapper = join(root, "invoke-installer.ps1");
     t.after(() => rm(root, { recursive: true, force: true }));
@@ -133,7 +137,7 @@ test(
       [
         '$ErrorActionPreference = "Continue"',
         '$ProgressPreference = "Continue"',
-        'function Invoke-WebRequest { throw "The test refused an unexpected download." }',
+        'function Invoke-WebRequest { Add-Content -LiteralPath $env:RELMIO_DOWNLOAD_LOG -Value "called"; throw "The test refused an unexpected download." }',
         'Invoke-Expression (Get-Content -LiteralPath $env:RELMIO_INSTALL_SCRIPT -Raw)',
         'Write-Output "PREFERENCES:$ErrorActionPreference/$ProgressPreference"',
         "",
@@ -149,6 +153,7 @@ test(
           ...process.env,
           PATH: `${fakeBin}${delimiter}${process.env.PATH}`,
           RELMIO_INSTALL_SCRIPT: resolve(installScript),
+          RELMIO_DOWNLOAD_LOG: downloadLog,
           RELMIO_TEST_LOG: log,
         },
       },
@@ -161,5 +166,6 @@ test(
       "--ignore-scripts",
       "relmio@latest",
     ]);
+    await assert.rejects(readFile(downloadLog, "utf8"), { code: "ENOENT" });
   },
 );

--- a/test/install-script.test.js
+++ b/test/install-script.test.js
@@ -309,6 +309,7 @@ test(
   async (t) => {
     const root = await mkdtemp(join(tmpdir(), "relmio-installed-node-test-"));
     const fakeBin = join(root, "bin");
+    const downloadLog = join(root, "unexpected-download.log");
     const log = join(root, "invocation.log");
     t.after(() => rm(root, { recursive: true, force: true }));
 
@@ -321,12 +322,16 @@ test(
       join(fakeBin, "npx"),
       '#!/bin/sh\nprintf "%s\\n" "$@" > "$RELMIO_TEST_LOG"\n',
     );
-    await writeExecutable(join(fakeBin, "curl"), "#!/bin/sh\nexit 97\n");
+    await writeExecutable(
+      join(fakeBin, "curl"),
+      '#!/bin/sh\nprintf "curl\\n" >> "$RELMIO_TEST_DOWNLOAD_LOG"\nexit 97\n',
+    );
 
     const { stdout } = await execFileAsync("/bin/sh", [installScript], {
       env: {
         ...process.env,
         PATH: `${fakeBin}:${process.env.PATH}`,
+        RELMIO_TEST_DOWNLOAD_LOG: downloadLog,
         RELMIO_TEST_LOG: log,
       },
     });
@@ -337,6 +342,7 @@ test(
       "--ignore-scripts",
       "relmio@latest",
     ]);
+    await assert.rejects(readFile(downloadLog, "utf8"), { code: "ENOENT" });
   },
 );
 
@@ -352,7 +358,9 @@ test(
     });
     const invocation = (await readFile(setup.log, "utf8")).trim().split("\n");
 
-    assert.match(stdout, /Downloading a temporary Node\.js 22 runtime/u);
+    assert.match(stdout, /Installing a temporary Node\.js 22 runtime\. Please wait/u);
+    assert.match(stdout, /Verifying the Node\.js SHA-256 checksum\. Please wait/u);
+    assert.match(stdout, /Extracting the verified temporary Node\.js 22 runtime\. Please wait/u);
     assert.match(stdout, /Verified Node\.js download/u);
     assert.match(
       invocation[0],

--- a/test/package-manager.test.js
+++ b/test/package-manager.test.js
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { deflateRawSync, inflateRawSync } from "node:zlib";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  buildWingetPortablePackage,
+  createDeterministicZip,
+  crc32,
+  peMachine,
+  validatePeArchitecture,
+} from "../scripts/build-winget-portable-package.js";
+import {
+  createHomebrewFormula,
+  createPackageManagerCandidates,
+  createWingetManifestFiles,
+  registryTarballUrl,
+  validateReleasePackage,
+  wingetInstallerUrl,
+} from "../scripts/generate-package-manager-manifests.js";
+
+const packageJson = {
+  license: "Apache-2.0",
+  name: "relmio",
+  repository: { url: "git+https://github.com/Demonbane18/relmio.git" },
+  version: "1.2.3",
+};
+const repositoryVersion = JSON.parse(
+  await readFile("package.json", "utf8"),
+).version;
+const digest = "a".repeat(64);
+
+function createPe(machine) {
+  const executable = Buffer.alloc(0x100);
+  executable.write("MZ", 0, "ascii");
+  executable.writeUInt32LE(0x80, 0x3c);
+  executable.write("PE\0\0", 0x80, "ascii");
+  executable.writeUInt16LE(machine, 0x84);
+  return executable;
+}
+
+function extractZipEntries(archive) {
+  const entries = new Map();
+  let offset = 0;
+  while (archive.readUInt32LE(offset) === 0x04034b50) {
+    const compressedSize = archive.readUInt32LE(offset + 18);
+    const filenameLength = archive.readUInt16LE(offset + 26);
+    const extraLength = archive.readUInt16LE(offset + 28);
+    const nameStart = offset + 30;
+    const contentsStart = nameStart + filenameLength + extraLength;
+    const name = archive.toString("utf8", nameStart, nameStart + filenameLength);
+    const compressed = archive.subarray(contentsStart, contentsStart + compressedSize);
+    entries.set(name, inflateRawSync(compressed));
+    offset = contentsStart + compressedSize;
+  }
+  return entries;
+}
+
+async function writeFixture(path, contents) {
+  await mkdir(join(path, ".."), { recursive: true });
+  await writeFile(path, contents);
+}
+
+test("release package metadata and immutable release URLs are validated", () => {
+  assert.deepEqual(validateReleasePackage(packageJson), { version: "1.2.3" });
+  assert.equal(
+    registryTarballUrl("1.2.3"),
+    "https://registry.npmjs.org/relmio/-/relmio-1.2.3.tgz",
+  );
+  assert.equal(
+    wingetInstallerUrl({ architecture: "arm64", version: "1.2.3" }),
+    "https://github.com/Demonbane18/relmio/releases/download/v1.2.3/relmio-1.2.3-windows-arm64.zip",
+  );
+  assert.throws(
+    () => validateReleasePackage({ ...packageJson, license: "MIT" }),
+    /license must be Apache-2\.0/u,
+  );
+  assert.throws(
+    () => wingetInstallerUrl({ architecture: "x86", version: "1.2.3" }),
+    /Unsupported WinGet architecture/u,
+  );
+});
+
+test("Homebrew candidate follows the standard Node formula layout", () => {
+  const formula = createHomebrewFormula({ sha256: digest, version: "1.2.3" });
+
+  assert.match(formula, /^class Relmio < Formula$/mu);
+  assert.match(formula, /url "https:\/\/registry\.npmjs\.org\/relmio\/-\/relmio-1\.2\.3\.tgz"/u);
+  assert.match(formula, /depends_on "node"/u);
+  assert.match(formula, /depends_on "python" => :build/u);
+  assert.match(formula, /system "npm", "install", \*std_npm_args/u);
+  assert.match(formula, /bin\.install_symlink libexec\.glob\("bin\/\*"\)/u);
+  assert.match(formula, /assert_predicate bin\/"relmio", :executable\?/u);
+  assert.match(formula, /system bin\/"relmio", "--version"/u);
+  assert.doesNotMatch(formula, /browserCommand/u);
+  assert.doesNotMatch(formula, /npm install -g/u);
+});
+
+test("WinGet candidates use current multi-file portable ZIP manifests", () => {
+  const manifests = createWingetManifestFiles({
+    installers: [
+      {
+        architecture: "arm64",
+        sha256: "b".repeat(64),
+        url: wingetInstallerUrl({ architecture: "arm64", version: "1.2.3" }),
+      },
+      {
+        architecture: "x64",
+        sha256: digest,
+        url: wingetInstallerUrl({ architecture: "x64", version: "1.2.3" }),
+      },
+    ],
+    version: "1.2.3",
+  });
+  const installer = manifests.get("Demonbane18.Relmio.installer.yaml");
+  const locale = manifests.get("Demonbane18.Relmio.locale.en-US.yaml");
+
+  assert.match(installer, /ManifestVersion: 1\.12\.0/u);
+  assert.match(installer, /InstallerType: zip/u);
+  assert.match(installer, /NestedInstallerType: portable/u);
+  assert.match(installer, /ArchiveBinariesDependOnPath: true/u);
+  assert.match(installer, /PortableCommandAlias: relmio/u);
+  assert.match(installer, /Architecture: arm64/u);
+  assert.match(installer, /Architecture: x64/u);
+  assert.match(installer, new RegExp(`InstallerSha256: ${digest.toUpperCase()}`, "u"));
+  assert.match(locale, /PackageLocale: en-US/u);
+  assert.match(locale, /License: Apache-2\.0/u);
+  assert.throws(
+    () =>
+      createWingetManifestFiles({
+        installers: [
+          { architecture: "x64", sha256: digest, url: "https://example.test/a.zip" },
+          { architecture: "x64", sha256: digest, url: "https://example.test/b.zip" },
+        ],
+        version: "1.2.3",
+      }),
+    /supplied more than once/u,
+  );
+});
+
+test("candidate generation uses local immutable artifacts and never overwrites staging", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "relmio-package-manager-"));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+  const tarball = join(directory, "relmio-1.2.3.tgz");
+  const x64Archive = join(directory, "relmio-1.2.3-windows-x64.zip");
+  const outputDirectory = join(directory, "candidates");
+  await Promise.all([
+    writeFile(tarball, "npm candidate"),
+    writeFile(x64Archive, "portable candidate"),
+  ]);
+
+  const result = await createPackageManagerCandidates({
+    npmTarballPath: tarball,
+    outputDirectory,
+    packageJson,
+    wingetInstallers: [{ architecture: "x64", path: x64Archive }],
+  });
+
+  assert.equal(result.version, "1.2.3");
+  assert.equal(result.generatedPaths.length, 4);
+  const formula = await readFile(
+    join(outputDirectory, "homebrew-tap", "Formula", "relmio.rb"),
+    "utf8",
+  );
+  assert.match(formula, new RegExp(createHashForTest("npm candidate"), "u"));
+  const installer = await readFile(
+    join(
+      outputDirectory,
+      "winget-pkgs",
+      "manifests",
+      "d",
+      "Demonbane18",
+      "Relmio",
+      "1.2.3",
+      "Demonbane18.Relmio.installer.yaml",
+    ),
+    "utf8",
+  );
+  assert.match(installer, new RegExp(createHashForTest("portable candidate").toUpperCase(), "u"));
+  await assert.rejects(
+    createPackageManagerCandidates({
+      npmTarballPath: tarball,
+      outputDirectory,
+      packageJson,
+      wingetInstallers: [],
+    }),
+    /Output directory already exists/u,
+  );
+});
+
+test("WinGet candidates do not require or generate a Homebrew tarball", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "relmio-winget-candidates-"));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+  const x64Archive = join(directory, "relmio-1.2.3-windows-x64.zip");
+  const outputDirectory = join(directory, "candidates");
+  await writeFile(x64Archive, "portable candidate");
+
+  const result = await createPackageManagerCandidates({
+    outputDirectory,
+    packageJson,
+    wingetInstallers: [{ architecture: "x64", path: x64Archive }],
+  });
+
+  assert.equal(result.generatedPaths.length, 3);
+  await assert.rejects(
+    readFile(join(outputDirectory, "homebrew-tap", "Formula", "relmio.rb")),
+    /ENOENT/u,
+  );
+});
+
+function createHashForTest(contents) {
+  return createHash("sha256").update(contents).digest("hex");
+}
+
+test("portable ZIP writer is deterministic and round-trips data", () => {
+  const files = [
+    { contents: Buffer.from("second"), path: "z/second.txt" },
+    { contents: Buffer.from("first"), path: "a/first.txt" },
+  ];
+  const first = createDeterministicZip(files);
+  const second = createDeterministicZip([...files].reverse());
+
+  assert.deepEqual(first, second);
+  assert.equal(crc32(Buffer.from("123456789")), 0xcbf43926);
+  assert.deepEqual(extractZipEntries(first), new Map([
+    ["a/first.txt", Buffer.from("first")],
+    ["z/second.txt", Buffer.from("second")],
+  ]));
+  assert.equal(deflateRawSync(Buffer.from("first")).length > 0, true);
+});
+
+test("portable package bundles its runtime, launcher, package tree, and npx", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "relmio-portable-package-"));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+  const runtimeDirectory = join(directory, "node-v22.14.0-win-x64");
+  const launcherPath = join(directory, "relmio.exe");
+  const productionModules = join(directory, "production-node-modules");
+  const firstOutput = join(
+    directory,
+    "first",
+    `relmio-${repositoryVersion}-windows-x64.zip`,
+  );
+  const secondOutput = join(
+    directory,
+    "second",
+    `relmio-${repositoryVersion}-windows-x64.zip`,
+  );
+  await Promise.all([
+    writeFixture(join(runtimeDirectory, "node.exe"), createPe(0x8664)),
+    writeFixture(
+      join(runtimeDirectory, "node_modules", "npm", "bin", "npx-cli.js"),
+      "export {};",
+    ),
+    writeFixture(launcherPath, createPe(0x8664)),
+    writeFixture(join(productionModules, "ssh2", "index.js"), "export class Client {}"),
+  ]);
+  const stageFixturePackage = async (target) => {
+    await writeFixture(join(target, "src", "cli.js"), "console.log('fixture');");
+  };
+
+  const first = await buildWingetPortablePackage({
+    architecture: "x64",
+    launcherPath,
+    nodeRuntimeDirectory: runtimeDirectory,
+    outputPath: firstOutput,
+    productionNodeModulesDirectory: productionModules,
+    stagePackage: stageFixturePackage,
+  });
+  const second = await buildWingetPortablePackage({
+    architecture: "x64",
+    launcherPath,
+    nodeRuntimeDirectory: runtimeDirectory,
+    outputPath: secondOutput,
+    productionNodeModulesDirectory: productionModules,
+    stagePackage: stageFixturePackage,
+  });
+
+  assert.equal(first.sha256, second.sha256);
+  assert.deepEqual(await readFile(firstOutput), await readFile(secondOutput));
+  const entries = extractZipEntries(await readFile(firstOutput));
+  assert.deepEqual(entries.get("relmio.exe"), createPe(0x8664));
+  assert.equal(entries.get("runtime/node.exe")?.subarray(0, 2).toString(), "MZ");
+  assert.equal(
+    entries.has("runtime/node_modules/npm/bin/npx-cli.js"),
+    true,
+  );
+  assert.equal(entries.has("app/node_modules/relmio/src/cli.js"), true);
+  assert.equal(entries.has("app/node_modules/ssh2/index.js"), true);
+});
+
+test("portable packaging rejects a mismatched Windows executable architecture", () => {
+  assert.equal(peMachine(createPe(0x8664)), 0x8664);
+  assert.throws(
+    () =>
+      validatePeArchitecture({
+        architecture: "arm64",
+        contents: createPe(0x8664),
+        label: "fixture launcher",
+      }),
+    /not built for arm64/u,
+  );
+});
+
+test("the Windows launcher uses the bundled Node runtime and app tree", async () => {
+  const launcher = await readFile("packaging/winget/relmio-launcher.c", "utf8");
+
+  assert.match(launcher, /runtime\\\\node\.exe/u);
+  assert.match(launcher, /app\\\\node_modules\\\\relmio\\\\src\\\\cli\.js/u);
+  assert.match(launcher, /CreateProcessW\(runtime_path/u);
+  assert.match(launcher, /CommandLineToArgvW/u);
+});

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -121,6 +121,15 @@ test("package-manager workflow builds review artifacts before release publicatio
   assert.match(workflow, /relmio\.exe"\) --version/u);
   assert.match(workflow, /RequiredVersion \$moduleVersion/u);
   assert.match(workflow, /moduleVersion = "1\.12\.440"/u);
+  const checksumMatchInvocation = workflow.match(
+    /\[regex\]::Match\(([\s\S]*?)\n\s*\)/u,
+  );
+  assert.ok(checksumMatchInvocation, "expected checksum regex invocation");
+  assert.doesNotMatch(
+    checksumMatchInvocation[1],
+    /,\s*$/u,
+    "PowerShell multiline calls must not have a trailing comma",
+  );
   assert.ok(
     workflow.indexOf("Seal reviewed package-manager candidates") <
       workflow.indexOf("Install-Module -Name Microsoft.WinGet.Client"),

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -130,6 +130,22 @@ test("package-manager workflow builds review artifacts before release publicatio
     /,\s*$/u,
     "PowerShell multiline calls must not have a trailing comma",
   );
+  const windowsArtifactUpload = workflow.match(
+    /name: Seal reviewed package-manager candidates[\s\S]*?(?=\n\s+- name: Validate generated WinGet manifests)/u,
+  );
+  assert.ok(windowsArtifactUpload, "expected Windows artifact upload block");
+  assert.match(
+    windowsArtifactUpload[0],
+    /path:\s*\|[\s\S]*?\.package-manager\/candidates\/[\s\S]*?include-hidden-files:\s*true/u,
+  );
+  const homebrewArtifactUpload = workflow.match(
+    /name: Upload the registry-derived formula candidate[\s\S]*?(?=\n\s+publish-release-assets:)/u,
+  );
+  assert.ok(homebrewArtifactUpload, "expected Homebrew artifact upload block");
+  assert.match(
+    homebrewArtifactUpload[0],
+    /path:\s+\.homebrew-release-candidate\/homebrew-tap\/Formula\/relmio\.rb[\s\S]*?include-hidden-files:\s*true/u,
+  );
   assert.ok(
     workflow.indexOf("Seal reviewed package-manager candidates") <
       workflow.indexOf("Install-Module -Name Microsoft.WinGet.Client"),

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -117,7 +117,12 @@ test("package-manager workflow builds review artifacts before release publicatio
   assert.match(workflow, /pull_request:/u);
   assert.match(workflow, /workflow_call:[\s\S]*release_tag:/u);
   assert.match(workflow, /permissions:\s*\n\s+contents: read/u);
-  assert.match(workflow, /winget validate --disable-interactivity/u);
+  const wingetValidation = workflow.match(/^\s*winget validate [^\r\n]+$/mu);
+  assert.ok(wingetValidation, "expected WinGet validation command");
+  assert.equal(
+    wingetValidation[0].trim(),
+    String.raw`winget validate --disable-interactivity --ignore-warnings ".package-manager\candidates\winget-pkgs\manifests\d\Demonbane18\Relmio\$version"`,
+  );
   assert.match(workflow, /relmio\.exe"\) --version/u);
   assert.match(workflow, /RequiredVersion \$moduleVersion/u);
   assert.match(workflow, /moduleVersion = "1\.12\.440"/u);

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -98,7 +98,43 @@ test("trusted publishing uses short-lived GitHub OIDC credentials", async () => 
   assert.match(workflow, /npm@11\.13\.0/u);
   assert.match(workflow, /npm run package:build -- \.release/u);
   assert.match(workflow, /npm publish/u);
+  assert.match(workflow, /package-managers:[\s\S]*needs:[\s\S]*- publish/u);
+  assert.match(workflow, /uses: \.\/\.github\/workflows\/package-manager-candidates\.yml/u);
   assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN|NPM_TOKEN|_authToken/u);
+});
+
+test("hosted CMD installer is checked out with Windows line endings", async () => {
+  const attributes = await readFile(".gitattributes", "utf8");
+  assert.match(attributes, /^web\/public\/install\.cmd text eol=crlf$/mu);
+});
+
+test("package-manager workflow builds review artifacts before release publication", async () => {
+  const workflow = await readFile(
+    ".github/workflows/package-manager-candidates.yml",
+    "utf8",
+  );
+
+  assert.match(workflow, /pull_request:/u);
+  assert.match(workflow, /workflow_call:[\s\S]*release_tag:/u);
+  assert.match(workflow, /permissions:\s*\n\s+contents: read/u);
+  assert.match(workflow, /winget validate --disable-interactivity/u);
+  assert.match(workflow, /relmio\.exe"\) --version/u);
+  assert.match(workflow, /RequiredVersion \$moduleVersion/u);
+  assert.match(workflow, /moduleVersion = "1\.12\.440"/u);
+  assert.ok(
+    workflow.indexOf("Seal reviewed package-manager candidates") <
+      workflow.indexOf("Install-Module -Name Microsoft.WinGet.Client"),
+  );
+  assert.match(workflow, /registry\.npmjs\.org\/relmio\/-\/\$\{tarball\}/u);
+  assert.match(workflow, /publish-release-assets:[\s\S]*contents: write/u);
+  assert.match(workflow, /gh release upload/u);
+  assert.doesNotMatch(workflow, /pull_request_target/u);
+
+  const actionReferences = [...workflow.matchAll(/uses:\s+[^\s@]+@([^\s#]+)/gu)];
+  assert.ok(actionReferences.length >= 4);
+  for (const [, reference] of actionReferences) {
+    assert.match(reference, /^[a-f0-9]{40}$/u);
+  }
 });
 
 test("public README documents the latest npm walkthrough and sanitized images", async () => {

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -157,12 +157,12 @@ test("browser code never uses innerHTML or web storage for credentials", async (
 test("copy success survives the browser clearing event.currentTarget", async () => {
   const app = await readFile("src/ui/app.js", "utf8");
   const functionStart = app.indexOf("function createCopyClickHandler(");
-  const functionEnd = app.indexOf("\n}\n\nconst handleCopyClick", functionStart);
+  const functionEnd = app.indexOf("const handleCopyClick", functionStart);
 
   assert.notEqual(functionStart, -1);
   assert.notEqual(functionEnd, -1);
 
-  const functionSource = app.slice(functionStart, functionEnd + 2);
+  const functionSource = app.slice(functionStart, functionEnd).trimEnd();
   const createCopyClickHandler = vm.runInNewContext(
     `${functionSource}; createCopyClickHandler`,
   );

--- a/web/app/components/CopyCommand.tsx
+++ b/web/app/components/CopyCommand.tsx
@@ -26,8 +26,8 @@ const installMethods = [
     id: "cmd",
     label: "CMD",
     command:
-      '"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "irm https://relmio.vercel.app/install.ps1 | iex"',
-    note: "Open Command Prompt, not PowerShell. This launches the same verified Windows installer.",
+      'for /f "delims=" %F in ("%TEMP%\\relmio-install-%RANDOM%-%RANDOM%-%RANDOM%.cmd") do @if exist "%~F" (exit /b 80) else curl -fsSL --remove-on-error https://relmio.vercel.app/install.cmd -o "%~F" && set "RELMIO_SELF_DELETE=%~F" && call "%~F"',
+    note: "Open Command Prompt, not PowerShell. This PowerShell-free, non-admin bootstrap reuses Node.js 22+ or verifies a temporary runtime.",
     prompt: ">",
   },
   {
@@ -122,7 +122,7 @@ export function CopyCommand() {
       <div
         className="install-method-tabs"
         role="tablist"
-        aria-label="Local terminal"
+        aria-label="Installation method"
       >
         {installMethods.map((method, index) => {
           const selected = selectedMethod === method.id;

--- a/web/app/install/page.tsx
+++ b/web/app/install/page.tsx
@@ -8,14 +8,14 @@ import { ThemeModeControl } from "../components/ThemeModeControl";
 export const metadata: Metadata = {
   title: "Install Relmio for n8n",
   description:
-    "Run the local Relmio wizard from macOS, Linux, PowerShell, or Command Prompt without installing Node.js first.",
+    "Install the local Relmio wizard with macOS/Linux, PowerShell, Command Prompt, or NPX.",
 };
 
 const steps = [
   {
     index: "01",
-    title: "Choose your terminal",
-    copy: "Use macOS/Linux, PowerShell, CMD, or NPX. Windows does not need Git Bash.",
+    title: "Choose an install method",
+    copy: "Use your local shell or NPX. Windows does not need Git Bash.",
   },
   {
     index: "02",
@@ -72,16 +72,24 @@ export default function InstallPage() {
           </p>
 
           <div className="install-command-stage" id="install-command">
-            <p>Choose your local terminal</p>
+            <p>Choose an installation method</p>
             <CopyCommand />
           </div>
 
           <p className="install-boundary">
+            <strong>Package-manager status:</strong> Homebrew tap publication
+            and WinGet catalog approval are pending. Their commands will appear
+            here only after each public package has passed its real install
+            test. Use a direct installer above today.
+          </p>
+
+          <p className="install-boundary">
             <strong>Run this on your own computer, not on the VPS.</strong>{" "}
-            The macOS/Linux and native Windows options reuse Node.js 22+ when
-            available, or download and verify a temporary official runtime.
-            NPX is for computers that already have Node.js 22 or newer. Relmio
-            does not edit, rebuild, or restart your existing n8n container.
+            The direct macOS/Linux and native Windows options reuse Node.js 22+
+            when available, or download and verify a temporary official
+            runtime. NPX is for computers that already have Node.js 22 or
+            newer. Relmio does not edit, rebuild, or restart your existing n8n
+            container.
           </p>
 
           <ol className="install-steps">

--- a/web/public/install.cmd
+++ b/web/public/install.cmd
@@ -1,0 +1,207 @@
+@echo off
+setlocal EnableExtensions DisableDelayedExpansion
+
+set "RELMIO_EXIT_CODE=1"
+call :main
+set "RELMIO_EXIT_CODE=%errorlevel%"
+
+:cleanup
+if defined RELMIO_TEMPORARY_DIRECTORY if exist "%RELMIO_TEMPORARY_DIRECTORY%\" (
+  rmdir /s /q "%RELMIO_TEMPORARY_DIRECTORY%" >nul 2>&1
+)
+if defined RELMIO_SELF_DELETE if /i "%RELMIO_SELF_DELETE%"=="%~f0" (
+  start "" /b "%ComSpec%" /d /q /c ""%SystemRoot%\System32\ping.exe" 127.0.0.1 -n 2 >nul 2>&1 & del /q ^"%~f0^" >nul 2>&1"
+)
+endlocal & exit /b %RELMIO_EXIT_CODE%
+
+:main
+set "RELMIO_MINIMUM_NODE_MAJOR=22"
+set "RELMIO_SYSTEM32=%SystemRoot%\System32"
+set "RELMIO_CURL=%RELMIO_SYSTEM32%\curl.exe"
+set "RELMIO_CERTUTIL=%RELMIO_SYSTEM32%\certutil.exe"
+set "RELMIO_TAR=%RELMIO_SYSTEM32%\tar.exe"
+set "RELMIO_WHERE=%RELMIO_SYSTEM32%\where.exe"
+set "RELMIO_FINDSTR=%RELMIO_SYSTEM32%\findstr.exe"
+set "RELMIO_TEMPORARY_DIRECTORY="
+
+call :findnode
+if errorlevel 1 goto :portable_runtime
+call :message "Using installed Node.js %RELMIO_INSTALLED_NODE_MAJOR% runtime; starting Relmio without a download."
+call "%RELMIO_INSTALLED_NPX%" --yes --ignore-scripts relmio@latest
+exit /b %errorlevel%
+
+:portable_runtime
+call :needtool "%RELMIO_CURL%" "curl.exe is required to download the temporary Node.js runtime."
+if errorlevel 1 exit /b 1
+call :needtool "%RELMIO_CERTUTIL%" "certutil.exe is required to verify the temporary Node.js runtime."
+if errorlevel 1 exit /b 1
+call :needtool "%RELMIO_TAR%" "tar.exe is required to extract the temporary Node.js runtime."
+if errorlevel 1 exit /b 1
+call :needtool "%RELMIO_WHERE%" "where.exe is required to find an installed Node.js runtime."
+if errorlevel 1 exit /b 1
+call :needtool "%RELMIO_FINDSTR%" "findstr.exe is required to validate Node.js version and checksum output."
+if errorlevel 1 exit /b 1
+
+set "RELMIO_ARCHITECTURE=%PROCESSOR_ARCHITEW6432%"
+if not defined RELMIO_ARCHITECTURE set "RELMIO_ARCHITECTURE=%PROCESSOR_ARCHITECTURE%"
+if /i "%RELMIO_ARCHITECTURE%"=="AMD64" set "RELMIO_NODE_ARCHITECTURE=x64"
+if /i "%RELMIO_ARCHITECTURE%"=="ARM64" set "RELMIO_NODE_ARCHITECTURE=arm64"
+if not defined RELMIO_NODE_ARCHITECTURE (
+  call :failure "Unsupported CPU architecture. Relmio supports Windows x64 and ARM64."
+  exit /b 1
+)
+
+set "RELMIO_TEMPORARY_DIRECTORY=%TEMP%\relmio-%RANDOM%%RANDOM%%RANDOM%"
+mkdir "%RELMIO_TEMPORARY_DIRECTORY%" >nul 2>&1
+if errorlevel 1 (
+  call :failure "Could not create a temporary directory for the Node.js runtime."
+  exit /b 1
+)
+
+set "RELMIO_NODE_VERSION=v22.23.2"
+set "RELMIO_ARCHIVE_NAME=node-%RELMIO_NODE_VERSION%-win-%RELMIO_NODE_ARCHITECTURE%.zip"
+set "RELMIO_EXPECTED_CHECKSUM="
+if /i "%RELMIO_NODE_ARCHITECTURE%"=="x64" set "RELMIO_EXPECTED_CHECKSUM=1177b4137ba5adaa56354ae40f1080c7450e8ae09cecb47da459d1c52ac99f97"
+if /i "%RELMIO_NODE_ARCHITECTURE%"=="arm64" set "RELMIO_EXPECTED_CHECKSUM=fec025a6da31757e3b6af84c5a1628e9d38442ca99a2161091d78f2fcfa35ef3"
+if not defined RELMIO_EXPECTED_CHECKSUM (
+  call :failure "No reviewed Node.js checksum is available for this architecture."
+  exit /b 1
+)
+set "RELMIO_ARCHIVE_PATH=%RELMIO_TEMPORARY_DIRECTORY%\%RELMIO_ARCHIVE_NAME%"
+set "RELMIO_ARCHIVE_URL=https://nodejs.org/download/release/%RELMIO_NODE_VERSION%/%RELMIO_ARCHIVE_NAME%"
+call :message "[1/4] Installing a temporary Node.js 22 runtime. Please wait; this does not install Node.js system-wide."
+call :message "[2/4] Downloading the reviewed official Node.js runtime. Please wait..."
+call :download "%RELMIO_ARCHIVE_URL%" "%RELMIO_ARCHIVE_PATH%"
+if errorlevel 1 (
+  call :failure "Could not download the official Node.js runtime. Check your HTTPS connection and try again."
+  exit /b 1
+)
+
+call :message "[3/4] Verifying the Node.js SHA-256 checksum. Please wait..."
+set "RELMIO_HASH_OUTPUT=%RELMIO_TEMPORARY_DIRECTORY%\runtime-sha256.txt"
+"%RELMIO_CERTUTIL%" -hashfile "%RELMIO_ARCHIVE_PATH%" SHA256 > "%RELMIO_HASH_OUTPUT%"
+if errorlevel 1 (
+  call :failure "certutil.exe could not calculate the Node.js SHA-256 checksum; nothing was executed."
+  exit /b 1
+)
+set "RELMIO_ACTUAL_CHECKSUM="
+set "RELMIO_HASH_MATCHES=0"
+for /f "usebackq tokens=1" %%A in ("%RELMIO_HASH_OUTPUT%") do (
+  call :checksum "%%A"
+  if not errorlevel 1 (
+    set /a RELMIO_HASH_MATCHES+=1
+    set "RELMIO_ACTUAL_CHECKSUM=%%A"
+  )
+)
+if not "%RELMIO_HASH_MATCHES%"=="1" (
+  call :failure "certutil.exe returned an invalid Node.js SHA-256 checksum; nothing was executed."
+  exit /b 1
+)
+call :checksum "%RELMIO_ACTUAL_CHECKSUM%"
+if errorlevel 1 (
+  call :failure "certutil.exe returned an invalid Node.js SHA-256 checksum; nothing was executed."
+  exit /b 1
+)
+if /i not "%RELMIO_ACTUAL_CHECKSUM%"=="%RELMIO_EXPECTED_CHECKSUM%" (
+  call :failure "Node.js download checksum did not match; nothing was executed."
+  exit /b 1
+)
+
+call :message "Verified Node.js download."
+call :message "[4/4] Extracting the verified temporary Node.js 22 runtime. Please wait..."
+"%RELMIO_TAR%" -xf "%RELMIO_ARCHIVE_PATH%" -C "%RELMIO_TEMPORARY_DIRECTORY%"
+if errorlevel 1 (
+  call :failure "tar.exe could not extract the verified Node.js runtime."
+  exit /b 1
+)
+
+set "RELMIO_RUNTIME_DIRECTORY=%RELMIO_TEMPORARY_DIRECTORY%\%RELMIO_ARCHIVE_NAME:.zip=%"
+set "RELMIO_NODE_BINARY=%RELMIO_RUNTIME_DIRECTORY%\node.exe"
+set "RELMIO_NPX_CLI=%RELMIO_RUNTIME_DIRECTORY%\node_modules\npm\bin\npx-cli.js"
+if not exist "%RELMIO_NODE_BINARY%" (
+  call :failure "The verified Node.js archive did not contain its runtime."
+  exit /b 1
+)
+if not exist "%RELMIO_NPX_CLI%" (
+  call :failure "The verified Node.js archive did not contain npm."
+  exit /b 1
+)
+
+call :message "Starting the newest Relmio wizard."
+set "PATH=%RELMIO_RUNTIME_DIRECTORY%;%PATH%"
+"%RELMIO_NODE_BINARY%" "%RELMIO_NPX_CLI%" --yes --ignore-scripts relmio@latest
+exit /b %errorlevel%
+
+:findnode
+set "RELMIO_INSTALLED_NODE="
+set "RELMIO_INSTALLED_NPX="
+set "RELMIO_INSTALLED_NODE_MAJOR="
+if not exist "%RELMIO_WHERE%" exit /b 1
+for /f "usebackq delims=" %%P in (`"%RELMIO_WHERE%" node.exe 2^>nul`) do (
+  call :nodeok "%%~fP"
+  if not errorlevel 1 (
+    set "RELMIO_INSTALLED_NODE=%%~fP"
+    call set "RELMIO_INSTALLED_NODE_MAJOR=%%RELMIO_SUPPORTED_NODE_MAJOR%%"
+    goto :find_installed_npx
+  )
+)
+exit /b 1
+
+:find_installed_npx
+for /f "usebackq delims=" %%P in (`"%RELMIO_WHERE%" npx.cmd 2^>nul`) do (
+  set "RELMIO_INSTALLED_NPX=%%~fP"
+  goto :installed_runtime_found
+)
+exit /b 1
+
+:installed_runtime_found
+if not defined RELMIO_INSTALLED_NODE exit /b 1
+if not defined RELMIO_INSTALLED_NPX exit /b 1
+exit /b 0
+
+:nodeok
+setlocal DisableDelayedExpansion
+set "RELMIO_NODE_VERSION="
+for /f "usebackq delims=" %%V in (`"%~1" --version 2^>nul`) do if not defined RELMIO_NODE_VERSION set "RELMIO_NODE_VERSION=%%V"
+if not defined RELMIO_NODE_VERSION endlocal & exit /b 1
+echo(%RELMIO_NODE_VERSION%| "%RELMIO_FINDSTR%" /r /x "v[1-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*" >nul
+if errorlevel 1 endlocal & exit /b 1
+for /f "tokens=1 delims=." %%M in ("%RELMIO_NODE_VERSION:~1%") do set "RELMIO_NODE_MAJOR=%%M"
+set /a RELMIO_NODE_MAJOR_NUMBER=RELMIO_NODE_MAJOR >nul 2>&1
+if errorlevel 1 endlocal & exit /b 1
+if %RELMIO_NODE_MAJOR_NUMBER% LSS %RELMIO_MINIMUM_NODE_MAJOR% endlocal & exit /b 1
+endlocal & set "RELMIO_SUPPORTED_NODE_MAJOR=%RELMIO_NODE_MAJOR%" & exit /b 0
+
+:checksum
+setlocal DisableDelayedExpansion
+set "RELMIO_CHECKSUM=%~1"
+if "%RELMIO_CHECKSUM:~63,1%"=="" endlocal & exit /b 1
+if not "%RELMIO_CHECKSUM:~64,1%"=="" endlocal & exit /b 1
+echo(%RELMIO_CHECKSUM%| "%RELMIO_FINDSTR%" /r /x "[0-9A-Fa-f][0-9A-Fa-f]*" >nul
+if errorlevel 1 endlocal & exit /b 1
+endlocal & exit /b 0
+
+:archive
+setlocal DisableDelayedExpansion
+set "RELMIO_CANDIDATE_ARCHIVE=%~1"
+set "RELMIO_CANDIDATE_ARCHITECTURE=%~2"
+echo(%RELMIO_CANDIDATE_ARCHIVE%| "%RELMIO_FINDSTR%" /r /x "node-v22\.[0-9][0-9]*\.[0-9][0-9]*-win-%RELMIO_CANDIDATE_ARCHITECTURE%\.zip" >nul
+if errorlevel 1 endlocal & exit /b 1
+endlocal & exit /b 0
+
+:needtool
+if exist "%~1" exit /b 0
+call :failure "%~2"
+exit /b 1
+
+:download
+"%RELMIO_CURL%" --fail --silent --show-error --proto "=https" --proto-redir "=https" --max-redirs 0 --connect-timeout 15 --max-time 600 --retry 2 --retry-delay 1 "%~1" -o "%~2"
+exit /b %errorlevel%
+
+:message
+echo Relmio installer: %~1
+exit /b 0
+
+:failure
+>&2 echo Relmio installer: %~1
+exit /b 1

--- a/web/public/install.ps1
+++ b/web/public/install.ps1
@@ -96,7 +96,8 @@
     $manifestPath = Join-Path $temporaryDirectory "SHASUMS256.txt"
     $manifestUrl = "https://nodejs.org/download/release/latest-v22.x/SHASUMS256.txt"
 
-    Write-RelmioInstallerMessage "Downloading a temporary Node.js 22 runtime."
+    Write-RelmioInstallerMessage "[1/4] Installing a temporary Node.js 22 runtime. Please wait; this does not install Node.js system-wide."
+    Write-RelmioInstallerMessage "[2/4] Downloading the official Node.js checksum manifest and runtime. Please wait..."
     Save-RelmioHttpsFile -Uri $manifestUrl -Destination $manifestPath
 
     $manifestPattern = '^(?<checksum>[0-9A-Fa-f]{64})\s+(?<filename>node-(?<version>v22\.\d+\.\d+)-win-(?<architecture>x64|arm64)\.zip)$'
@@ -121,12 +122,14 @@
     $archiveUrl = "$nodeDistributionUrl/$($runtime.Version)/$($runtime.Filename)"
     Save-RelmioHttpsFile -Uri $archiveUrl -Destination $archivePath
 
+    Write-RelmioInstallerMessage "[3/4] Verifying the Node.js SHA-256 checksum. Please wait..."
     $actualChecksum = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
     if (-not [string]::Equals($actualChecksum, $runtime.Checksum, [StringComparison]::Ordinal)) {
       throw "Node.js download checksum did not match; nothing was executed."
     }
     Write-RelmioInstallerMessage "Verified Node.js download."
 
+    Write-RelmioInstallerMessage "[4/4] Extracting the verified temporary Node.js 22 runtime. Please wait..."
     Expand-Archive -LiteralPath $archivePath -DestinationPath $temporaryDirectory -Force
     $archiveRoot = [IO.Path]::GetFileNameWithoutExtension($runtime.Filename)
     $nodeBinary = Join-Path $temporaryDirectory "$archiveRoot\node.exe"

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -99,7 +99,8 @@ trap cleanup EXIT HUP INT TERM
 manifest_path="$temporary_directory/SHASUMS256.txt"
 manifest_url="$node_dist_url/latest-v22.x/SHASUMS256.txt"
 
-say "Downloading a temporary Node.js 22 runtime."
+say "[1/4] Installing a temporary Node.js 22 runtime. Please wait; this does not install Node.js system-wide."
+say "[2/4] Downloading the official Node.js checksum manifest and runtime. Please wait..."
 download "$manifest_url" "$manifest_path" \
   || fail "Could not download the official Node.js checksum manifest."
 
@@ -156,6 +157,7 @@ archive_url="$node_dist_url/$node_version/$archive_name"
 download "$archive_url" "$archive_path" \
   || fail "Could not download the official Node.js runtime."
 
+say "[3/4] Verifying the Node.js SHA-256 checksum. Please wait..."
 if command -v sha256sum >/dev/null 2>&1; then
   actual_checksum="$(sha256sum "$archive_path" | awk '{ print $1 }')"
 elif command -v shasum >/dev/null 2>&1; then
@@ -167,7 +169,7 @@ fi
 [ "$actual_checksum" = "$expected_checksum" ] \
   || fail "Node.js download checksum did not match; nothing was executed."
 say "Verified Node.js download."
-
+say "[4/4] Extracting the verified temporary Node.js 22 runtime. Please wait..."
 if [ "$archive_extension" = "zip" ]; then
   unzip -q "$archive_path" -d "$temporary_directory"
   archive_root="${archive_name%.zip}"

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -76,9 +76,10 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
   const response = await requestApp("/install");
   assert.equal(response.status, 200);
 
-  const [html, installScript, powerShellInstallScript] = await Promise.all([
+  const [html, installScript, commandPromptInstallScript, powerShellInstallScript] = await Promise.all([
     response.text(),
     readFile(new URL("../dist/client/install.sh", import.meta.url), "utf8"),
+    readFile(new URL("../dist/client/install.cmd", import.meta.url), "utf8"),
     readFile(new URL("../dist/client/install.ps1", import.meta.url), "utf8"),
   ]);
   assert.match(html, /Install Relmio for n8n/);
@@ -94,30 +95,47 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
     html,
     /curl -fsSL https:\/\/relmio\.vercel\.app\/install\.sh \| sh/,
   );
+  assert.doesNotMatch(html, /brew install Demonbane18\/relmio\/relmio/);
+  assert.doesNotMatch(html, /winget install --exact --id Demonbane18\.Relmio/);
+  assert.match(html, /Homebrew tap publication/);
+  assert.match(html, /WinGet catalog approval/);
   assert.match(
     html,
     /irm https:\/\/relmio\.vercel\.app\/install\.ps1 \| iex/,
   );
   assert.match(
     html,
-    /&quot;%SystemRoot%\\System32\\WindowsPowerShell\\v1\.0\\powershell\.exe&quot; -NoProfile -ExecutionPolicy Bypass -Command &quot;irm https:\/\/relmio\.vercel\.app\/install\.ps1 \| iex&quot;/,
+    /for \/f &quot;delims=&quot; %F/,
   );
+  assert.match(html, /relmio-install-%RANDOM%-%RANDOM%-%RANDOM%\.cmd/);
+  assert.match(html, /--remove-on-error/);
+  assert.match(html, /RELMIO_SELF_DELETE=%~F/);
+  assert.doesNotMatch(html, /-o install\.cmd/);
   assert.match(html, /npx --yes --ignore-scripts relmio@latest/);
-  assert.match(html, /role="tablist"[^>]*aria-label="Local terminal"/);
+  assert.match(html, /role="tablist"[^>]*aria-label="Installation method"/);
   assert.match(html, /role="tab"[^>]*aria-selected="true"[^>]*>[^<]*macOS \/ Linux/);
+  assert.doesNotMatch(html, /role="tab"[^>]*>[^<]*Homebrew/);
+  assert.doesNotMatch(html, /role="tab"[^>]*>[^<]*WinGet/);
   assert.match(html, /role="tab"[^>]*aria-selected="false"[^>]*>[^<]*PowerShell/);
   assert.match(html, /role="tab"[^>]*aria-selected="false"[^>]*>[^<]*CMD/);
   assert.match(html, /role="tab"[^>]*aria-selected="false"[^>]*>[^<]*NPX/);
   assert.match(html, /macOS, Linux, WSL, or Git Bash/);
   assert.match(html, /No Git Bash or preinstalled Node\.js required/);
   assert.match(html, /Open Command Prompt, not PowerShell/);
+  assert.match(html, /PowerShell-free, non-admin bootstrap/);
   assert.match(html, /NPX requires Node\.js 22 or newer/);
+  assert.match(html, /commands will appear[^<]*only after each public package/);
   assert.match(html, /Copy installation command/);
+  assert.match(html, /Choose an installation method/);
   assert.match(html, /Run this on your own computer/);
   assert.doesNotMatch(html, /href="https:\/\/www\.npmjs\.com/);
   assert.match(installScript, /^#!\/bin\/sh/m);
   assert.match(installScript, /Node\.js download checksum did not match/);
   assert.match(installScript, /--ignore-scripts relmio@latest/);
+  assert.doesNotMatch(commandPromptInstallScript, /powershell|pwsh/iu);
+  assert.match(commandPromptInstallScript, /certutil\.exe/u);
+  assert.match(commandPromptInstallScript, /Node\.js download checksum did not match/u);
+  assert.match(commandPromptInstallScript, /--ignore-scripts relmio@latest/u);
   assert.match(powerShellInstallScript, /Get-FileHash/);
   assert.match(powerShellInstallScript, /Node\.js download checksum did not match/);
   assert.match(powerShellInstallScript, /--ignore-scripts/);


### PR DESCRIPTION
Adds a PowerShell-free native CMD installer with verified temporary Node fallback, progress and existing Node reuse. Prepares trustworthy Homebrew and WinGet release artifacts, updates the web installer and documentation, and extends cross-platform tests and OIDC release workflows. Homebrew and WinGet public commands remain hidden until their distribution endpoints are live.