### PR TITLE
Fix curl installer terminal handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+### Fixed
+
+- Keep the controlling terminal attached when the macOS/Linux installer is
+  piped through `sh`, so the Relmio wizard can open its interactive browser
+  setup flow.
+
 ## [0.3.1] - 2026-08-10
 
 ### Changed

--- a/test/install-script.test.js
+++ b/test/install-script.test.js
@@ -88,21 +88,46 @@ function runInstallerWithoutControllingTerminal(env) {
   );
 }
 
-function runGitBashInstallerInTerminal(shell, env) {
+async function waitForCompletion(path, timeout = 60_000) {
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() < deadline) {
+    try {
+      return await readFile(path, "utf8");
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 50));
+  }
+
+  throw new Error("Timed out waiting for the Git Bash installer fixture.");
+}
+
+async function runGitBashInstallerInTerminal(
+  shell,
+  env,
+  completionLog = null,
+) {
   if (process.platform !== "win32") {
     return runCommandInPseudoTerminal(pipedInstallerCommand, env, shell);
   }
 
-  return execFileAsync(
+  await execFileAsync(
     process.env.ComSpec || "cmd.exe",
     [
       "/d",
       "/s",
       "/c",
-      `start "" /wait "${shell}" -lc "${pipedInstallerCommand}"`,
+      `start "" "${shell}" "${env.RELMIO_TEST_LAUNCHER}"`,
     ],
-    { env, timeout: 60_000 },
+    { env, timeout: 10_000 },
   );
+
+  const exitCode = (await waitForCompletion(completionLog)).trim();
+  if (exitCode !== "0") {
+    throw new Error(`Git Bash installer fixture exited with ${exitCode}.`);
+  }
+  return { stderr: "", stdout: "" };
 }
 
 async function resolveGitBashShell() {
@@ -231,6 +256,8 @@ async function createGitBashBootstrapEnvironment() {
   const bootstrapTemp = join(root, "tmp");
   const log = join(root, "invocation.log");
   const pipeLog = join(root, "pipe.log");
+  const completionLog = join(root, "completion.log");
+  const launcher = join(root, "launch.sh");
   const bashEnvironment = join(root, "bash-environment");
   const fixture = await createWindowsNodeFixture(root);
 
@@ -244,6 +271,15 @@ async function createGitBashBootstrapEnvironment() {
     );
   }
   await writeExecutable(join(fakeBin, "node"), '#!/bin/sh\nprintf "18\\n"\n');
+  await writeExecutable(
+    launcher,
+    `#!/bin/sh
+${pipedInstallerCommand}
+status=$?
+echo "$status" > "$RELMIO_TEST_COMPLETION_LOG"
+exit "$status"
+`,
+  );
   await writeExecutable(
     join(fakeBin, "uname"),
     `#!/bin/sh
@@ -315,6 +351,7 @@ cp -R "$RELMIO_TEST_WINDOWS_ROOT" "$destination/"
 
   return {
     bootstrapTemp,
+    completionLog,
     fixture,
     log,
     pipeLog,
@@ -327,7 +364,9 @@ cp -R "$RELMIO_TEST_WINDOWS_ROOT" "$destination/"
         ? { BASH_ENV: toGitBashPath(bashEnvironment) }
         : {}),
       RELMIO_TEST_ARCHIVE: fixture.archive,
+      RELMIO_TEST_COMPLETION_LOG: toGitBashPath(completionLog),
       RELMIO_TEST_LOG: log,
+      RELMIO_TEST_LAUNCHER: toGitBashPath(launcher),
       RELMIO_TEST_MANIFEST: fixture.manifest,
       RELMIO_TEST_PIPE_LOG: pipeLog,
       RELMIO_TEST_INSTALLER: toGitBashPath(resolve(installScript)),
@@ -576,7 +615,11 @@ test(
     const shell = await resolveGitBashShell();
     t.after(() => rm(setup.root, { recursive: true, force: true }));
 
-    const { stdout } = await runGitBashInstallerInTerminal(shell, setup.env);
+    const { stdout } = await runGitBashInstallerInTerminal(
+      shell,
+      setup.env,
+      setup.completionLog,
+    );
     const invocation = (await readFile(setup.log, "utf8")).trim().split("\n");
     assert.equal(await readFile(setup.pipeLog, "utf8"), "installer-script-piped\n");
 

--- a/test/install-script.test.js
+++ b/test/install-script.test.js
@@ -88,18 +88,19 @@ function runInstallerWithoutControllingTerminal(env) {
   );
 }
 
-async function runGitBashInstallerInTerminal(shell, env) {
+function runGitBashInstallerInTerminal(shell, env) {
   if (process.platform !== "win32") {
     return runCommandInPseudoTerminal(pipedInstallerCommand, env, shell);
   }
 
-  const gitRoot = resolve(shell, "..", "..");
-  const winpty = join(gitRoot, "usr", "bin", "winpty.exe");
-  await access(winpty);
-
   return execFileAsync(
-    winpty,
-    ["-Xallow-non-tty", "--", shell, "-lc", pipedInstallerCommand],
+    process.env.ComSpec || "cmd.exe",
+    [
+      "/d",
+      "/s",
+      "/c",
+      `start "" /wait "${shell}" -lc "${pipedInstallerCommand}"`,
+    ],
     { env, timeout: 60_000 },
   );
 }
@@ -212,6 +213,7 @@ if (realpathSync(firstPathEntry) !== realpathSync(runtimeDirectory)) {
 
 appendFileSync(log, "child-node-ok\\n");
 appendFileSync(log, process.stdin.isTTY ? "stdin-is-a-tty\\n" : "stdin-is-not-a-tty\\n");
+process.exit(0);
 `,
     "utf8",
   );

--- a/test/install-script.test.js
+++ b/test/install-script.test.js
@@ -112,13 +112,21 @@ async function runGitBashInstallerInTerminal(
     return runCommandInPseudoTerminal(pipedInstallerCommand, env, shell);
   }
 
+  const gitRoot = resolve(shell, "..", "..");
+  const terminal = join(gitRoot, "usr", "bin", "mintty.exe");
+  await access(terminal);
+
   await new Promise((resolveSpawn, rejectSpawn) => {
-    const child = spawn(shell, [env.RELMIO_TEST_LAUNCHER], {
-      detached: true,
-      env,
-      stdio: "ignore",
-      windowsHide: false,
-    });
+    const child = spawn(
+      terminal,
+      ["--hold=never", "--exec", shell, env.RELMIO_TEST_LAUNCHER],
+      {
+        detached: true,
+        env,
+        stdio: "ignore",
+        windowsHide: false,
+      },
+    );
     child.once("error", rejectSpawn);
     child.once("spawn", () => {
       child.unref();
@@ -128,7 +136,10 @@ async function runGitBashInstallerInTerminal(
 
   const exitCode = (await waitForCompletion(completionLog)).trim();
   if (exitCode !== "0") {
-    throw new Error(`Git Bash installer fixture exited with ${exitCode}.`);
+    const diagnostics = await readFile(env.RELMIO_TEST_DIAGNOSTIC_LOG, "utf8");
+    throw new Error(
+      `Git Bash installer fixture exited with ${exitCode}: ${diagnostics.trim()}`,
+    );
   }
   return { stderr: "", stdout: "" };
 }
@@ -260,6 +271,7 @@ async function createGitBashBootstrapEnvironment() {
   const log = join(root, "invocation.log");
   const pipeLog = join(root, "pipe.log");
   const completionLog = join(root, "completion.log");
+  const diagnosticLog = join(root, "diagnostic.log");
   const launcher = join(root, "launch.sh");
   const bashEnvironment = join(root, "bash-environment");
   const fixture = await createWindowsNodeFixture(root);
@@ -277,7 +289,7 @@ async function createGitBashBootstrapEnvironment() {
   await writeExecutable(
     launcher,
     `#!/bin/sh
-${pipedInstallerCommand}
+${pipedInstallerCommand} > "$RELMIO_TEST_DIAGNOSTIC_LOG" 2>&1
 status=$?
 echo "$status" > "$RELMIO_TEST_COMPLETION_LOG"
 exit "$status"
@@ -368,6 +380,7 @@ cp -R "$RELMIO_TEST_WINDOWS_ROOT" "$destination/"
         : {}),
       RELMIO_TEST_ARCHIVE: fixture.archive,
       RELMIO_TEST_COMPLETION_LOG: toGitBashPath(completionLog),
+      RELMIO_TEST_DIAGNOSTIC_LOG: toGitBashPath(diagnosticLog),
       RELMIO_TEST_LOG: log,
       RELMIO_TEST_LAUNCHER: toGitBashPath(launcher),
       RELMIO_TEST_MANIFEST: fixture.manifest,

--- a/test/install-script.test.js
+++ b/test/install-script.test.js
@@ -88,20 +88,19 @@ function runInstallerWithoutControllingTerminal(env) {
   );
 }
 
-function runGitBashInstallerInTerminal(shell, env) {
+async function runGitBashInstallerInTerminal(shell, env) {
   if (process.platform !== "win32") {
     return runCommandInPseudoTerminal(pipedInstallerCommand, env, shell);
   }
 
+  const gitRoot = resolve(shell, "..", "..");
+  const winpty = join(gitRoot, "usr", "bin", "winpty.exe");
+  await access(winpty);
+
   return execFileAsync(
-    process.env.ComSpec || "cmd.exe",
-    [
-      "/d",
-      "/s",
-      "/c",
-      `start "" /wait "${shell}" -lc "${pipedInstallerCommand}"`,
-    ],
-    { env },
+    winpty,
+    ["-Xallow-non-tty", "--", shell, "-lc", pipedInstallerCommand],
+    { env, timeout: 60_000 },
   );
 }
 

--- a/test/install-script.test.js
+++ b/test/install-script.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   access,
@@ -112,16 +112,19 @@ async function runGitBashInstallerInTerminal(
     return runCommandInPseudoTerminal(pipedInstallerCommand, env, shell);
   }
 
-  await execFileAsync(
-    process.env.ComSpec || "cmd.exe",
-    [
-      "/d",
-      "/s",
-      "/c",
-      `start "" "${shell}" "${env.RELMIO_TEST_LAUNCHER}"`,
-    ],
-    { env, timeout: 10_000 },
-  );
+  await new Promise((resolveSpawn, rejectSpawn) => {
+    const child = spawn(shell, [env.RELMIO_TEST_LAUNCHER], {
+      detached: true,
+      env,
+      stdio: "ignore",
+      windowsHide: false,
+    });
+    child.once("error", rejectSpawn);
+    child.once("spawn", () => {
+      child.unref();
+      resolveSpawn();
+    });
+  });
 
   const exitCode = (await waitForCompletion(completionLog)).trim();
   if (exitCode !== "0") {

--- a/test/install-script.test.js
+++ b/test/install-script.test.js
@@ -26,6 +26,84 @@ const gitBashShell =
   process.platform === "win32"
     ? process.env.RELMIO_TEST_POSIX_SHELL
     : "/bin/sh";
+const pseudoTerminal =
+  process.platform === "darwin" || process.platform === "linux"
+    ? "python3"
+    : null;
+const pipedInstallerCommand =
+  "curl -fsSL https://relmio.vercel.app/install.sh | sh";
+const pseudoTerminalProgram = String.raw`
+import errno
+import os
+import pty
+import sys
+
+child_process, terminal = pty.fork()
+if child_process == 0:
+    os.execvpe(sys.argv[1], [sys.argv[1], "-c", sys.argv[2]], os.environ)
+
+while True:
+    try:
+        output = os.read(terminal, 1024)
+        if not output:
+            break
+        os.write(1, output)
+    except OSError as error:
+        if error.errno == errno.EIO:
+            break
+        raise
+
+_, status = os.waitpid(child_process, 0)
+sys.exit(os.waitstatus_to_exitcode(status))
+`;
+const noControllingTerminalProgram = String.raw`
+import os
+import sys
+
+os.setsid()
+os.execvpe("/bin/sh", ["/bin/sh", sys.argv[1]], os.environ)
+`;
+
+async function runCommandInPseudoTerminal(
+  command,
+  env,
+  shell = "/bin/sh",
+) {
+  return execFileAsync(
+    pseudoTerminal,
+    ["-c", pseudoTerminalProgram, shell, command],
+    { env },
+  );
+}
+
+function runPipedInstallerInPseudoTerminal(env) {
+  return runCommandInPseudoTerminal(pipedInstallerCommand, env);
+}
+
+function runInstallerWithoutControllingTerminal(env) {
+  return execFileAsync(
+    pseudoTerminal,
+    ["-c", noControllingTerminalProgram, installScript],
+    { env },
+  );
+}
+
+function runGitBashInstallerInTerminal(shell, env) {
+  if (process.platform !== "win32") {
+    return runCommandInPseudoTerminal(pipedInstallerCommand, env, shell);
+  }
+
+  return execFileAsync(
+    process.env.ComSpec || "cmd.exe",
+    [
+      "/d",
+      "/s",
+      "/c",
+      `start "" /wait "${shell}" -lc "${pipedInstallerCommand}"`,
+    ],
+    { env },
+  );
+}
 
 async function resolveGitBashShell() {
   if (
@@ -66,7 +144,10 @@ async function writeExecutable(path, contents) {
   await chmod(path, 0o755);
 }
 
-async function createPortableNodeFixture(root, { validChecksum = true } = {}) {
+async function createPortableNodeFixture(
+  root,
+  { captureStdin = false, validChecksum = true } = {},
+) {
   const platform = process.platform === "darwin" ? "darwin" : "linux";
   const architecture = process.arch === "arm64" ? "arm64" : "x64";
   const version = "v22.23.2";
@@ -82,7 +163,16 @@ async function createPortableNodeFixture(root, { validChecksum = true } = {}) {
   await mkdir(join(archiveRoot, "bin"), { recursive: true });
   await writeExecutable(
     nodePath,
-    '#!/bin/sh\nprintf "%s\\n" "$@" > "$RELMIO_TEST_LOG"\n',
+    captureStdin
+      ? `#!/bin/sh
+printf "%s\\n" "$@" > "$RELMIO_TEST_LOG"
+if [ -t 0 ]; then
+  printf "stdin-is-a-tty\\n" >> "$RELMIO_TEST_LOG"
+else
+  printf "stdin-is-not-a-tty\\n" >> "$RELMIO_TEST_LOG"
+fi
+`
+      : '#!/bin/sh\nprintf "%s\\n" "$@" > "$RELMIO_TEST_LOG"\n',
   );
   await writeFile(join(npmCli, "npx-cli.js"), "// fixture\n", "utf8");
   await execFileAsync("tar", ["-czf", archive, "-C", fixtureRoot, basename]);
@@ -122,6 +212,7 @@ if (realpathSync(firstPathEntry) !== realpathSync(runtimeDirectory)) {
 }
 
 appendFileSync(log, "child-node-ok\\n");
+appendFileSync(log, process.stdin.isTTY ? "stdin-is-a-tty\\n" : "stdin-is-not-a-tty\\n");
 `,
     "utf8",
   );
@@ -138,6 +229,7 @@ async function createGitBashBootstrapEnvironment() {
   const fakeBin = join(root, "bin");
   const bootstrapTemp = join(root, "tmp");
   const log = join(root, "invocation.log");
+  const pipeLog = join(root, "pipe.log");
   const bashEnvironment = join(root, "bash-environment");
   const fixture = await createWindowsNodeFixture(root);
 
@@ -185,6 +277,10 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 case "$url" in
+  https://relmio.vercel.app/install.sh)
+    printf "installer-script-piped\\n" > "$RELMIO_TEST_PIPE_LOG"
+    cat "$RELMIO_TEST_INSTALLER"
+    ;;
   https://nodejs.org/download/release/latest-v22.x/SHASUMS256.txt)
     cp "$RELMIO_TEST_MANIFEST" "$output"
     ;;
@@ -220,6 +316,7 @@ cp -R "$RELMIO_TEST_WINDOWS_ROOT" "$destination/"
     bootstrapTemp,
     fixture,
     log,
+    pipeLog,
     root,
     env: {
       ...process.env,
@@ -231,17 +328,24 @@ cp -R "$RELMIO_TEST_WINDOWS_ROOT" "$destination/"
       RELMIO_TEST_ARCHIVE: fixture.archive,
       RELMIO_TEST_LOG: log,
       RELMIO_TEST_MANIFEST: fixture.manifest,
+      RELMIO_TEST_PIPE_LOG: pipeLog,
+      RELMIO_TEST_INSTALLER: toGitBashPath(resolve(installScript)),
       RELMIO_TEST_WINDOWS_ROOT: fixture.fixtureRoot,
     },
   };
 }
 
-async function createBootstrapEnvironment({ validChecksum = true } = {}) {
+async function createBootstrapEnvironment(
+  { captureStdin = false, validChecksum = true } = {},
+) {
   const root = await mkdtemp(join(tmpdir(), "relmio-install-test-"));
   const fakeBin = join(root, "bin");
   const bootstrapTemp = join(root, "tmp");
   const log = join(root, "invocation.log");
-  const fixture = await createPortableNodeFixture(root, { validChecksum });
+  const fixture = await createPortableNodeFixture(root, {
+    captureStdin,
+    validChecksum,
+  });
 
   await mkdir(fakeBin);
   await mkdir(bootstrapTemp);
@@ -274,6 +378,9 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 case "$url" in
+  https://relmio.vercel.app/install.sh)
+    cat "$RELMIO_TEST_INSTALLER"
+    ;;
   https://nodejs.org/download/release/latest-v22.x/SHASUMS256.txt)
     cp "$RELMIO_TEST_MANIFEST" "$output"
     ;;
@@ -327,13 +434,11 @@ test(
       '#!/bin/sh\nprintf "curl\\n" >> "$RELMIO_TEST_DOWNLOAD_LOG"\nexit 97\n',
     );
 
-    const { stdout } = await execFileAsync("/bin/sh", [installScript], {
-      env: {
-        ...process.env,
-        PATH: `${fakeBin}:${process.env.PATH}`,
-        RELMIO_TEST_DOWNLOAD_LOG: downloadLog,
-        RELMIO_TEST_LOG: log,
-      },
+    const { stdout } = await runCommandInPseudoTerminal(installScript, {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      RELMIO_TEST_DOWNLOAD_LOG: downloadLog,
+      RELMIO_TEST_LOG: log,
     });
 
     assert.match(stdout, /Using installed Node\.js 22/u);
@@ -347,15 +452,102 @@ test(
 );
 
 test(
+  "curl installer explains when no controlling terminal is available",
+  { skip: process.platform === "win32" },
+  async (t) => {
+    const root = await mkdtemp(join(tmpdir(), "relmio-no-tty-test-"));
+    const fakeBin = join(root, "bin");
+    const log = join(root, "invocation.log");
+    t.after(() => rm(root, { recursive: true, force: true }));
+
+    await mkdir(fakeBin);
+    await writeExecutable(
+      join(fakeBin, "node"),
+      '#!/bin/sh\nprintf "22\\n"\n',
+    );
+    await writeExecutable(
+      join(fakeBin, "npx"),
+      '#!/bin/sh\nprintf "unexpected invocation\\n" > "$RELMIO_TEST_LOG"\n',
+    );
+
+    await assert.rejects(
+      runInstallerWithoutControllingTerminal({
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        RELMIO_TEST_LOG: log,
+      }),
+      /An interactive terminal is required to start Relmio/u,
+    );
+    await assert.rejects(readFile(log, "utf8"), { code: "ENOENT" });
+  },
+);
+
+test(
+  "curl installer gives an installed runtime its controlling terminal after a piped shell handoff",
+  { skip: !pseudoTerminal },
+  async (t) => {
+    const root = await mkdtemp(join(tmpdir(), "relmio-installed-node-tty-test-"));
+    const fakeBin = join(root, "bin");
+    const log = join(root, "invocation.log");
+    t.after(() => rm(root, { recursive: true, force: true }));
+
+    await mkdir(fakeBin);
+    await writeExecutable(
+      join(fakeBin, "node"),
+      '#!/bin/sh\nprintf "22\\n"\n',
+    );
+    await writeExecutable(
+      join(fakeBin, "npx"),
+      `#!/bin/sh
+if [ -t 0 ]; then
+  printf "stdin-is-a-tty\\n" > "$RELMIO_TEST_LOG"
+else
+  printf "stdin-is-not-a-tty\\n" > "$RELMIO_TEST_LOG"
+fi
+`,
+    );
+    await writeExecutable(
+      join(fakeBin, "curl"),
+      '#!/bin/sh\ncat "$RELMIO_TEST_INSTALLER"\n',
+    );
+
+    await runPipedInstallerInPseudoTerminal({
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      RELMIO_TEST_INSTALLER: resolve(installScript),
+      RELMIO_TEST_LOG: log,
+    });
+
+    assert.equal(await readFile(log, "utf8"), "stdin-is-a-tty\n");
+  },
+);
+
+test(
+  "curl installer gives a portable runtime its controlling terminal after a piped shell handoff",
+  { skip: !pseudoTerminal || !supportsPortableFixture },
+  async (t) => {
+    const setup = await createBootstrapEnvironment({ captureStdin: true });
+    t.after(() => rm(setup.root, { recursive: true, force: true }));
+
+    await runPipedInstallerInPseudoTerminal({
+      ...setup.env,
+      RELMIO_TEST_INSTALLER: resolve(installScript),
+    });
+
+    const invocation = (await readFile(setup.log, "utf8")).trim().split("\n");
+    assert.equal(invocation.at(-1), "stdin-is-a-tty");
+    assert.deepEqual(await readdir(setup.bootstrapTemp), []);
+  },
+);
+
+test(
   "curl installer downloads, verifies, and removes a temporary Node runtime",
   { skip: !supportsPortableFixture },
   async (t) => {
     const setup = await createBootstrapEnvironment();
     t.after(() => rm(setup.root, { recursive: true, force: true }));
 
-    const { stdout } = await execFileAsync("/bin/sh", [installScript], {
-      env: setup.env,
-    });
+    const { stdout } = await runCommandInPseudoTerminal(installScript, setup.env);
     const invocation = (await readFile(setup.log, "utf8")).trim().split("\n");
 
     assert.match(stdout, /Installing a temporary Node\.js 22 runtime\. Please wait/u);
@@ -383,17 +575,19 @@ test(
     const shell = await resolveGitBashShell();
     t.after(() => rm(setup.root, { recursive: true, force: true }));
 
-    const { stdout } = await execFileAsync(shell, [installScript], {
-      env: setup.env,
-    });
+    const { stdout } = await runGitBashInstallerInTerminal(shell, setup.env);
     const invocation = (await readFile(setup.log, "utf8")).trim().split("\n");
+    assert.equal(await readFile(setup.pipeLog, "utf8"), "installer-script-piped\n");
 
-    assert.match(stdout, /Verified Node\.js download/u);
+    if (process.platform !== "win32") {
+      assert.match(stdout, /Verified Node\.js download/u);
+    }
     assert.match(
       invocation[0].replaceAll("\\", "/"),
       new RegExp(`${setup.fixture.basename}/node_modules/npm/bin/npx-cli\\.js$`, "u"),
     );
-    assert.equal(invocation.at(-1), "child-node-ok");
+    assert.equal(invocation.at(-2), "child-node-ok");
+    assert.equal(invocation.at(-1), "stdin-is-a-tty");
     assert.deepEqual(await readdir(setup.bootstrapTemp), []);
   },
 );
@@ -406,8 +600,14 @@ test(
     t.after(() => rm(setup.root, { recursive: true, force: true }));
 
     await assert.rejects(
-      execFileAsync("/bin/sh", [installScript], { env: setup.env }),
-      /Node\.js download checksum did not match/u,
+      runCommandInPseudoTerminal(installScript, setup.env),
+      (error) => {
+        assert.match(
+          error.stdout,
+          /Node\.js download checksum did not match/u,
+        );
+        return true;
+      },
     );
     await assert.rejects(readFile(setup.log, "utf8"), { code: "ENOENT" });
     assert.deepEqual(await readdir(setup.bootstrapTemp), []);

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -5,6 +5,7 @@ set -eu
 minimum_node_major=22
 node_dist_url="https://nodejs.org/download/release"
 temporary_directory=""
+terminal_input="/dev/tty"
 
 say() {
   printf 'Relmio installer: %s\n' "$1"
@@ -14,6 +15,10 @@ fail() {
   printf 'Relmio installer: %s\n' "$1" >&2
   exit 1
 }
+
+if ! ( : < "$terminal_input" ) 2>/dev/null; then
+  fail "An interactive terminal is required to start Relmio. Run this command from a local terminal."
+fi
 
 download() {
   curl -fsSL \
@@ -45,7 +50,7 @@ case "$installed_node_major" in
     if [ "$installed_node_major" -ge "$minimum_node_major" ] \
       && command -v npx >/dev/null 2>&1; then
       say "Using installed Node.js ${installed_node_major} runtime."
-      npx --yes --ignore-scripts relmio@latest </dev/null
+      npx --yes --ignore-scripts relmio@latest < "$terminal_input"
       exit $?
     fi
     ;;
@@ -190,4 +195,4 @@ fi
 say "Starting the newest Relmio wizard."
 node_directory="${node_binary%/*}"
 PATH="$node_directory${PATH:+:$PATH}" \
-  "$node_binary" "$npx_cli" --yes --ignore-scripts relmio@latest </dev/null
+  "$node_binary" "$npx_cli" --yes --ignore-scripts relmio@latest < "$terminal_input"


### PR DESCRIPTION
## What changed

- validate that a controlling terminal is available before starting the macOS/Linux installer
- pass `/dev/tty` to both the installed-Node and portable-Node Relmio launch paths
- add real PTY regression coverage for the exact `curl | sh` pipeline, both runtime paths, no-terminal failure, and the Git Bash fixture

## Why

The installer historically redirected the Relmio process from `/dev/null` so it would not consume the remaining curl pipe. After the CLI began requiring interactive stdin and stdout, that redirect guaranteed a non-interactive launch and produced the “interactive terminal” error even from a real terminal.

## Impact

`curl -fsSL https://relmio.vercel.app/install.sh | sh` can open the local wizard again while still failing clearly when no controlling terminal exists. PowerShell, CMD, and npm behavior are unchanged.

## Validation

- `npm run check` — 123 passed, 6 Windows-only skipped, 0 failed
- focused installer suite — 7/7 passed
- `sh -n web/public/install.sh`
- `git diff --check`
- `npm audit --audit-level=high`
- `npm pack --dry-run`
- independent Astral Sol review: ship

Native Windows CI remains required before merge. After merge, the live Vercel installer and external Homebrew tap will be synchronized and verified by the release-everywhere audit.
