### PR TITLE
feat: ship copyable n8n HTTP Request recipe and v0.3.0

### DIFF
--- a/.agents/skills/changelog/SKILL.md
+++ b/.agents/skills/changelog/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: changelog
+description: Prepare and audit Relmio minor, patch, and major-feature release notes with synchronized semantic-version metadata. Use when changing CHANGELOG.md, choosing a release number, summarizing prior releases, creating a Git tag, or preparing a GitHub/npm release.
+---
+
+# Relmio changelog steward
+
+Use this skill whenever a release changes user-visible behavior, package
+metadata, documentation, installer behavior, or the public website.
+
+## Establish the release scope
+
+1. Read `package.json`, `package-lock.json`, `CHANGELOG.md`, the latest tags,
+   and the commits since the last release.
+2. Treat the newest released version as the baseline. Summarize only changes
+   that are present in the release, not future work under `Unreleased`.
+3. Keep release notes user-facing: describe the outcome and the reason it
+   matters, not internal implementation trivia.
+
+## Choose the semantic version
+
+Relmio is pre-1.0, so use the normal SemVer interpretation for `0.y.z`:
+
+- increment `z` for backward-compatible fixes, docs, or small maintenance;
+- increment `y` for a meaningful new capability, workflow, or compatibility
+  surface. Treat this as a major feature release in the release title even
+  though SemVer reserves the first digit for the eventual stable major line;
+- use `1.0.0` only when the project declares its stable public API;
+- increment the first digit after `1.0.0` for breaking public changes.
+
+Never reuse a published version. Confirm that `v<version>` does not already
+exist before preparing the release.
+
+## Write the entry
+
+Keep `## Unreleased` at the top. Add the newest dated entry immediately below
+it using the exact form `## [X.Y.Z] - YYYY-MM-DD`. Use only sections that have
+content, in this order:
+
+1. `Added` for new commands, pages, workflows, or supported capabilities;
+2. `Changed` for intentional behavior, UX, compatibility, or documentation
+   updates;
+3. `Fixed` for corrected failures and regressions;
+4. `Security` for security-boundary or dependency fixes.
+
+For a major feature release, begin `Added` or `Changed` with a short
+“Highlights since vA.B.C” bullet group when the release consolidates several
+prior patch releases. Do not copy every historical bullet; combine related
+changes and preserve the most important user impact. Keep sensitive values,
+tokens, private hosts, and live URLs out of the entry.
+
+## Synchronize release metadata
+
+The same version must appear in:
+
+- `package.json`;
+- both version fields in `package-lock.json`;
+- the newest `CHANGELOG.md` heading;
+- the annotated Git tag `v<version>` on the exact release commit;
+- the npm package and GitHub release after publication.
+
+Run `npm run release:check` before committing. Do not hand-edit a generated
+tarball or claim a tag/npm release exists until the external write succeeds.
+
+## Verify the release
+
+Run the repository's full check, dependency audit, package build, and package
+preview. Review the diff for accidental credentials or private infrastructure
+details. After a release is merged and published, verify the tag points to the
+merged commit and query npm anonymously for the exact version and integrity.

--- a/.agents/skills/changelog/agents/openai.yaml
+++ b/.agents/skills/changelog/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Changelog Steward"
+  short_description: "Standardize Relmio release notes"
+  default_prompt: "Use $changelog to prepare a synchronized semantic-version release changelog."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+## [0.3.0] - 2026-08-05
+
+### Added
+
+- Add a copy-ready n8n HTTP Request recipe to the local wizard, including the
+  private Chat Completions URL, Generic Credential Type → Bearer Auth fields,
+  the harmless `local-only` bearer placeholder, JSON headers, the structured
+  response-format body, and a full recipe copy action.
+- Add the same structured `gpt-5.6-sol` example and importable cURL recipe to
+  the GitHub README, npm README, and n8n configuration guide.
+- Add a repository-local changelog skill that standardizes Relmio's patch,
+  pre-1.0 feature, and stable major release numbering and metadata checks.
+
+### Changed
+
+- Treat `0.3.0` as Relmio's major feature release within the pre-1.0 series;
+  it consolidates the key improvements shipped from v0.2.10 through v0.2.14:
+  resilient Windows OAuth/bootstrap flows, native Command Prompt installation,
+  compact accessible wizard recipes, verified Homebrew/package-manager
+  preparation, and release-time package checks.
+- Keep the HTTP Request body aligned with n8n's `messages` format by targeting
+  `/v1/chat/completions`; the separate OpenAI Chat Model guidance continues to
+  support the Responses API where that node exposes the switch.
+
 ## [0.2.14] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -553,14 +553,49 @@ For an **OpenAI Chat Model**:
 
 The bridge supports both `/v1/responses` and `/v1/chat/completions`.
 
-For an **HTTP Request** node, an example endpoint is:
+For an **HTTP Request** node, use n8n's **Generic Credential Type** with
+**Bearer Auth**. Name the credential `openai-oauth` and enter the harmless
+placeholder `local-only` as its bearer token. Use this private endpoint and
+enable **Send Headers** and **Send Body**:
 
 ```text
-POST http://n8n-openai-oauth:10531/v1/responses
+POST http://n8n-openai-oauth:10531/v1/chat/completions
+Content-Type: application/json
 ```
 
-n8n may send `Authorization: Bearer local-only`. The bridge does not treat
-that placeholder as an OpenAI API key or secret.
+Select **JSON** and **Using JSON**, then paste this body (replace only the
+model if the wizard reports a different ID):
+
+```json
+{
+  "model": "gpt-5.6-sol",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is a robot?"
+    }
+  ],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "answer",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "content": { "type": "string" }
+        },
+        "required": ["content"],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
+}
+```
+
+The wizard's **Copy HTTP request recipe** action includes the same fields and
+body. The complete guide also includes an importable cURL command. The
+`local-only` bearer value is not an OpenAI Platform API key or secret.
 
 For complete copy-paste recipes for an **AI Agent**, **Basic LLM Chain**, and
 **HTTP Request** node, including an importable cURL command, open

--- a/docs/n8n-configuration.md
+++ b/docs/n8n-configuration.md
@@ -97,8 +97,9 @@ the chain.
 
 ## 3. HTTP Request node
 
-The HTTP Request recipe calls the bridge directly and does not need the n8n
-OpenAI credential.
+The HTTP Request recipe calls the bridge directly with n8n's generic Bearer
+Auth credential. It uses the Chat Completions route because the body below uses
+the `messages` format shown in the n8n node.
 
 ### Copy-paste fields
 
@@ -111,69 +112,120 @@ POST
 URL:
 
 ```text
-http://n8n-openai-oauth:10531/v1/responses
+http://n8n-openai-oauth:10531/v1/chat/completions
 ```
 
 Authentication:
 
 ```text
-None
+Generic Credential Type
 ```
 
-Header 1 name:
+Generic Auth Type:
 
 ```text
-Authorization
+Bearer Auth
 ```
 
-Header 1 value:
+Credential name:
 
 ```text
-Bearer local-only
+openai-oauth
 ```
 
-Header 2 name:
+Bearer token:
+
+```text
+local-only
+```
+
+Enable **Send Headers** and add this header:
+
+Header name:
 
 ```text
 Content-Type
 ```
 
-Header 2 value:
+Header value:
 
 ```text
 application/json
 ```
 
-JSON body:
+Enable **Send Body**, select **JSON** for **Body Content Type**, and choose
+**Using JSON** for **Specify Body**. Paste this body:
 
 ```json
 {
-  "model": "PASTE_ONE_MODEL_ID_FROM_THE_WIZARD",
-  "input": "Reply with exactly: bridge works"
+  "model": "gpt-5.6-sol",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is a robot?"
+    }
+  ],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "answer",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "content": { "type": "string" }
+        },
+        "required": ["content"],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
 }
 ```
 
-Enable **Send Headers** and **Send Body**, select a JSON body, and paste the
-object above.
+If the wizard reports a different model ID, replace only `gpt-5.6-sol` with
+that detected ID. The `local-only` bearer value is a harmless n8n placeholder;
+it is not an OpenAI Platform API key.
 
 ### Importable cURL version
 
-The n8n HTTP Request node can import a cURL command. Replace only the model
-placeholder:
+The n8n HTTP Request node can import this cURL command. Replace only the model
+if the wizard reports a different ID:
 
 ```bash
 curl --request POST \
-  --url http://n8n-openai-oauth:10531/v1/responses \
+  --url http://n8n-openai-oauth:10531/v1/chat/completions \
   --header 'Authorization: Bearer local-only' \
   --header 'Content-Type: application/json' \
   --data '{
-    "model": "PASTE_ONE_MODEL_ID_FROM_THE_WIZARD",
-    "input": "Reply with exactly: bridge works"
+    "model": "gpt-5.6-sol",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is a robot?"
+      }
+    ],
+    "response_format": {
+      "type": "json_schema",
+      "json_schema": {
+        "name": "answer",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "content": { "type": "string" }
+          },
+          "required": ["content"],
+          "additionalProperties": false
+        },
+        "strict": true
+      }
+    }
   }'
 ```
 
-The placeholder header is included because it matches OpenAI-compatible
-client behavior. It is not a real API credential.
+The cURL `Authorization` header is equivalent to the n8n Bearer Auth
+credential. It is included so the command can be imported or run as a direct
+connectivity check.
 
 ### Expression-driven HTTP body
 
@@ -182,8 +234,26 @@ After the fixed test succeeds, switch the entire JSON body field to
 
 ```javascript
 ={{ {
-  model: "PASTE_ONE_MODEL_ID_FROM_THE_WIZARD",
-  input: $json.prompt
+  model: "gpt-5.6-sol",
+  messages: [
+    {
+      role: "user",
+      content: $json.prompt
+    }
+  ],
+  response_format: {
+    type: "json_schema",
+    json_schema: {
+      name: "answer",
+      schema: {
+        type: "object",
+        properties: { content: { type: "string" } },
+        required: ["content"],
+        additionalProperties: false
+      },
+      strict: true
+    }
+  }
 } }}
 ```
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -219,6 +219,43 @@ Add Custom Header: Off
 The `local-only` value is a placeholder required by n8n. It is not an OpenAI
 Platform API key.
 
+For an n8n **HTTP Request** node, use **Generic Credential Type** → **Bearer
+Auth**, name the credential `openai-oauth`, and enter `local-only` as the
+bearer token. Enable **Send Headers** with `Content-Type: application/json`,
+then enable **Send Body** → **JSON** → **Using JSON** and paste:
+
+```json
+{
+  "model": "gpt-5.6-sol",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is a robot?"
+    }
+  ],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "answer",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "content": { "type": "string" }
+        },
+        "required": ["content"],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
+}
+```
+
+Use `POST http://n8n-openai-oauth:10531/v1/chat/completions` as the URL. The
+local wizard's **Copy HTTP request recipe** action supplies the same fields.
+Replace the model only if the wizard reports a different ID. The full guide
+has the importable cURL version.
+
 ## Important boundaries
 
 - Relmio does not create an OpenAI Platform API key.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relmio",
-  "version": "0.2.14",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relmio",
-      "version": "0.2.14",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ssh2": "1.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relmio",
-  "version": "0.2.14",
+  "version": "0.3.0",
   "description": "Turn a supported ChatGPT/Codex OAuth sign-in into a private OpenAI-compatible endpoint, starting with self-hosted n8n.",
   "keywords": [
     "relmio",

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -123,8 +123,28 @@ async function copyText(value) {
 function renderHttpRequestBody(model) {
   element("result-http-body").textContent = JSON.stringify(
     {
-      model,
-      input: "Reply with exactly: bridge works",
+      model: model === "Not detected" ? "gpt-5.6-sol" : model,
+      messages: [
+        {
+          role: "user",
+          content: "What is a robot?",
+        },
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "answer",
+          schema: {
+            type: "object",
+            properties: {
+              content: { type: "string" },
+            },
+            required: ["content"],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      },
     },
     null,
     2,
@@ -144,9 +164,16 @@ function copyHttpRecipe() {
   return [
     "Method: POST",
     `URL: ${element("result-http-url").textContent}`,
-    "Authorization: Bearer local-only",
+    "Authentication: Generic Credential Type",
+    "Generic Auth Type: Bearer Auth",
+    "Credential: openai-oauth",
+    `Bearer token: ${element("result-key").textContent}`,
+    `Authorization: ${element("result-http-auth").textContent}`,
     "Content-Type: application/json",
-    "Authentication: None",
+    "Send Headers: On",
+    "Send Body: On",
+    "Body Content Type: JSON",
+    "Specify Body: Using JSON",
     "JSON body:",
     element("result-http-body").textContent,
   ].join("\n");
@@ -598,7 +625,7 @@ element("install-button").addEventListener("click", async (event) => {
     element("result-model").textContent = firstModel;
     element("result-models").textContent = result.models.join(", ");
     element("result-http-url").textContent =
-      `${result.baseUrl.replace(/\/$/u, "")}/responses`;
+      `${result.baseUrl.replace(/\/$/u, "")}/chat/completions`;
     renderHttpRequestBody(firstModel);
     showStep(5);
     setMessage(

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -488,7 +488,7 @@
               <div>
                 <dt>URL</dt>
                 <dd class="result-value">
-                  <code id="result-http-url">http://n8n-openai-oauth:10531/v1/responses</code>
+                  <code id="result-http-url">http://n8n-openai-oauth:10531/v1/chat/completions</code>
                   <button
                     class="button secondary copy-value"
                     type="button"
@@ -501,16 +501,43 @@
                 </dd>
               </div>
               <div>
-                <dt>Authorization</dt>
-                <dd><code>Bearer local-only</code></dd>
+                <dt>Authentication</dt>
+                <dd>Generic Credential Type</dd>
+              </div>
+              <div>
+                <dt>Generic Auth Type</dt>
+                <dd>Bearer Auth</dd>
+              </div>
+              <div>
+                <dt>Credential</dt>
+                <dd><code>openai-oauth</code></dd>
+              </div>
+              <div>
+                <dt>Bearer token</dt>
+                <dd><code>local-only</code></dd>
+              </div>
+              <div>
+                <dt>Authorization header</dt>
+                <dd class="result-value">
+                  <code id="result-http-auth">Bearer local-only</code>
+                  <button
+                    class="button secondary copy-value"
+                    type="button"
+                    data-copy-target="result-http-auth"
+                    data-copy-label="Authorization header"
+                    aria-label="Copy Authorization header"
+                  >
+                    Copy
+                  </button>
+                </dd>
               </div>
               <div>
                 <dt>Content-Type</dt>
                 <dd><code>application/json</code></dd>
               </div>
               <div>
-                <dt>Authentication</dt>
-                <dd>None</dd>
+                <dt>Send body</dt>
+                <dd>On · JSON · Using JSON</dd>
               </div>
               <div class="sample-body-row">
                 <dt>JSON body</dt>

--- a/test/documentation.test.js
+++ b/test/documentation.test.js
@@ -166,9 +166,11 @@ test("n8n configuration guide provides copy-paste model and HTTP recipes", async
   assert.match(guide, /AI Agent/u);
   assert.match(guide, /Basic LLM Chain/u);
   assert.match(guide, /OpenAI Chat Model/u);
-  assert.match(guide, /http:\/\/n8n-openai-oauth:10531\/v1\/responses/u);
+  assert.match(guide, /http:\/\/n8n-openai-oauth:10531\/v1\/chat\/completions/u);
   assert.match(guide, /Bearer local-only/u);
-  assert.match(guide, /PASTE_ONE_MODEL_ID_FROM_THE_WIZARD/u);
+  assert.match(guide, /"model": "gpt-5\.6-sol"/u);
+  assert.match(guide, /"messages"/u);
+  assert.match(guide, /"response_format"/u);
   assert.match(guide, /curl --request POST/u);
   assert.match(guide, /node version 1\.3/u);
   assert.match(guide, /\/v1\/chat\/completions/u);

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -99,9 +99,16 @@ test("wizard HTML has accessible landmarks, labels, and no inline scripts", asyn
     /<details class="recipe-disclosure">[\s\S]*<summary>[\s\S]*HTTP Request node/u,
   );
   assert.match(html, /<dt>Method<\/dt>[\s\S]*<code>POST<\/code>/u);
-  assert.match(html, /Authorization[\s\S]*Bearer local-only/u);
+  assert.match(html, /Generic Auth Type[\s\S]*Bearer Auth/u);
+  assert.match(html, /Credential[\s\S]*openai-oauth/u);
+  assert.match(html, /Bearer token[\s\S]*local-only/u);
+  assert.match(html, /Authorization header[\s\S]*Bearer local-only/u);
+  assert.match(
+    html,
+    /data-copy-target="result-http-auth"[\s\S]*aria-label="Copy Authorization header"/u,
+  );
   assert.match(html, /Content-Type[\s\S]*application\/json/u);
-  assert.match(html, /Authentication[\s\S]*None/u);
+  assert.match(html, /Send body[\s\S]*JSON[\s\S]*Using JSON/u);
   assert.match(html, /id="result-http-body"/u);
   assert.match(html, /OpenAI credential[\s\S]*OpenAI Chat Model/u);
   assert.doesNotMatch(html, /<script(?![^>]*\bsrc=)/);
@@ -139,10 +146,15 @@ test("browser code never uses innerHTML or web storage for credentials", async (
     app,
     /const textarea = document\.createElement\("textarea"\);[\s\S]*textarea\.focus\(\);[\s\S]*textarea\.select\(\);[\s\S]*textarea\.setSelectionRange\?\.\(0, textarea\.value\.length\);[\s\S]*document\.execCommand\("copy"\)[\s\S]*finally \{[\s\S]*textarea\.remove\(\);[\s\S]*previouslyFocused\?\.focus\?\.\(\);[\s\S]*if \(copied\) \{[\s\S]*navigator\.clipboard\.writeText\(value\)/u,
   );
-  assert.match(
-    app,
-    /JSON\.stringify\(\s*\{[\s\S]*input: "Reply with exactly: bridge works"/u,
-  );
+  assert.match(app, /messages:[\s\S]*What is a robot\?/u);
+  assert.match(app, /response_format:[\s\S]*json_schema/u);
+  assert.match(app, /additionalProperties: false/u);
+  assert.match(app, /strict: true/u);
+  assert.match(app, /chat\/completions/u);
+  assert.match(app, /Authentication: Generic Credential Type/u);
+  assert.match(app, /Generic Auth Type: Bearer Auth/u);
+  assert.match(app, /Authorization: \$\{element\("result-http-auth"\)\.textContent\}/u);
+  assert.match(app, /Specify Body: Using JSON/u);
   assert.match(app, /function dismissToast\(toast\)/u);
   assert.match(app, /document\.body\.dataset\.currentStep = String\(step\)/u);
   assert.match(


### PR DESCRIPTION
## Summary

- update the local wizard's HTTP Request recipe to the n8n Generic Credential Type / Bearer Auth flow shown in the supplied references;
- use the private `/v1/chat/completions` route with `Bearer local-only`, JSON headers, and the supplied structured `gpt-5.6-sol` body;
- add copy actions for the URL, Authorization header, JSON body, and complete recipe;
- synchronize the GitHub README, npm README, and n8n configuration guide;
- prepare `v0.3.0` and add the repository-local changelog skill.

## Verification

- `npm run check` — 117 passed, 6 Windows-only tests skipped;
- `npm audit --audit-level=high` — 0 vulnerabilities;
- `npm run package:build -- .release` and `npm pack --dry-run` — pass;
- web lint, typecheck, Vinext build/tests (14/14), Next webpack build, and web audit — pass;
- Opera GX sanitized wizard QA at desktop and 390px mobile — no console issues, failed requests, or overflow; copy actions report `Copied`.

The release tag and GitHub release will be created only after this PR's required checks pass.
