### PR TITLE
Fix Homebrew dependency ordering

### DIFF
--- a/scripts/generate-package-manager-manifests.js
+++ b/scripts/generate-package-manager-manifests.js
@@ -74,8 +74,8 @@ export function createHomebrewFormula({ sha256, version }) {
   sha256 "${digest}"
   license "Apache-2.0"
 
-  depends_on "node"
   depends_on "python" => :build
+  depends_on "node"
 
   def install
     system "npm", "install", *std_npm_args

--- a/test/package-manager.test.js
+++ b/test/package-manager.test.js
@@ -91,6 +91,11 @@ test("Homebrew candidate follows the standard Node formula layout", () => {
   assert.match(formula, /url "https:\/\/registry\.npmjs\.org\/relmio\/-\/relmio-1\.2\.3\.tgz"/u);
   assert.match(formula, /depends_on "node"/u);
   assert.match(formula, /depends_on "python" => :build/u);
+  assert.ok(
+    formula.indexOf('depends_on "python" => :build') <
+      formula.indexOf('depends_on "node"'),
+    "Homebrew build dependencies must precede runtime dependencies",
+  );
   assert.match(formula, /system "npm", "install", \*std_npm_args/u);
   assert.match(formula, /bin\.install_symlink libexec\.glob\("bin\/\*"\)/u);
   assert.match(formula, /assert_predicate bin\/"relmio", :executable\?/u);


### PR DESCRIPTION
Makes generated Homebrew formula candidates pass brew style by emitting the build-only Python dependency before the runtime Node dependency. Adds a regression assertion for the required order. Validation: focused test, full npm check, npm audit, npm package preview, generated candidate, and brew style.