### PR TITLE
feat: expose verified Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ the VPS.
 curl -fsSL https://relmio.vercel.app/install.sh | sh
 ```
 
+### Homebrew (macOS or Linux)
+
+```bash
+brew tap Demonbane18/relmio && brew install relmio
+```
+
 ### Windows PowerShell
 
 ```powershell
@@ -72,9 +78,9 @@ SHA-256 checksum, run Relmio with npm lifecycle scripts disabled, and remove
 the temporary runtime when the wizard closes. They do not install Node.js
 system-wide.
 
-Homebrew tap publication and WinGet catalog approval are pending. Their install
-commands will be added here only after each public package passes a real
-package-manager installation test. Use a direct installer above today.
+Homebrew is available from the public `Demonbane18/relmio` tap. The WinGet
+command stays hidden until Microsoft accepts its catalog pull request and the
+catalog updates. Until then, use Homebrew or a direct installer above.
 
 The Command Prompt route is PowerShell-free, runs as the current user, and
 does not request administrator access or change Windows security policy. Keep
@@ -384,6 +390,12 @@ Choose a terminal already installed on your computer.
 curl -fsSL https://relmio.vercel.app/install.sh | sh
 ```
 
+#### Homebrew (macOS or Linux)
+
+```bash
+brew tap Demonbane18/relmio && brew install relmio
+```
+
 #### Windows PowerShell
 
 ```powershell
@@ -401,8 +413,9 @@ when present. If Node.js is missing or older than 22, they show staged
 **Please wait** messages while they download and verify a temporary official
 Node.js 22 runtime without installing it system-wide. Native Windows does not
 require Git Bash; Command Prompt uses a PowerShell-free, non-admin bootstrap.
-Homebrew and WinGet release candidates are prepared separately. Their public
-commands remain hidden until the tap and catalog packages pass real installs.
+Homebrew is available from the public `Demonbane18/relmio` tap. The WinGet
+command stays hidden until Microsoft accepts its catalog pull request and the
+catalog updates.
 
 Anyone who already has [Node.js 22 or newer](https://nodejs.org/en/download)
 can run the npm package directly instead:

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ OpenAI Platform API key or replace the local n8n setup wizard.
 </figure>
 
 The site's [Install wizard](https://relmio.vercel.app/install) page provides a
-clickable macOS/Linux, PowerShell, Command Prompt, and NPX switcher for the
+clickable macOS/Linux, Homebrew, PowerShell, Command Prompt, and NPX switcher for the
 current self-hosted n8n and Hostinger VPS setup path.
 
 ## Browser interface and theme modes

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,6 +40,12 @@ macOS, Linux, WSL, or Git Bash:
 curl -fsSL https://relmio.vercel.app/install.sh | sh
 ```
 
+Homebrew (macOS or Linux):
+
+```bash
+brew tap Demonbane18/relmio && brew install relmio
+```
+
 Windows PowerShell:
 
 ```powershell
@@ -59,8 +65,9 @@ temporary runtime and verifies its SHA-256 checksum before execution. The
 Command Prompt route is PowerShell-free, non-admin, and does not change Windows
 security policy.
 
-Homebrew tap publication and WinGet catalog approval are pending. Until each
-public package passes its real install test, use one of the direct bootstrap
+Homebrew is available from the public `Demonbane18/relmio` tap. The WinGet
+command stays hidden until Microsoft accepts its catalog pull request and the
+catalog updates. Until then, use Homebrew or one of the direct bootstrap
 commands on this page.
 
 If you choose the existing-Node fallback, confirm Node is version 22 or newer

--- a/npm/README.md
+++ b/npm/README.md
@@ -96,6 +96,12 @@ the VPS.
 curl -fsSL https://relmio.vercel.app/install.sh | sh
 ```
 
+### Homebrew (macOS or Linux)
+
+```bash
+brew tap Demonbane18/relmio && brew install relmio
+```
+
 ### Windows PowerShell
 
 ```powershell
@@ -120,9 +126,9 @@ the temporary runtime when the wizard closes. The Command Prompt path runs as
 the current user and does not request administrator access or change Windows
 security policy.
 
-Homebrew tap publication and WinGet catalog approval are pending. Their install
-commands will be added only after each public package passes a real
-package-manager installation test. Use a direct installer above today.
+Homebrew is available from the public `Demonbane18/relmio` tap. The WinGet
+command stays hidden until Microsoft accepts its catalog pull request and the
+catalog updates. Until then, use Homebrew or a direct installer above.
 
 Users who already have Node.js 22 or newer can run the npm package directly:
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -72,7 +72,7 @@ installing the private n8n sidecar.
 </figure>
 
 Use the site's [Install wizard](https://relmio.vercel.app/install) page for a
-clickable macOS/Linux, PowerShell, Command Prompt, and NPX command switcher
+clickable macOS/Linux, Homebrew, PowerShell, Command Prompt, and NPX command switcher
 tailored to the current self-hosted n8n and Hostinger VPS setup path.
 
 ### Browser interface and theme modes

--- a/packaging/package-managers.md
+++ b/packaging/package-managers.md
@@ -2,7 +2,8 @@
 
 This directory prepares reviewable candidates. It does not publish a Homebrew
 formula, upload a GitHub Release asset, create a WinGet pull request, or make
-`brew install relmio` / `winget install Demonbane18.Relmio` available.
+external catalog decisions. Those actions happen in the separate tap and
+catalog repositories.
 
 ## Homebrew
 
@@ -21,6 +22,14 @@ registry and confirm its SHA-256 matches the generated formula. Then validate
 the candidate in the separate tap repository with Homebrew's current audit and
 source-install commands. There is no tap in this repository and no assumption
 that `homebrew/core` accepts the formula.
+
+### External status
+
+The external [`Demonbane18/homebrew-relmio`](https://github.com/Demonbane18/homebrew-relmio)
+tap is live at formula commit `6c8038f`. Its macOS workflow run `30905921073`
+passed the Homebrew audit, tap-qualified install, `relmio --version`, and
+`brew test` for Relmio 0.2.14. This repository generated the reviewed
+candidate; the external tap repository publishes and tests it.
 
 ## WinGet
 
@@ -50,6 +59,11 @@ validate` and the repository's Sandbox test against the generated directory,
 then submit exactly one version through a separate `winget-pkgs` pull request.
 The package is not available through WinGet until that pull request is merged
 and the catalog has updated.
+
+A WinGet manifest pull request has been submitted separately and is pending
+review, merge, and catalog propagation. This repository's generator does not
+submit that pull request or publish the catalog entry, and public documentation
+must keep the WinGet install command hidden until the catalog accepts it.
 
 ## Generate candidates
 

--- a/test/documentation.test.js
+++ b/test/documentation.test.js
@@ -122,7 +122,7 @@ test("Windows Command Prompt documentation uses the PowerShell-free native boots
   assert.match(troubleshooting, /validated manual link/u);
 });
 
-test("public guides hide package-manager commands until their catalogs are live", async () => {
+test("public guides expose the tested Homebrew tap while WinGet remains pending", async () => {
   const [readme, npmReadme, troubleshooting, maintainerGuide] = await Promise.all([
     readFile("README.md", "utf8"),
     readFile("npm/README.md", "utf8"),
@@ -131,13 +131,24 @@ test("public guides hide package-manager commands until their catalogs are live"
   ]);
 
   for (const guide of [readme, npmReadme, troubleshooting]) {
-    assert.doesNotMatch(guide, /brew install Demonbane18\/relmio\/relmio/u);
-    assert.doesNotMatch(guide, /winget install --exact --id Demonbane18\.Relmio/u);
-    assert.match(guide, /Homebrew tap publication/iu);
-    assert.match(guide, /WinGet catalog approval/iu);
+    assert.match(
+      guide,
+      /brew tap Demonbane18\/relmio && brew install relmio/u,
+    );
+    assert.doesNotMatch(guide, /\bwinget install\b/iu);
+    assert.match(guide, /Homebrew is available/iu);
+    assert.match(guide, /WinGet\s+command.*hidden/iu);
   }
   assert.match(maintainerGuide, /exact\s+immutable tarball downloaded back from the registry/iu);
+  assert.match(maintainerGuide, /Demonbane18\/homebrew-relmio/u);
+  assert.match(maintainerGuide, /6c8038f/u);
+  assert.match(maintainerGuide, /30905921073/u);
   assert.match(maintainerGuide, /Demonbane18\.Relmio/u);
+  assert.match(maintainerGuide, /WinGet manifest pull request.*submitted/iu);
+  assert.match(
+    maintainerGuide,
+    /pending\s+review, merge, and catalog propagation/iu,
+  );
 });
 
 test("n8n configuration guide provides copy-paste model and HTTP recipes", async () => {

--- a/test/documentation.test.js
+++ b/test/documentation.test.js
@@ -44,7 +44,10 @@ test("README and manual guide copy the generated sidecar files exactly", async (
 });
 
 test("README keeps every local install path and layman diagrams visible", async () => {
-  const readme = await readFile("README.md", "utf8");
+  const [readme, npmReadme] = await Promise.all([
+    readFile("README.md", "utf8"),
+    readFile("npm/README.md", "utf8"),
+  ]);
   const mermaidBlocks = readme.match(/```mermaid/gu) ?? [];
 
   assert.match(readme, /## Choose a setup path/u);
@@ -63,6 +66,12 @@ test("README keeps every local install path and layman diagrams visible", async 
   assert.match(readme, /The wizard is a convenience layer, not a requirement/u);
   assert.ok(mermaidBlocks.length >= 4);
   assert.doesNotMatch(readme, /—/u);
+  for (const guide of [readme, npmReadme]) {
+    assert.match(
+      guide,
+      /clickable macOS\/Linux, Homebrew, PowerShell, Command Prompt, and NPX (?:command )?switcher/u,
+    );
+  }
 });
 
 test("beginner documentation states the critical safety and product limits", async () => {

--- a/web/app/components/CopyCommand.tsx
+++ b/web/app/components/CopyCommand.tsx
@@ -16,6 +16,13 @@ const installMethods = [
     prompt: "$",
   },
   {
+    id: "homebrew",
+    label: "Homebrew",
+    command: "brew tap Demonbane18/relmio && brew install relmio",
+    note: "For macOS or Linux computers with Homebrew. It installs Relmio and its Node.js dependency.",
+    prompt: "$",
+  },
+  {
     id: "powershell",
     label: "PowerShell",
     command: "irm https://relmio.vercel.app/install.ps1 | iex",

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1776,7 +1776,7 @@ main {
   width: 100%;
   min-height: 52px;
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 4px;
   padding: 4px;
   border: 1px solid var(--line);

--- a/web/app/install/page.tsx
+++ b/web/app/install/page.tsx
@@ -8,14 +8,14 @@ import { ThemeModeControl } from "../components/ThemeModeControl";
 export const metadata: Metadata = {
   title: "Install Relmio for n8n",
   description:
-    "Install the local Relmio wizard with macOS/Linux, PowerShell, Command Prompt, or NPX.",
+    "Install the local Relmio wizard with Homebrew, macOS/Linux, PowerShell, Command Prompt, or NPX.",
 };
 
 const steps = [
   {
     index: "01",
     title: "Choose an install method",
-    copy: "Use your local shell or NPX. Windows does not need Git Bash.",
+    copy: "Use Homebrew, your local shell, or NPX. Windows does not need Git Bash.",
   },
   {
     index: "02",
@@ -66,9 +66,9 @@ export default function InstallPage() {
           <h1>Install Relmio for n8n</h1>
           <p className="install-lede">
             Run one local wizard to sign in with ChatGPT, verify your VPS, and
-            install a private OpenAI-compatible sidecar beside n8n. Choose the
-            terminal already on your computer. Native Windows works without
-            Git Bash or a preinstalled Node.js runtime.
+            install a private OpenAI-compatible sidecar beside n8n. Choose
+            Homebrew or the terminal already on your computer. Native Windows
+            works without Git Bash or a preinstalled Node.js runtime.
           </p>
 
           <div className="install-command-stage" id="install-command">
@@ -77,10 +77,10 @@ export default function InstallPage() {
           </div>
 
           <p className="install-boundary">
-            <strong>Package-manager status:</strong> Homebrew tap publication
-            and WinGet catalog approval are pending. Their commands will appear
-            here only after each public package has passed its real install
-            test. Use a direct installer above today.
+            <strong>Package-manager status:</strong> Homebrew is available from
+            the public <code>Demonbane18/relmio</code> tap. The WinGet command
+            stays hidden until Microsoft accepts its catalog pull request and
+            the catalog updates.
           </p>
 
           <p className="install-boundary">

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -95,10 +95,13 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
     html,
     /curl -fsSL https:\/\/relmio\.vercel\.app\/install\.sh \| sh/,
   );
-  assert.doesNotMatch(html, /brew install Demonbane18\/relmio\/relmio/);
-  assert.doesNotMatch(html, /winget install --exact --id Demonbane18\.Relmio/);
-  assert.match(html, /Homebrew tap publication/);
-  assert.match(html, /WinGet catalog approval/);
+  assert.match(
+    html,
+    /brew tap Demonbane18\/relmio &amp;&amp; brew install relmio/,
+  );
+  assert.doesNotMatch(html, /\bwinget install\b/i);
+  assert.match(html, /Homebrew is available/);
+  assert.match(html, /WinGet command.*hidden/);
   assert.match(
     html,
     /irm https:\/\/relmio\.vercel\.app\/install\.ps1 \| iex/,
@@ -114,7 +117,7 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
   assert.match(html, /npx --yes --ignore-scripts relmio@latest/);
   assert.match(html, /role="tablist"[^>]*aria-label="Installation method"/);
   assert.match(html, /role="tab"[^>]*aria-selected="true"[^>]*>[^<]*macOS \/ Linux/);
-  assert.doesNotMatch(html, /role="tab"[^>]*>[^<]*Homebrew/);
+  assert.match(html, /role="tab"[^>]*aria-selected="false"[^>]*>[^<]*Homebrew/);
   assert.doesNotMatch(html, /role="tab"[^>]*>[^<]*WinGet/);
   assert.match(html, /role="tab"[^>]*aria-selected="false"[^>]*>[^<]*PowerShell/);
   assert.match(html, /role="tab"[^>]*aria-selected="false"[^>]*>[^<]*CMD/);
@@ -124,7 +127,7 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
   assert.match(html, /Open Command Prompt, not PowerShell/);
   assert.match(html, /PowerShell-free, non-admin bootstrap/);
   assert.match(html, /NPX requires Node\.js 22 or newer/);
-  assert.match(html, /commands will appear[^<]*only after each public package/);
+  assert.match(html, /WinGet command stays hidden[^<]*catalog updates/);
   assert.match(html, /Copy installation command/);
   assert.match(html, /Choose an installation method/);
   assert.match(html, /Run this on your own computer/);

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -76,12 +76,21 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
   const response = await requestApp("/install");
   assert.equal(response.status, 200);
 
-  const [html, installScript, commandPromptInstallScript, powerShellInstallScript] = await Promise.all([
+  const [html, installScript, commandPromptInstallScript, powerShellInstallScript, globalsCss] = await Promise.all([
     response.text(),
     readFile(new URL("../dist/client/install.sh", import.meta.url), "utf8"),
     readFile(new URL("../dist/client/install.cmd", import.meta.url), "utf8"),
     readFile(new URL("../dist/client/install.ps1", import.meta.url), "utf8"),
+    readFile(new URL("../app/globals.css", import.meta.url), "utf8"),
   ]);
+  const desktopInstallTabsRule = globalsCss.match(
+    /\.install-method-tabs\s*\{(?<declarations>[^}]*)\}/u,
+  );
+  assert.ok(desktopInstallTabsRule, "expected desktop install tabs rule");
+  assert.match(
+    desktopInstallTabsRule.groups.declarations,
+    /grid-template-columns:\s*repeat\(5,\s*minmax\(0,\s*1fr\)\);/u,
+  );
   assert.match(html, /Install Relmio for n8n/);
   assert.match(html, /data-astryx-theme="relmio"/);
   assert.match(html, /aria-label="Color theme"/);


### PR DESCRIPTION
## Summary

macOS and Linux users can now choose the public, tested Homebrew tap directly from Relmio's install page and guides. Direct curl, PowerShell, Command Prompt, and NPX routes remain available and unchanged; WinGet remains hidden until Microsoft accepts the catalog submission.

The public tap passed strict audit, a tap-qualified install, an exact `relmio --version` assertion, and `brew test` on macOS before this command was exposed. This follow-up changes only installation guidance and its UI/tests, so the sidecar-only VPS safety boundary and wizard behavior are unchanged.

## Validation

- `npm.cmd run check`: 123 tests, 0 failures; pass/skip counts vary by host platform
- `web/npm.cmd test`: production build plus 14/14 tests passed
- Web lint and TypeScript typecheck passed
- `npm.cmd audit --audit-level=high`: 0 vulnerabilities
- `npm.cmd pack --dry-run`: Relmio 0.2.14, 54 files
- Homebrew tap workflow: strict audit, install, exact version, and formula test passed on macOS
- Fresh Astral Sol/high review of the published tap: `ship`, no actionable findings

## Follow-up

WinGet stays out of all public commands until its external review, merge, and catalog propagation finish.

Related: microsoft/winget-pkgs#411993
