### PR TITLE
fix: make OAuth process recovery retry-safe

### DIFF
--- a/src/services/oauth.js
+++ b/src/services/oauth.js
@@ -10,6 +10,10 @@ const LOGIN_URL_TIMEOUT_MS = 15_000;
 const LOGIN_TIMEOUT_MS = 300_000;
 const PROCESS_TIMEOUT_MS = LOGIN_TIMEOUT_MS + 15_000;
 const CREDENTIAL_POLL_INTERVAL_MS = 100;
+const PROCESS_TERMINATION_GRACE_MS = 1_000;
+const PROCESS_TERMINATION_FORCE_WAIT_MS = 1_000;
+const TERMINATION_UNCONFIRMED_MESSAGE =
+  "ChatGPT sign-in could not be stopped safely. Close the sign-in helper, then restart Relmio.";
 const LOGIN_URL_PREFIX = "OpenAI OAuth login URL: ";
 const OPENAI_AUTH_ORIGIN = "https://auth.openai.com";
 const SUPPORTED_LOOPBACK_REDIRECT_HOSTNAMES = new Set([
@@ -206,6 +210,11 @@ export async function startOAuthLogin({
   spawnProcess = spawn,
   createPendingId = randomUUID,
   waitForCredentialPoll = wait,
+  killProcess = process.kill,
+  terminationGraceMs = PROCESS_TERMINATION_GRACE_MS,
+  terminationForceWaitMs = PROCESS_TERMINATION_FORCE_WAIT_MS,
+  createTimer = setTimeout,
+  clearTimer = clearTimeout,
 } = {}) {
   const npxInvocation = createNpxInvocation({ platform, env, execPath });
   const authPath = resolveAuthPath({ env, homeDirectory });
@@ -241,6 +250,7 @@ export async function startOAuthLogin({
         shell: false,
         stdio: ["ignore", "pipe", "pipe"],
         windowsHide: true,
+        ...(platform === "win32" ? {} : { detached: true }),
       },
     );
   } catch (error) {
@@ -251,6 +261,7 @@ export async function startOAuthLogin({
   }
   const loginOutput = { stdout: "", stderr: "" };
   let loginOutputBytes = 0;
+  let cancelAttempt = () => Promise.resolve();
   let resolveAuthorizationUrl;
   let rejectAuthorizationUrl;
   let authorizationUrlSettled = false;
@@ -280,7 +291,9 @@ export async function startOAuthLogin({
       settleAuthorizationUrl(
         new Error("The sign-in command returned too much output."),
       );
-      child.kill?.("SIGTERM");
+      void requestCancellation("The sign-in command returned too much output.").catch(
+        () => {},
+      );
       return;
     }
     loginOutput[stream] += output;
@@ -291,7 +304,7 @@ export async function startOAuthLogin({
       }
     } catch (error) {
       settleAuthorizationUrl(error);
-      child.kill?.("SIGTERM");
+      void requestCancellation(error.message).catch(() => {});
     }
   };
 
@@ -346,24 +359,273 @@ export async function startOAuthLogin({
     settleProcessClose(null, code);
   });
 
-  const loginUrlTimeout = setTimeout(() => {
-    settleAuthorizationUrl(
-      new Error("The sign-in command did not provide a fresh login link."),
+  const loginUrlTimeout = createTimer(() => {
+    const error = new Error(
+      "The sign-in command did not provide a fresh login link.",
     );
-    child.kill?.("SIGTERM");
+    settleAuthorizationUrl(error);
+    void requestCancellation(error.message).catch(() => {});
   }, LOGIN_URL_TIMEOUT_MS);
 
-  const savePendingCredential = async () => {
-    await readAuthContents({
-      authPath: pendingAuthPath,
-      fileSystem,
+  let keepPollingForCredential = true;
+  let cancellationRequested = false;
+  let rejectCancellation;
+  const cancellationPromise = new Promise((_, rejectPromise) => {
+    rejectCancellation = rejectPromise;
+  });
+  cancellationPromise.catch(() => {});
+
+  const promotionAuthPath = `${pendingAuthPath}.ready`;
+  let credentialPromotion;
+  let promotionPhase = "idle";
+  const promotionCancellationWaitMs =
+    terminationGraceMs + terminationForceWaitMs;
+  const createRetryBlockedError = () =>
+    Object.assign(new Error(TERMINATION_UNCONFIRMED_MESSAGE), {
+      retryBlocked: true,
     });
-    await fileSystem.chmod(pendingAuthPath, 0o600);
-    await fileSystem.copyFile(pendingAuthPath, authPath);
-    await fileSystem.chmod(authPath, 0o600);
+  const assertPromotionActive = () => {
+    if (cancellationRequested) {
+      throw new Error("ChatGPT sign-in did not finish. Start a fresh login.");
+    }
+  };
+  const savePendingCredential = () => {
+    if (credentialPromotion) {
+      return credentialPromotion;
+    }
+
+    credentialPromotion = (async () => {
+      promotionPhase = "staging";
+      try {
+        assertPromotionActive();
+        await readAuthContents({
+          authPath: pendingAuthPath,
+          fileSystem,
+        });
+        assertPromotionActive();
+        await fileSystem.chmod(pendingAuthPath, 0o600);
+        assertPromotionActive();
+        await fileSystem.copyFile(pendingAuthPath, promotionAuthPath);
+        assertPromotionActive();
+        await fileSystem.chmod(promotionAuthPath, 0o600);
+        assertPromotionActive();
+        promotionPhase = "committing";
+        await fileSystem.rename(promotionAuthPath, authPath);
+        promotionPhase = "committed";
+        await fileSystem.chmod(authPath, 0o600);
+      } catch (error) {
+        if (cancellationRequested && promotionPhase !== "committed") {
+          promotionPhase = "cancelled";
+        }
+        throw error;
+      }
+    })();
+    credentialPromotion.catch(() => {});
+    return credentialPromotion;
   };
 
-  let keepPollingForCredential = true;
+  const waitForBoundedResult = (promise, milliseconds) =>
+    new Promise((resolvePromise) => {
+      let settled = false;
+      const timer = createTimer(() => {
+        if (!settled) {
+          settled = true;
+          resolvePromise(false);
+        }
+      }, milliseconds);
+      promise.then(
+        () => {
+          if (!settled) {
+            settled = true;
+            clearTimer(timer);
+            resolvePromise(true);
+          }
+        },
+        () => {
+          if (!settled) {
+            settled = true;
+            clearTimer(timer);
+            resolvePromise(true);
+          }
+        },
+      );
+    });
+
+  const waitForDuration = (milliseconds) =>
+    new Promise((resolvePromise) => {
+      createTimer(() => resolvePromise(true), milliseconds);
+    });
+
+  const waitForTaskkill = (taskkill, milliseconds) =>
+    new Promise((resolvePromise) => {
+      let settled = false;
+      const finish = (confirmed) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimer(timer);
+        resolvePromise(confirmed);
+      };
+      const timer = createTimer(() => finish(false), milliseconds);
+      taskkill?.once?.("error", () => finish(false));
+      taskkill?.once?.("close", (code) => finish(code === 0));
+      if (!taskkill?.once) {
+        finish(false);
+      }
+    });
+
+  let terminationPromise;
+  const terminateProcessTree = () => {
+    if (terminationPromise) {
+      return terminationPromise;
+    }
+
+    terminationPromise = (async () => {
+      const hasChildPid = Number.isSafeInteger(child.pid) && child.pid > 0;
+
+      if (platform === "win32" && hasChildPid) {
+        const runTaskkill = async (force, timeout) => {
+          try {
+            const taskkill = spawnProcess(
+              "taskkill",
+              ["/pid", String(child.pid), "/t", ...(force ? ["/f"] : [])],
+              {
+                shell: false,
+                stdio: "ignore",
+                windowsHide: true,
+              },
+            );
+            return await waitForTaskkill(taskkill, timeout);
+          } catch {
+            return false;
+          }
+        };
+        if (
+          (await runTaskkill(false, terminationGraceMs)) ||
+          (await runTaskkill(true, terminationForceWaitMs))
+        ) {
+          return;
+        }
+      } else if (hasChildPid) {
+        const processGroupIsGone = () => {
+          try {
+            killProcess(-child.pid, 0);
+            return false;
+          } catch (error) {
+            return error?.code === "ESRCH";
+          }
+        };
+        try {
+          killProcess(-child.pid, "SIGTERM");
+        } catch {
+          // The group may have already exited between launch and cancellation.
+        }
+        if (
+          processGroupIsGone() ||
+          ((await waitForDuration(terminationGraceMs)) && processGroupIsGone())
+        ) {
+          return;
+        }
+        try {
+          killProcess(-child.pid, "SIGKILL");
+        } catch {
+          // A final process-group check below determines whether it is gone.
+        }
+        if (
+          processGroupIsGone() ||
+          ((await waitForDuration(terminationForceWaitMs)) &&
+            processGroupIsGone())
+        ) {
+          return;
+        }
+      } else {
+        try {
+          child.kill?.("SIGTERM");
+        } catch {
+          // The process may have already exited before cancellation.
+        }
+        if (
+          processCloseSettled ||
+          (await waitForBoundedResult(
+            processClosePromise,
+            terminationGraceMs,
+          ))
+        ) {
+          return;
+        }
+        try {
+          child.kill?.("SIGKILL");
+        } catch {
+          // The direct child is only a last resort when no PID is available.
+        }
+        if (
+          processCloseSettled ||
+          (await waitForBoundedResult(
+            processClosePromise,
+            terminationForceWaitMs,
+          ))
+        ) {
+          return;
+        }
+      }
+
+      throw createRetryBlockedError();
+    })();
+    return terminationPromise;
+  };
+
+  cancelAttempt = async (
+    message = "ChatGPT sign-in stopped. Start a fresh login.",
+  ) => {
+    if (!cancellationRequested) {
+      cancellationRequested = true;
+      keepPollingForCredential = false;
+      rejectCancellation(new Error(message));
+    }
+    let promotionError;
+    try {
+      if (
+        credentialPromotion &&
+        !(await waitForBoundedResult(
+          credentialPromotion,
+          promotionCancellationWaitMs,
+        ))
+      ) {
+        promotionError = createRetryBlockedError();
+      }
+    } catch {
+      // Cancellation intentionally abandons a staged but unpromoted credential.
+    }
+    if (
+      promotionPhase === "committing" ||
+      promotionPhase === "committed"
+    ) {
+      promotionError = createRetryBlockedError();
+    }
+    let terminationError;
+    try {
+      await terminateProcessTree();
+    } catch (error) {
+      terminationError = error;
+    }
+    if (promotionError) {
+      throw promotionError;
+    }
+    if (terminationError) {
+      throw terminationError;
+    }
+  };
+
+  let cancellationResult;
+  const requestCancellation = (message) => {
+    if (!cancellationResult) {
+      cancellationResult = cancelAttempt(message);
+      cancellationResult.catch(() => {});
+    }
+    return cancellationResult;
+  };
+
   const pendingCredentialPromise = (async () => {
     await authorizationUrlPromise;
     while (keepPollingForCredential) {
@@ -384,8 +646,9 @@ export async function startOAuthLogin({
 
   const completion = (async () => {
     let processTimeout;
+    let completedSuccessfully = false;
     try {
-      return await Promise.race([
+      const result = await Promise.race([
         pendingCredentialPromise,
         processClosePromise.then(async (code) => {
           if (code !== 0) {
@@ -396,26 +659,50 @@ export async function startOAuthLogin({
           await savePendingCredential();
           return { success: true };
         }),
+        cancellationPromise,
         new Promise((_, rejectPromise) => {
-          processTimeout = setTimeout(() => {
-            child.kill?.("SIGTERM");
-            rejectPromise(
-              new Error("The sign-in request expired. Start a fresh login."),
+          processTimeout = createTimer(() => {
+            const error = new Error(
+              "The sign-in request expired. Start a fresh login.",
             );
+            void requestCancellation(error.message).catch(() => {});
+            rejectPromise(error);
           }, PROCESS_TIMEOUT_MS);
         }),
       ]);
+      completedSuccessfully = result.success === true;
+      return result;
     } finally {
       keepPollingForCredential = false;
-      clearTimeout(processTimeout);
-      clearTimeout(loginUrlTimeout);
-      if (!processCloseSettled) {
-        child.kill?.("SIGTERM");
+      clearTimer(processTimeout);
+      clearTimer(loginUrlTimeout);
+      try {
+        await credentialPromotion;
+      } catch {
+        // A cancellation can abandon an attempt-local staged credential.
+      }
+      if (cancellationResult) {
+        try {
+          await cancellationResult;
+        } catch (error) {
+          if (error?.retryBlocked === true) {
+            throw error;
+          }
+        }
+      }
+      const committedBeforeFailure =
+        !completedSuccessfully && promotionPhase === "committed";
+      if (!completedSuccessfully || !processCloseSettled) {
+        await terminateProcessTree();
       }
       try {
         await fileSystem.rm(pendingAuthPath, { force: true });
+        await fileSystem.rm(promotionAuthPath, { force: true });
       } catch {
         // A failed cleanup must not hide the actionable sign-in result.
+      }
+      if (committedBeforeFailure) {
+        throw createRetryBlockedError();
       }
     }
   })();
@@ -435,21 +722,29 @@ export async function startOAuthLogin({
         },
       ),
     ]);
-    clearTimeout(loginUrlTimeout);
+    clearTimer(loginUrlTimeout);
     return {
       authorizationUrl,
       completion,
       cancel() {
-        child.kill?.("SIGTERM");
+        return requestCancellation();
       },
     };
   } catch (error) {
-    clearTimeout(loginUrlTimeout);
-    child.kill?.("SIGTERM");
+    clearTimer(loginUrlTimeout);
+    let retryBlocked = false;
     try {
-      await completion;
+      await requestCancellation(error.message);
+    } catch {
+      retryBlocked = true;
+    }
+    try {
+      await waitForBoundedResult(completion, promotionCancellationWaitMs);
     } catch {
       // Preserve the more specific authorization-link error.
+    }
+    if (retryBlocked) {
+      error.retryBlocked = true;
     }
     throw error;
   }

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -10,6 +10,10 @@ const state = {
   discovery: null,
   networks: null,
   installAttempted: false,
+  oauthAttemptId: null,
+  oauthRetryBlocked: false,
+  oauthLoginGeneration: 0,
+  oauthLoginWindow: null,
 };
 
 const element = (id) => document.getElementById(id);
@@ -245,16 +249,63 @@ function validateAuthorizationUrl(value) {
   return url.toString();
 }
 
-async function waitForOAuthCompletion() {
+function validateOAuthAttemptId(value) {
+  if (typeof value !== "string" || !/^[0-9a-f-]{8,128}$/iu.test(value)) {
+    throw new Error(
+      "The wizard returned an unexpected sign-in attempt. Start again.",
+    );
+  }
+  return value;
+}
+
+function setOAuthStopControlVisible(visible) {
+  const stopButton = element("stop-login-button");
+  stopButton.hidden = !visible;
+  stopButton.disabled = !visible;
+  stopButton.setAttribute("aria-busy", "false");
+}
+
+function blockOAuthRetry() {
+  state.oauthRetryBlocked = true;
+  state.oauthAttemptId = null;
+  state.oauthLoginWindow?.close?.();
+  state.oauthLoginWindow = null;
+  element("login-link").hidden = true;
+  element("login-link").removeAttribute("href");
+  setOAuthStopControlVisible(false);
+  const loginButton = element("login-button");
+  setBusy(loginButton, false);
+  loginButton.disabled = true;
+}
+
+async function waitForOAuthCompletion(expectedAttemptId) {
   for (let attempt = 0; attempt < 330; attempt += 1) {
     const result = await api("/api/oauth/status");
+    if (result.retryBlocked === true) {
+      const error = new Error(
+        result.error ??
+          "ChatGPT sign-in could not be stopped safely. Close the sign-in helper, then restart Relmio.",
+      );
+      error.oauthRetryBlocked = true;
+      throw error;
+    }
+    if (result.attemptId !== expectedAttemptId) {
+      throw new Error(
+        "The ChatGPT sign-in was replaced by a newer attempt. Start again.",
+      );
+    }
     if (result.status === "success") {
       return;
     }
     if (result.status === "error") {
-      throw new Error(
+      const error = new Error(
         result.error ?? "ChatGPT sign-in did not finish. Start again.",
       );
+      error.oauthRetryBlocked = result.retryBlocked === true;
+      throw error;
+    }
+    if (result.status === "cancelled") {
+      throw new Error("ChatGPT sign-in was stopped. Start again.");
     }
     await delay(attempt < 40 ? 250 : 1_000);
   }
@@ -324,7 +375,9 @@ async function api(path, { method = "GET", body } = {}) {
     );
   }
   if (!response.ok) {
-    throw new Error(result.error ?? "The request failed.");
+    const error = new Error(result.error ?? "The request failed.");
+    error.oauthRetryBlocked = result.retryBlocked === true;
+    throw error;
   }
   return result;
 }
@@ -450,13 +503,21 @@ async function discover() {
 
 element("login-button").addEventListener("click", async (event) => {
   const button = event.currentTarget;
+  if (state.oauthRetryBlocked) {
+    return;
+  }
   const loginLink = element("login-link");
+  const loginGeneration = state.oauthLoginGeneration + 1;
+  state.oauthLoginGeneration = loginGeneration;
+  state.oauthAttemptId = null;
   const loginWindow = window.open("about:blank", "_blank");
+  state.oauthLoginWindow = loginWindow;
   let loginWindowNavigated = false;
   prepareOAuthPopup(loginWindow);
   clearError();
   loginLink.hidden = true;
   loginLink.removeAttribute("href");
+  setOAuthStopControlVisible(false);
   setBusy(button, true, "Waiting for browser sign-in…");
   setMessage(
     "Preparing a fresh ChatGPT sign-in. The existing local credential will be replaced only after sign-in succeeds.",
@@ -467,6 +528,12 @@ element("login-button").addEventListener("click", async (event) => {
       body: {},
     });
     const authorizationUrl = validateAuthorizationUrl(result.authorizationUrl);
+    const attemptId = validateOAuthAttemptId(result.attemptId);
+    if (state.oauthLoginGeneration !== loginGeneration) {
+      return;
+    }
+    state.oauthAttemptId = attemptId;
+    setOAuthStopControlVisible(true);
     loginLink.href = authorizationUrl;
     loginLink.hidden = false;
     if (loginWindow) {
@@ -477,7 +544,10 @@ element("login-button").addEventListener("click", async (event) => {
     setMessage(
       "Complete the newly opened sign-in within five minutes. If no tab opened, use “Open fresh ChatGPT sign-in” below. If an OpenAI OAuth browser extension intercepts the callback, disable it temporarily and start again.",
     );
-    await waitForOAuthCompletion();
+    await waitForOAuthCompletion(attemptId);
+    if (state.oauthLoginGeneration !== loginGeneration) {
+      return;
+    }
     loginLink.hidden = true;
     loginLink.removeAttribute("href");
     await refreshAuthStatus({ fresh: true });
@@ -485,9 +555,66 @@ element("login-button").addEventListener("click", async (event) => {
     if (loginWindow && !loginWindowNavigated) {
       loginWindow.close();
     }
-    showError(error);
+    if (state.oauthLoginGeneration === loginGeneration) {
+      if (error.oauthRetryBlocked === true) {
+        blockOAuthRetry();
+      }
+      showError(error);
+    }
   } finally {
-    setBusy(button, false);
+    if (state.oauthLoginGeneration === loginGeneration) {
+      state.oauthAttemptId = null;
+      state.oauthLoginWindow = null;
+      setOAuthStopControlVisible(false);
+      setBusy(button, false);
+      if (state.oauthRetryBlocked) {
+        button.disabled = true;
+      }
+    }
+  }
+});
+
+element("stop-login-button").addEventListener("click", async (event) => {
+  const stopButton = event.currentTarget;
+  const attemptId = state.oauthAttemptId;
+  const loginGeneration = state.oauthLoginGeneration;
+  if (typeof attemptId !== "string") {
+    return;
+  }
+  clearError();
+  setBusy(stopButton, true, "Stopping sign-in…");
+  try {
+    const result = await api("/api/oauth/cancel", {
+      method: "POST",
+      body: { attemptId },
+    });
+    if (
+      state.oauthLoginGeneration !== loginGeneration ||
+      result.attemptId !== attemptId ||
+      result.status !== "cancelled"
+    ) {
+      return;
+    }
+    state.oauthLoginGeneration += 1;
+    state.oauthAttemptId = null;
+    state.oauthLoginWindow?.close?.();
+    state.oauthLoginWindow = null;
+    element("login-link").hidden = true;
+    element("login-link").removeAttribute("href");
+    setBusy(element("login-button"), false);
+    setOAuthStopControlVisible(false);
+    setMessage("ChatGPT sign-in stopped. You can start again.");
+  } catch (error) {
+    if (state.oauthLoginGeneration === loginGeneration) {
+      if (error.oauthRetryBlocked === true) {
+        state.oauthLoginGeneration += 1;
+        blockOAuthRetry();
+      }
+      showError(error);
+      if (!state.oauthRetryBlocked) {
+        setBusy(stopButton, false);
+      }
+    }
   }
 });
 

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -203,6 +203,9 @@
           >
             Open fresh ChatGPT sign-in
           </a>
+          <button id="stop-login-button" class="button secondary" type="button" hidden>
+            Stop ChatGPT sign-in
+          </button>
           <button id="signin-next" class="button primary" type="button" disabled>
             Continue to VPS
           </button>

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -31,6 +31,7 @@ import { startCodexDeviceLogin } from "../services/codex-login.js";
 const MAX_BODY_BYTES = 32 * 1024;
 const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 const RATE_LIMIT_MAX = 10;
+const OAUTH_SHUTDOWN_WAIT_MS = 2_000;
 
 const defaultServices = {
   getAuthStatus,
@@ -108,6 +109,37 @@ function enforceRateLimit(state, key) {
   }
   recent.push(now);
   state.rateLimits.set(key, recent);
+}
+
+function waitForBoundedResult(promise, milliseconds) {
+  if (!promise) {
+    return Promise.resolve(true);
+  }
+  return new Promise((resolvePromise) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        resolvePromise(false);
+      }
+    }, milliseconds);
+    Promise.resolve(promise).then(
+      () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolvePromise(true);
+        }
+      },
+      () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolvePromise(true);
+        }
+      },
+    );
+  });
 }
 
 function readJsonBody(request) {
@@ -190,6 +222,32 @@ function safeErrorMessage(error) {
     return "The request could not be completed safely.";
   }
   return message;
+}
+
+async function cancelOAuthLogin(state, login) {
+  try {
+    await login.attempt.cancel();
+  } catch {
+    if (state.oauthLogin === login) {
+      login.status = "error";
+      login.retryBlocked = true;
+      login.error =
+        "ChatGPT sign-in could not be stopped safely. Close the sign-in helper, then restart Relmio.";
+    }
+    state.oauthRetryBlocked = true;
+    state.oauthStartupError =
+      "ChatGPT sign-in could not be stopped safely. Close the sign-in helper, then restart Relmio.";
+    throw Object.assign(
+      new Error(
+        "ChatGPT sign-in could not be stopped safely. Close the sign-in helper, then restart Relmio.",
+      ),
+      { retryBlocked: true, statusCode: 409 },
+    );
+  }
+
+  if (state.oauthLogin === login && login.status === "pending") {
+    login.status = "cancelled";
+  }
 }
 
 async function loadDefaultUiFiles() {
@@ -297,8 +355,16 @@ async function handleApi(request, response, path, state) {
   if (request.method === "GET" && path === "/api/oauth/status") {
     const login = state.oauthLogin;
     sendJson(response, 200, {
-      status: login?.status ?? "idle",
-      ...(login?.status === "error" ? { error: login.error } : {}),
+      status: login?.status ?? (state.oauthStartupError ? "error" : "idle"),
+      ...(login ? { attemptId: login.attemptId } : {}),
+      ...(login?.status === "error"
+        ? { error: login.error }
+        : state.oauthStartupError
+          ? { error: state.oauthStartupError }
+          : {}),
+      ...(state.oauthRetryBlocked || login?.retryBlocked === true
+        ? { retryBlocked: true }
+        : {}),
     });
     return;
   }
@@ -342,41 +408,145 @@ async function handleApi(request, response, path, state) {
         { statusCode: 403 },
       );
     }
-    enforceRateLimit(state, path);
-    if (state.oauthLogin?.status === "pending") {
-      state.oauthLogin.attempt.cancel();
-      try {
-        await state.oauthLogin.attempt.completion;
-      } catch {
-        // Starting again intentionally replaces the previous local attempt.
-      }
+    if (state.closing) {
+      throw Object.assign(new Error("The local wizard is closing."), {
+        statusCode: 409,
+      });
     }
+    if (state.oauthRetryBlocked || state.oauthLogin?.retryBlocked === true) {
+      throw Object.assign(
+        new Error(
+          "ChatGPT sign-in could not be stopped safely. Close the sign-in helper, then restart Relmio.",
+        ),
+        { retryBlocked: true, statusCode: 409 },
+      );
+    }
+    if (state.oauthLoginStartInFlight) {
+      throw Object.assign(
+        new Error("A ChatGPT sign-in start is already in progress."),
+        { statusCode: 409 },
+      );
+    }
+    enforceRateLimit(state, path);
+    state.oauthLoginStartInFlight = true;
+    state.oauthStartupError = null;
+    let startAttempted = false;
+    let startPromise;
+    try {
+      const previousLogin = state.oauthLogin;
+      if (previousLogin?.status === "pending") {
+        await cancelOAuthLogin(state, previousLogin);
+      }
 
-    const attempt = await state.services.startOAuthLogin();
-    const login = {
-      attempt,
-      error: null,
-      status: "pending",
-    };
-    state.oauthLogin = login;
-    attempt.completion.then(
-      () => {
-        if (state.oauthLogin === login) {
-          login.status = "success";
+      if (state.closing) {
+        throw Object.assign(new Error("The local wizard is closing."), {
+          statusCode: 409,
+        });
+      }
+      if (
+        state.oauthLogin === previousLogin &&
+        previousLogin?.status !== "pending" &&
+        previousLogin?.retryBlocked !== true
+      ) {
+        state.oauthLogin = null;
+      }
+      startAttempted = true;
+      startPromise = Promise.resolve(state.services.startOAuthLogin());
+      state.oauthLoginStartPromise = startPromise;
+      const attempt = await startPromise;
+      const login = {
+        attempt,
+        attemptId: randomUUID(),
+        error: null,
+        retryBlocked: false,
+        status: "pending",
+      };
+      state.oauthLogin = login;
+      attempt.completion.then(
+        () => {
+          if (
+            state.oauthLogin === login &&
+            login.status === "pending" &&
+            !state.closing
+          ) {
+            login.status = "success";
+          }
+        },
+        (error) => {
+          if (
+            state.oauthLogin === login &&
+            login.status === "pending" &&
+            !state.closing
+          ) {
+            login.status = "error";
+            login.error = safeErrorMessage(error);
+            if (error?.retryBlocked === true) {
+              login.retryBlocked = true;
+              state.oauthRetryBlocked = true;
+              state.oauthStartupError = login.error;
+            }
+          }
+        },
+      );
+      if (state.closing) {
+        try {
+          await cancelOAuthLogin(state, login);
+        } catch {
+          // The server is already closing and must not restart this helper.
         }
-      },
-      (error) => {
-        if (state.oauthLogin === login) {
-          login.status = "error";
-          login.error = safeErrorMessage(error);
-        }
-      },
-    );
-    sendJson(response, 200, { authorizationUrl: attempt.authorizationUrl });
-    return;
+        throw Object.assign(new Error("The local wizard is closing."), {
+          statusCode: 409,
+        });
+      }
+      sendJson(response, 200, {
+        authorizationUrl: attempt.authorizationUrl,
+        attemptId: login.attemptId,
+      });
+      return;
+    } catch (error) {
+      const message = safeErrorMessage(error);
+      if (startAttempted) {
+        state.oauthStartupError = message;
+      }
+      if (error?.retryBlocked === true) {
+        state.oauthRetryBlocked = true;
+        state.oauthStartupError = message;
+      }
+      throw error;
+    } finally {
+      if (state.oauthLoginStartPromise === startPromise) {
+        state.oauthLoginStartPromise = null;
+      }
+      state.oauthLoginStartInFlight = false;
+    }
   }
 
   const body = await readJsonBody(request);
+
+  if (path === "/api/oauth/cancel") {
+    requireLiveLocalAction(state, "Live ChatGPT sign-in");
+    const login = state.oauthLogin;
+    if (
+      !login ||
+      login.status !== "pending" ||
+      !body ||
+      typeof body !== "object" ||
+      Array.isArray(body) ||
+      typeof body.attemptId !== "string" ||
+      body.attemptId !== login.attemptId
+    ) {
+      throw Object.assign(
+        new Error("The ChatGPT sign-in attempt has already changed. Start again."),
+        { statusCode: 409 },
+      );
+    }
+    await cancelOAuthLogin(state, login);
+    sendJson(response, 200, {
+      status: login.status,
+      attemptId: login.attemptId,
+    });
+    return;
+  }
 
   if (path === "/api/local/plan") {
     const plan = createLocalDeploymentPlan({
@@ -670,6 +840,7 @@ function createRequestHandler(state) {
       if (!response.headersSent) {
         sendJson(response, error.statusCode ?? 400, {
           error: safeErrorMessage(error),
+          ...(error.retryBlocked === true ? { retryBlocked: true } : {}),
         });
       } else {
         response.end();
@@ -684,6 +855,7 @@ export async function startWizardServer({
   uiFiles,
   port = 0,
   previewMode = false,
+  oauthShutdownWaitMs = OAUTH_SHUTDOWN_WAIT_MS,
 } = {}) {
   if (typeof sessionToken !== "string" || sessionToken.length < 32) {
     throw new TypeError("A strong wizard session token is required.");
@@ -699,12 +871,17 @@ export async function startWizardServer({
     discovery: null,
     networksByContainer: new Map(),
     oauthLogin: null,
+    oauthRetryBlocked: false,
+    oauthStartupError: null,
+    oauthLoginStartInFlight: false,
+    oauthLoginStartPromise: null,
     localPlan: null,
     localInstallInFlight: false,
     codexLogin: null,
     codexLoginStartInFlight: false,
     rateLimits: new Map(),
     previewMode: previewMode === true,
+    oauthShutdownWaitMs,
     closing: false,
   };
   const server = createServer(createRequestHandler(state));
@@ -724,13 +901,26 @@ export async function startWizardServer({
     origin: state.origin,
     async close() {
       state.closing = true;
-      state.oauthLogin?.attempt.cancel();
+      await waitForBoundedResult(
+        state.oauthLoginStartPromise,
+        state.oauthShutdownWaitMs,
+      );
+      if (state.oauthLogin?.status === "pending") {
+        try {
+          await cancelOAuthLogin(state, state.oauthLogin);
+        } catch {
+          // The bounded OAuth cancellation result must not prevent server shutdown.
+        }
+      }
       const codexLogin = state.codexLogin;
       state.codexLogin = null;
       codexLogin?.cancel();
       state.connection?.close();
       state.connection = null;
-      await new Promise((resolve) => server.close(resolve));
+      await waitForBoundedResult(
+        new Promise((resolve) => server.close(resolve)),
+        state.oauthShutdownWaitMs,
+      );
     },
   };
 }

--- a/test/oauth.test.js
+++ b/test/oauth.test.js
@@ -42,6 +42,10 @@ function createMemoryFileSystem(files) {
     async copyFile(source, destination) {
       files[destination] = files[source];
     },
+    async rename(source, destination) {
+      files[destination] = files[source];
+      delete files[source];
+    },
     async rm(path) {
       delete files[path];
     },
@@ -448,8 +452,14 @@ test("startOAuthLogin waits for close after exit before finalizing stdout", asyn
 });
 
 test("startOAuthLogin surfaces a sanitized callback port conflict from stderr", async () => {
-  const spawnProcess = () => {
+  const calls = [];
+  const spawnProcess = (command, args) => {
+    calls.push({ command, args });
     const child = new EventEmitter();
+    if (command === "taskkill") {
+      return child;
+    }
+    child.pid = 5150;
     child.stdout = new EventEmitter();
     child.stderr = new EventEmitter();
     child.stderr.resume = () => {};
@@ -477,6 +487,8 @@ test("startOAuthLogin surfaces a sanitized callback port conflict from stderr", 
         execPath: "C:\\portable\\node.exe",
         spawnProcess,
         createPendingId: () => "port-conflict",
+        terminationGraceMs: 0,
+        terminationForceWaitMs: 0,
       }),
     (error) => {
       assert.equal(
@@ -484,9 +496,14 @@ test("startOAuthLogin surfaces a sanitized callback port conflict from stderr", 
         "OpenAI OAuth login needs http://localhost:1455/auth/callback, but port 1455 is already in use. Stop the process using that port and try again.",
       );
       assert.doesNotMatch(error.message, /not-for-users|token=/u);
+      assert.equal(error.retryBlocked, true);
       return true;
     },
   );
+  assert.deepEqual(calls.slice(1), [
+    { command: "taskkill", args: ["/pid", "5150", "/t"] },
+    { command: "taskkill", args: ["/pid", "5150", "/t", "/f"] },
+  ]);
 });
 
 test("startOAuthLogin uses the current Node runtime for Windows npm launchers", async () => {
@@ -624,7 +641,7 @@ test("startOAuthLogin saves a valid pending credential before the helper exits",
     child = new EventEmitter();
     child.stdout = new EventEmitter();
     child.stderr = { resume() {} };
-    child.kill = () => {};
+    child.kill = () => queueMicrotask(() => finishChild(child, 1));
     pendingAuthPath = args[args.indexOf("--oauth-file") + 1];
     queueMicrotask(() => {
       const authorizationUrl = new URL(
@@ -652,6 +669,8 @@ test("startOAuthLogin saves a valid pending credential before the helper exits",
     platform: "darwin",
     spawnProcess,
     createPendingId: () => "fresh",
+    terminationGraceMs: 0,
+    terminationForceWaitMs: 0,
     waitForCredentialPoll: async () => {
       pollCount += 1;
       files[pendingAuthPath] =
@@ -677,7 +696,6 @@ test("startOAuthLogin saves a valid pending credential before the helper exits",
     );
   } finally {
     finishChild(child, 1);
-    login.cancel();
   }
 });
 
@@ -776,4 +794,530 @@ test("startOAuthLogin only accepts exact supported authorization and callback UR
   const ipv6Login = await startWithAuthorizationUrl(ipv6AuthorizationUrl);
   assert.equal(ipv6Login.authorizationUrl, ipv6AuthorizationUrl.toString());
   assert.deepEqual(await ipv6Login.completion, { success: true });
+});
+
+test("startOAuthLogin cancels the detached helper process group with a bounded forceful fallback", async () => {
+  const signals = [];
+  let processGroupGone = false;
+  let spawnOptions;
+  const spawnProcess = (_command, _args, options) => {
+    spawnOptions = options;
+    const child = new EventEmitter();
+    child.pid = 4242;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {
+      throw new Error("The wrapper process must not be the only cancellation target.");
+    };
+    queueMicrotask(() => {
+      child.stdout.emit(
+        "data",
+        Buffer.from(
+          `OpenAI OAuth login URL: ${createAuthorizationUrl()}\n`,
+        ),
+      );
+    });
+    return child;
+  };
+
+  const login = await startOAuthLogin({
+    fileSystem: createMemoryFileSystem({}),
+    env: {},
+    homeDirectory: "/home/user",
+    platform: "darwin",
+    spawnProcess,
+    createPendingId: () => "process-tree",
+    killProcess(pid, signal) {
+      signals.push([pid, signal]);
+      if (signal === "SIGKILL") {
+        processGroupGone = true;
+      }
+      if (signal === 0 && processGroupGone) {
+        const error = new Error("gone");
+        error.code = "ESRCH";
+        throw error;
+      }
+    },
+    terminationGraceMs: 50,
+    terminationForceWaitMs: 50,
+  });
+
+  await login.cancel();
+  await assert.rejects(login.completion, /stopped|fresh login/i);
+  assert.equal(spawnOptions.detached, true);
+  assert.deepEqual(signals, [
+    [-4242, "SIGTERM"],
+    [-4242, 0],
+    [-4242, 0],
+    [-4242, "SIGKILL"],
+    [-4242, 0],
+  ]);
+});
+
+test("startOAuthLogin cancellation waits for a delayed promotion and keeps the older credential", async () => {
+  const files = {};
+  const homeDirectory = resolve("oauth-cancel-promotion-home");
+  const authPath = resolve(homeDirectory, ".n8n-openai-oauth", "auth.json");
+  files[authPath] = '{"older":true}';
+  const memoryFileSystem = createMemoryFileSystem(files);
+  let pendingAuthPath;
+  let releaseCopy;
+  const copyRelease = new Promise((resolvePromise) => {
+    releaseCopy = resolvePromise;
+  });
+  let markCopyStarted;
+  const copyStarted = new Promise((resolvePromise) => {
+    markCopyStarted = resolvePromise;
+  });
+  const fileSystem = {
+    ...memoryFileSystem,
+    async copyFile(source, destination) {
+      markCopyStarted();
+      await copyRelease;
+      files[destination] = files[source];
+    },
+  };
+  const spawnProcess = (_command, args) => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => queueMicrotask(() => finishChild(child, 1));
+    pendingAuthPath = args[args.indexOf("--oauth-file") + 1];
+    queueMicrotask(() => {
+      child.stdout.emit(
+        "data",
+        Buffer.from(`OpenAI OAuth login URL: ${createAuthorizationUrl()}\n`),
+      );
+    });
+    return child;
+  };
+
+  const login = await startOAuthLogin({
+    fileSystem,
+    env: {},
+    homeDirectory,
+    platform: "darwin",
+    spawnProcess,
+    createPendingId: () => "cancel-promotion",
+    terminationGraceMs: 50,
+    terminationForceWaitMs: 50,
+    waitForCredentialPoll: async () => {
+      files[pendingAuthPath] = '{"newer":true}';
+    },
+  });
+
+  await copyStarted;
+  let cancellationFinished = false;
+  const cancellation = login.cancel().then(() => {
+    cancellationFinished = true;
+  });
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
+  assert.equal(cancellationFinished, false);
+
+  releaseCopy();
+  await cancellation;
+  await assert.rejects(login.completion, /stopped|fresh login/i);
+  assert.equal(files[authPath], '{"older":true}');
+});
+
+test("startOAuthLogin rejects cancellation when the detached process group survives both signals", async () => {
+  const signals = [];
+  const spawnProcess = () => {
+    const child = new EventEmitter();
+    child.pid = 4343;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {
+      throw new Error("The detached process group must be signalled instead.");
+    };
+    queueMicrotask(() => {
+      child.stdout.emit(
+        "data",
+        Buffer.from(`OpenAI OAuth login URL: ${createAuthorizationUrl()}\n`),
+      );
+    });
+    return child;
+  };
+
+  const login = await startOAuthLogin({
+    fileSystem: createMemoryFileSystem({}),
+    env: {},
+    homeDirectory: "/home/user",
+    platform: "darwin",
+    spawnProcess,
+    createPendingId: () => "surviving-process-group",
+    killProcess(pid, signal) {
+      signals.push([pid, signal]);
+    },
+    terminationGraceMs: 0,
+    terminationForceWaitMs: 0,
+  });
+
+  await assert.rejects(
+    login.cancel(),
+    /could not be stopped safely/i,
+  );
+  assert.deepEqual(signals, [
+    [-4343, "SIGTERM"],
+    [-4343, 0],
+    [-4343, 0],
+    [-4343, "SIGKILL"],
+    [-4343, 0],
+    [-4343, 0],
+  ]);
+});
+
+test("startOAuthLogin rejects cancellation when Windows taskkill cannot confirm its tree", async () => {
+  const calls = [];
+  const spawnProcess = (command, args) => {
+    calls.push({ command, args });
+    const child = new EventEmitter();
+    if (command === "taskkill") {
+      queueMicrotask(() => finishChild(child, 1));
+      return child;
+    }
+    child.pid = 5454;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {
+      throw new Error("taskkill must own the Windows process tree.");
+    };
+    queueMicrotask(() => {
+      child.stdout.emit(
+        "data",
+        Buffer.from(`OpenAI OAuth login URL: ${createAuthorizationUrl()}\n`),
+      );
+    });
+    return child;
+  };
+
+  const login = await startOAuthLogin({
+    fileSystem: createMemoryFileSystem({}),
+    env: {},
+    homeDirectory: "/home/user",
+    platform: "win32",
+    execPath: "C:\\portable\\node.exe",
+    spawnProcess,
+    createPendingId: () => "taskkill-nonzero",
+    terminationGraceMs: 0,
+    terminationForceWaitMs: 0,
+  });
+
+  await assert.rejects(
+    login.cancel(),
+    /could not be stopped safely/i,
+  );
+  assert.deepEqual(calls.slice(1), [
+    { command: "taskkill", args: ["/pid", "5454", "/t"] },
+    { command: "taskkill", args: ["/pid", "5454", "/t", "/f"] },
+  ]);
+});
+
+test("startOAuthLogin bounds a hung Windows taskkill and reports unconfirmed termination", async () => {
+  const calls = [];
+  const spawnProcess = (command, args) => {
+    calls.push({ command, args });
+    const child = new EventEmitter();
+    if (command === "taskkill") {
+      return child;
+    }
+    child.pid = 5555;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {
+      throw new Error("taskkill must own the Windows process tree.");
+    };
+    queueMicrotask(() => {
+      child.stdout.emit(
+        "data",
+        Buffer.from(`OpenAI OAuth login URL: ${createAuthorizationUrl()}\n`),
+      );
+    });
+    return child;
+  };
+
+  const login = await startOAuthLogin({
+    fileSystem: createMemoryFileSystem({}),
+    env: {},
+    homeDirectory: "/home/user",
+    platform: "win32",
+    execPath: "C:\\portable\\node.exe",
+    spawnProcess,
+    createPendingId: () => "taskkill-hung",
+    terminationGraceMs: 0,
+    terminationForceWaitMs: 0,
+  });
+
+  await assert.rejects(
+    login.cancel(),
+    /could not be stopped safely/i,
+  );
+  assert.deepEqual(calls.slice(1), [
+    { command: "taskkill", args: ["/pid", "5555", "/t"] },
+    { command: "taskkill", args: ["/pid", "5555", "/t", "/f"] },
+  ]);
+});
+
+test("startOAuthLogin reports cancellation as indeterminate after final credential commit begins", async () => {
+  const files = {};
+  const homeDirectory = resolve("oauth-rename-barrier-home");
+  const authPath = resolve(homeDirectory, ".n8n-openai-oauth", "auth.json");
+  files[authPath] = '{"older":true}';
+  const memoryFileSystem = createMemoryFileSystem(files);
+  let pendingAuthPath;
+  let releaseRename;
+  const renameRelease = new Promise((resolvePromise) => {
+    releaseRename = resolvePromise;
+  });
+  let markRenameStarted;
+  const renameStarted = new Promise((resolvePromise) => {
+    markRenameStarted = resolvePromise;
+  });
+  const fileSystem = {
+    ...memoryFileSystem,
+    async rename(source, destination) {
+      markRenameStarted();
+      await renameRelease;
+      files[destination] = files[source];
+      delete files[source];
+    },
+  };
+  const spawnProcess = (_command, args) => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => queueMicrotask(() => finishChild(child, 1));
+    pendingAuthPath = args[args.indexOf("--oauth-file") + 1];
+    queueMicrotask(() => {
+      child.stdout.emit(
+        "data",
+        Buffer.from(`OpenAI OAuth login URL: ${createAuthorizationUrl()}\n`),
+      );
+    });
+    return child;
+  };
+
+  const login = await startOAuthLogin({
+    fileSystem,
+    env: {},
+    homeDirectory,
+    platform: "darwin",
+    spawnProcess,
+    createPendingId: () => "rename-barrier",
+    terminationGraceMs: 50,
+    terminationForceWaitMs: 50,
+    waitForCredentialPoll: async () => {
+      files[pendingAuthPath] = '{"newer":true}';
+    },
+  });
+
+  await renameStarted;
+  let cancellationSettled = false;
+  const cancellation = login.cancel().finally(() => {
+    cancellationSettled = true;
+  });
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
+  assert.equal(cancellationSettled, false);
+
+  releaseRename();
+  await assert.rejects(cancellation, /could not be stopped safely/i);
+  assert.equal(files[authPath], '{"newer":true}');
+});
+
+test("startOAuthLogin bounds a never-settling staged promotion and blocks its later final write", async () => {
+  const files = {};
+  const homeDirectory = resolve("oauth-never-settling-promotion-home");
+  const authPath = resolve(homeDirectory, ".n8n-openai-oauth", "auth.json");
+  files[authPath] = '{"older":true}';
+  const memoryFileSystem = createMemoryFileSystem(files);
+  let pendingAuthPath;
+  let releaseCopy;
+  const copyRelease = new Promise((resolvePromise) => {
+    releaseCopy = resolvePromise;
+  });
+  let markCopyStarted;
+  const copyStarted = new Promise((resolvePromise) => {
+    markCopyStarted = resolvePromise;
+  });
+  const fileSystem = {
+    ...memoryFileSystem,
+    async copyFile(source, destination) {
+      markCopyStarted();
+      await copyRelease;
+      files[destination] = files[source];
+    },
+  };
+  const spawnProcess = (_command, args) => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => queueMicrotask(() => finishChild(child, 1));
+    pendingAuthPath = args[args.indexOf("--oauth-file") + 1];
+    queueMicrotask(() => {
+      child.stdout.emit(
+        "data",
+        Buffer.from(`OpenAI OAuth login URL: ${createAuthorizationUrl()}\n`),
+      );
+    });
+    return child;
+  };
+
+  const login = await startOAuthLogin({
+    fileSystem,
+    env: {},
+    homeDirectory,
+    platform: "darwin",
+    spawnProcess,
+    createPendingId: () => "never-settling-promotion",
+    terminationGraceMs: 0,
+    terminationForceWaitMs: 0,
+    waitForCredentialPoll: async () => {
+      files[pendingAuthPath] = '{"newer":true}';
+    },
+  });
+
+  await copyStarted;
+  try {
+    const result = await Promise.race([
+      login.cancel().then(
+        () => "resolved",
+        () => "rejected",
+      ),
+      new Promise((resolvePromise) => {
+        setTimeout(() => resolvePromise("timed out"), 50);
+      }),
+    ]);
+    assert.equal(result, "rejected");
+  } finally {
+    releaseCopy();
+  }
+  await new Promise((resolvePromise) => setImmediate(resolvePromise));
+  assert.equal(files[authPath], '{"older":true}');
+});
+
+test("startOAuthLogin marks a timeout retry-blocked when final credential commit has started", async () => {
+  const files = {};
+  const homeDirectory = resolve("oauth-timeout-rename-home");
+  const authPath = resolve(homeDirectory, ".n8n-openai-oauth", "auth.json");
+  files[authPath] = '{"older":true}';
+  const memoryFileSystem = createMemoryFileSystem(files);
+  let pendingAuthPath;
+  let releaseRename;
+  const renameRelease = new Promise((resolvePromise) => {
+    releaseRename = resolvePromise;
+  });
+  let markRenameStarted;
+  const renameStarted = new Promise((resolvePromise) => {
+    markRenameStarted = resolvePromise;
+  });
+  const fileSystem = {
+    ...memoryFileSystem,
+    async rename(source, destination) {
+      markRenameStarted();
+      await renameRelease;
+      files[destination] = files[source];
+      delete files[source];
+    },
+  };
+  let fireProcessTimeout;
+  const createTimer = (callback, milliseconds) => {
+    if (milliseconds === 315_000) {
+      fireProcessTimeout = callback;
+      return { milliseconds };
+    }
+    if (milliseconds === 0) {
+      queueMicrotask(callback);
+    }
+    return { milliseconds };
+  };
+  const spawnProcess = (_command, args) => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => queueMicrotask(() => finishChild(child, 1));
+    pendingAuthPath = args[args.indexOf("--oauth-file") + 1];
+    queueMicrotask(() => {
+      child.stdout.emit(
+        "data",
+        Buffer.from(`OpenAI OAuth login URL: ${createAuthorizationUrl()}\n`),
+      );
+    });
+    return child;
+  };
+
+  const login = await startOAuthLogin({
+    fileSystem,
+    env: {},
+    homeDirectory,
+    platform: "darwin",
+    spawnProcess,
+    createPendingId: () => "timeout-rename",
+    createTimer,
+    clearTimer() {},
+    terminationGraceMs: 50,
+    terminationForceWaitMs: 50,
+    waitForCredentialPoll: async () => {
+      files[pendingAuthPath] = '{"newer":true}';
+    },
+  });
+
+  await renameStarted;
+  fireProcessTimeout();
+  releaseRename();
+  await assert.rejects(login.completion, (error) => {
+    assert.equal(error.retryBlocked, true);
+    assert.match(error.message, /could not be stopped safely/i);
+    return true;
+  });
+  assert.equal(files[authPath], '{"newer":true}');
+});
+
+test("startOAuthLogin marks unconfirmed cleanup retry-blocked after returning a URL", async () => {
+  const signals = [];
+  let child;
+  const spawnProcess = () => {
+    child = new EventEmitter();
+    child.pid = 6262;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {
+      throw new Error("The detached process group must be signalled instead.");
+    };
+    queueMicrotask(() => {
+      child.stdout.emit(
+        "data",
+        Buffer.from(`OpenAI OAuth login URL: ${createAuthorizationUrl()}\n`),
+      );
+    });
+    return child;
+  };
+
+  const login = await startOAuthLogin({
+    fileSystem: createMemoryFileSystem({}),
+    env: {},
+    homeDirectory: "/home/user",
+    platform: "darwin",
+    spawnProcess,
+    createPendingId: () => "unconfirmed-after-url",
+    killProcess(pid, signal) {
+      signals.push([pid, signal]);
+    },
+    terminationGraceMs: 0,
+    terminationForceWaitMs: 0,
+  });
+
+  finishChild(child, 1);
+  await assert.rejects(login.completion, (error) => {
+    assert.equal(error.retryBlocked, true);
+    assert.match(error.message, /could not be stopped safely/i);
+    return true;
+  });
+  assert.deepEqual(signals, [
+    [-6262, "SIGTERM"],
+    [-6262, 0],
+    [-6262, 0],
+    [-6262, "SIGKILL"],
+    [-6262, 0],
+    [-6262, 0],
+  ]);
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -174,13 +174,691 @@ test("wizard returns the exact fresh OAuth link and reports completion", async (
     body: "{}",
   });
   assert.equal(loginResponse.status, 200);
-  assert.deepEqual(await loginResponse.json(), {
-    authorizationUrl: "https://auth.openai.com/oauth/authorize?fixture=true",
-  });
+  const login = await loginResponse.json();
+  assert.equal(
+    login.authorizationUrl,
+    "https://auth.openai.com/oauth/authorize?fixture=true",
+  );
+  assert.match(login.attemptId, /^[0-9a-f-]+$/u);
 
   await new Promise((resolve) => setImmediate(resolve));
   const statusResponse = await api(wizard.origin, "/api/oauth/status");
-  assert.deepEqual(await statusResponse.json(), { status: "success" });
+  const status = await statusResponse.json();
+  assert.equal(status.status, "success");
+  assert.match(status.attemptId, /^[0-9a-f-]+$/u);
+});
+
+test("wizard replaces OAuth attempts without waiting forever for superseded completion", async (t) => {
+  const { services } = createServices();
+  let starts = 0;
+  let cancelled = 0;
+  services.startOAuthLogin = async () => {
+    starts += 1;
+    return {
+      authorizationUrl: `https://auth.openai.com/oauth/authorize?attempt=${starts}`,
+      completion:
+        starts === 1 ? new Promise(() => {}) : Promise.resolve({ success: true }),
+      async cancel() {
+        cancelled += 1;
+      },
+    };
+  };
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+  t.after(() => wizard.close());
+
+  const first = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  const firstBody = await first.json();
+  const second = await Promise.race([
+    api(wizard.origin, "/api/oauth/login", {
+      method: "POST",
+      headers: { Origin: wizard.origin },
+      body: "{}",
+    }),
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("replacement waited for old completion")), 50);
+    }),
+  ]);
+  const secondBody = await second.json();
+
+  assert.equal(starts, 2);
+  assert.equal(cancelled, 1);
+  assert.equal(typeof firstBody.attemptId, "string");
+  assert.equal(typeof secondBody.attemptId, "string");
+  assert.notEqual(firstBody.attemptId, secondBody.attemptId);
+});
+
+test("wizard retires a cancelled OAuth attempt when replacement startup is retry-blocked", async (t) => {
+  const { services } = createServices();
+  let starts = 0;
+  services.startOAuthLogin = async () => {
+    starts += 1;
+    if (starts === 2) {
+      throw Object.assign(
+        new Error("The ChatGPT sign-in result could not be confirmed."),
+        { retryBlocked: true },
+      );
+    }
+    return {
+      authorizationUrl: "https://auth.openai.com/oauth/authorize?fixture=true",
+      completion: new Promise(() => {}),
+      cancel() {},
+    };
+  };
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+  t.after(() => wizard.close());
+
+  const first = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  await first.json();
+  const replacement = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+
+  assert.equal(replacement.status, 400);
+  assert.deepEqual(await replacement.json(), {
+    error: "The ChatGPT sign-in result could not be confirmed.",
+    retryBlocked: true,
+  });
+
+  const status = await api(wizard.origin, "/api/oauth/status");
+  assert.deepEqual(await status.json(), {
+    status: "error",
+    error: "The ChatGPT sign-in result could not be confirmed.",
+    retryBlocked: true,
+  });
+
+  const retry = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  assert.equal(retry.status, 409);
+  assert.equal(starts, 2);
+});
+
+test("wizard retires a cancelled OAuth attempt when replacement startup fails normally", async (t) => {
+  const { services } = createServices();
+  let starts = 0;
+  services.startOAuthLogin = () => {
+    starts += 1;
+    if (starts === 2) {
+      throw new Error("The ChatGPT sign-in could not be started.");
+    }
+    return {
+      authorizationUrl: "https://auth.openai.com/oauth/authorize?fixture=true",
+      completion: new Promise(() => {}),
+      cancel() {},
+    };
+  };
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+  t.after(() => wizard.close());
+
+  const first = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  await first.json();
+  const replacement = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  assert.equal(replacement.status, 400);
+
+  const status = await api(wizard.origin, "/api/oauth/status");
+  assert.deepEqual(await status.json(), {
+    status: "error",
+    error: "The ChatGPT sign-in could not be started.",
+  });
+  assert.equal(starts, 2);
+});
+
+test("wizard retires a manually cancelled OAuth attempt before a failed replacement starts", async (t) => {
+  const { services } = createServices();
+  let starts = 0;
+  services.startOAuthLogin = () => {
+    starts += 1;
+    if (starts === 2) {
+      throw new Error("The ChatGPT sign-in could not be started.");
+    }
+    return {
+      authorizationUrl: "https://auth.openai.com/oauth/authorize?fixture=true",
+      completion: new Promise(() => {}),
+      cancel() {},
+    };
+  };
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+  t.after(() => wizard.close());
+
+  const first = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  const { attemptId } = await first.json();
+  const cancelled = await api(wizard.origin, "/api/oauth/cancel", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: JSON.stringify({ attemptId }),
+  });
+  assert.equal(cancelled.status, 200);
+
+  const replacement = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  assert.equal(replacement.status, 400);
+
+  const status = await api(wizard.origin, "/api/oauth/status");
+  assert.deepEqual(await status.json(), {
+    status: "error",
+    error: "The ChatGPT sign-in could not be started.",
+  });
+  assert.equal(starts, 2);
+});
+
+test("wizard blocks retry after a manually cancelled OAuth attempt's replacement fails safely", async (t) => {
+  const { services } = createServices();
+  let starts = 0;
+  services.startOAuthLogin = () => {
+    starts += 1;
+    if (starts === 2) {
+      throw Object.assign(
+        new Error("The ChatGPT sign-in result could not be confirmed."),
+        { retryBlocked: true },
+      );
+    }
+    return {
+      authorizationUrl: "https://auth.openai.com/oauth/authorize?fixture=true",
+      completion: new Promise(() => {}),
+      cancel() {},
+    };
+  };
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+  t.after(() => wizard.close());
+
+  const first = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  const { attemptId } = await first.json();
+  const cancelled = await api(wizard.origin, "/api/oauth/cancel", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: JSON.stringify({ attemptId }),
+  });
+  assert.equal(cancelled.status, 200);
+
+  const replacement = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  assert.equal(replacement.status, 400);
+  assert.deepEqual(await replacement.json(), {
+    error: "The ChatGPT sign-in result could not be confirmed.",
+    retryBlocked: true,
+  });
+
+  const status = await api(wizard.origin, "/api/oauth/status");
+  assert.deepEqual(await status.json(), {
+    status: "error",
+    error: "The ChatGPT sign-in result could not be confirmed.",
+    retryBlocked: true,
+  });
+
+  const retry = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  assert.equal(retry.status, 409);
+  assert.equal(starts, 2);
+});
+
+test("wizard rejects a concurrent OAuth login while the first helper is starting", async (t) => {
+  const { services } = createServices();
+  let starts = 0;
+  let releaseStart;
+  const started = new Promise((resolvePromise) => {
+    releaseStart = resolvePromise;
+  });
+  let markStartEntered;
+  const startEntered = new Promise((resolvePromise) => {
+    markStartEntered = resolvePromise;
+  });
+  const attempt = {
+    authorizationUrl: "https://auth.openai.com/oauth/authorize?fixture=true",
+    completion: new Promise(() => {}),
+    cancel() {},
+  };
+  services.startOAuthLogin = async () => {
+    starts += 1;
+    markStartEntered();
+    await started;
+    return attempt;
+  };
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+  t.after(() => wizard.close());
+
+  const first = api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  await startEntered;
+  try {
+    const second = await Promise.race([
+      api(wizard.origin, "/api/oauth/login", {
+        method: "POST",
+        headers: { Origin: wizard.origin },
+        body: "{}",
+      }),
+      new Promise((resolvePromise) => {
+        setTimeout(() => resolvePromise(null), 25);
+      }),
+    ]);
+
+    assert.equal(second?.status, 409);
+    assert.equal(starts, 1);
+  } finally {
+    releaseStart();
+  }
+  assert.equal((await first).status, 200);
+});
+
+test("wizard close waits for an OAuth helper that is still starting and cancels it", async () => {
+  const { services } = createServices();
+  let releaseStart;
+  const started = new Promise((resolvePromise) => {
+    releaseStart = resolvePromise;
+  });
+  let markStartEntered;
+  const startEntered = new Promise((resolvePromise) => {
+    markStartEntered = resolvePromise;
+  });
+  let cancelled = 0;
+  services.startOAuthLogin = async () => {
+    markStartEntered();
+    await started;
+    return {
+      authorizationUrl: "https://auth.openai.com/oauth/authorize?fixture=true",
+      completion: new Promise(() => {}),
+      cancel() {
+        cancelled += 1;
+      },
+    };
+  };
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+
+  const loginRequest = api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  await startEntered;
+
+  let closed = false;
+  const close = wizard.close().then(() => {
+    closed = true;
+  });
+  await new Promise((resolvePromise) => setImmediate(resolvePromise));
+  assert.equal(closed, false);
+
+  releaseStart();
+  assert.equal((await loginRequest).status, 409);
+  await close;
+  assert.equal(cancelled, 1);
+});
+
+test("wizard cancels only the current OAuth attempt through its protected same-origin action", async (t) => {
+  const { services } = createServices();
+  let cancelled = 0;
+  services.startOAuthLogin = async () => ({
+    authorizationUrl: "https://auth.openai.com/oauth/authorize?fixture=true",
+    completion: new Promise(() => {}),
+    async cancel() {
+      cancelled += 1;
+    },
+  });
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+  t.after(() => wizard.close());
+
+  const login = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  const { attemptId } = await login.json();
+  const cancelledResponse = await api(wizard.origin, "/api/oauth/cancel", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: JSON.stringify({ attemptId }),
+  });
+
+  assert.equal(cancelledResponse.status, 200);
+  assert.deepEqual(await cancelledResponse.json(), {
+    status: "cancelled",
+    attemptId,
+  });
+  assert.equal(cancelled, 1);
+
+  const staleResponse = await api(wizard.origin, "/api/oauth/cancel", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: JSON.stringify({ attemptId: "not-the-current-attempt" }),
+  });
+  assert.equal(staleResponse.status, 409);
+  assert.equal(cancelled, 1);
+});
+
+test("wizard blocks another OAuth start when cancellation cannot confirm termination", async (t) => {
+  const { services } = createServices();
+  let starts = 0;
+  services.startOAuthLogin = async () => {
+    starts += 1;
+    return {
+      authorizationUrl: "https://auth.openai.com/oauth/authorize?fixture=true",
+      completion: new Promise(() => {}),
+      async cancel() {
+        throw new Error("unconfirmed helper termination");
+      },
+    };
+  };
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+  t.after(() => wizard.close());
+
+  const login = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  const { attemptId } = await login.json();
+  const cancelled = await api(wizard.origin, "/api/oauth/cancel", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: JSON.stringify({ attemptId }),
+  });
+
+  assert.equal(cancelled.status, 409);
+  assert.deepEqual(await cancelled.json(), {
+    error:
+      "ChatGPT sign-in could not be stopped safely. Close the sign-in helper, then restart Relmio.",
+    retryBlocked: true,
+  });
+
+  const status = await api(wizard.origin, "/api/oauth/status");
+  assert.deepEqual(await status.json(), {
+    status: "error",
+    attemptId,
+    error:
+      "ChatGPT sign-in could not be stopped safely. Close the sign-in helper, then restart Relmio.",
+    retryBlocked: true,
+  });
+
+  const retry = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  assert.equal(retry.status, 409);
+  assert.deepEqual(await retry.json(), {
+    error:
+      "ChatGPT sign-in could not be stopped safely. Close the sign-in helper, then restart Relmio.",
+    retryBlocked: true,
+  });
+  assert.equal(starts, 1);
+});
+
+test("wizard blocks another OAuth start after an unconfirmed startup cleanup", async (t) => {
+  const { services } = createServices();
+  let starts = 0;
+  services.startOAuthLogin = async () => {
+    starts += 1;
+    throw Object.assign(
+      new Error(
+        "OpenAI OAuth login needs http://localhost:1455/auth/callback, but port 1455 is already in use. Stop the process using that port and try again.",
+      ),
+      { retryBlocked: true },
+    );
+  };
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+  t.after(() => wizard.close());
+
+  const first = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  assert.equal(first.status, 400);
+  assert.deepEqual(await first.json(), {
+    error:
+      "OpenAI OAuth login needs http://localhost:1455/auth/callback, but port 1455 is already in use. Stop the process using that port and try again.",
+    retryBlocked: true,
+  });
+
+  const status = await api(wizard.origin, "/api/oauth/status");
+  assert.deepEqual(await status.json(), {
+    status: "error",
+    error:
+      "OpenAI OAuth login needs http://localhost:1455/auth/callback, but port 1455 is already in use. Stop the process using that port and try again.",
+    retryBlocked: true,
+  });
+
+  const retry = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  assert.equal(retry.status, 409);
+  assert.deepEqual(await retry.json(), {
+    error:
+      "ChatGPT sign-in could not be stopped safely. Close the sign-in helper, then restart Relmio.",
+    retryBlocked: true,
+  });
+  assert.equal(starts, 1);
+});
+
+test("wizard close is bounded when OAuth startup never settles and cancels a late helper", async () => {
+  const { services } = createServices();
+  let releaseStart;
+  const startup = new Promise((resolvePromise) => {
+    releaseStart = resolvePromise;
+  });
+  let markStartEntered;
+  const startEntered = new Promise((resolvePromise) => {
+    markStartEntered = resolvePromise;
+  });
+  let cancelled = 0;
+  services.startOAuthLogin = async () => {
+    markStartEntered();
+    return await startup;
+  };
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    oauthShutdownWaitMs: 0,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+
+  const loginRequest = api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  await startEntered;
+
+  const lateAttempt = {
+    authorizationUrl: "https://auth.openai.com/oauth/authorize?fixture=true",
+    completion: new Promise(() => {}),
+    cancel() {
+      cancelled += 1;
+    },
+  };
+  const close = wizard.close();
+  try {
+    await Promise.race([
+      close,
+      new Promise((_, rejectPromise) => {
+        setTimeout(
+          () => rejectPromise(new Error("wizard close waited for OAuth startup")),
+          50,
+        );
+      }),
+    ]);
+  } finally {
+    releaseStart(lateAttempt);
+    await close;
+  }
+  const loginResponse = await loginRequest;
+  assert.equal(loginResponse.status, 409);
+  await new Promise((resolvePromise) => setImmediate(resolvePromise));
+  assert.equal(cancelled, 1);
+});
+
+test("wizard persists a retry-blocked completion failure and refuses another helper", async (t) => {
+  const { services } = createServices();
+  let starts = 0;
+  let rejectCompletion;
+  const completion = new Promise((_, rejectPromise) => {
+    rejectCompletion = rejectPromise;
+  });
+  services.startOAuthLogin = async () => {
+    starts += 1;
+    return {
+      authorizationUrl: "https://auth.openai.com/oauth/authorize?fixture=true",
+      completion,
+      cancel() {},
+    };
+  };
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+  t.after(() => wizard.close());
+
+  const loginResponse = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  const { attemptId } = await loginResponse.json();
+  rejectCompletion(
+    Object.assign(
+      new Error("The ChatGPT sign-in result could not be confirmed."),
+      { retryBlocked: true },
+    ),
+  );
+  await new Promise((resolvePromise) => setImmediate(resolvePromise));
+
+  const status = await api(wizard.origin, "/api/oauth/status");
+  assert.deepEqual(await status.json(), {
+    status: "error",
+    attemptId,
+    error: "The ChatGPT sign-in result could not be confirmed.",
+    retryBlocked: true,
+  });
+
+  const retry = await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+  assert.equal(retry.status, 409);
+  assert.deepEqual(await retry.json(), {
+    error:
+      "ChatGPT sign-in could not be stopped safely. Close the sign-in helper, then restart Relmio.",
+    retryBlocked: true,
+  });
+  assert.equal(starts, 1);
+});
+
+test("wizard close waits for cancellation of a pending OAuth attempt", async () => {
+  const { services } = createServices();
+  let releaseCancel;
+  const cancellation = new Promise((resolve) => {
+    releaseCancel = resolve;
+  });
+  services.startOAuthLogin = async () => ({
+    authorizationUrl: "https://auth.openai.com/oauth/authorize?fixture=true",
+    completion: new Promise(() => {}),
+    cancel() {
+      return cancellation;
+    },
+  });
+  const wizard = await startWizardServer({
+    sessionToken,
+    services,
+    uiFiles: { "/": "", "/app.js": "", "/styles.css": "" },
+  });
+  await api(wizard.origin, "/api/oauth/login", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: "{}",
+  });
+
+  let closed = false;
+  const close = wizard.close().then(() => {
+    closed = true;
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(closed, false);
+  releaseCancel();
+  await close;
+  assert.equal(closed, true);
 });
 
 test("preview mode identifies itself and refuses to start live OAuth", async (t) => {
@@ -214,6 +892,14 @@ test("preview mode identifies itself and refuses to start live OAuth", async (t)
   assert.deepEqual(await loginResponse.json(), {
     error: "Live ChatGPT sign-in is disabled in sanitized preview mode.",
   });
+  assert.equal(loginStarted, false);
+
+  const cancelResponse = await api(wizard.origin, "/api/oauth/cancel", {
+    method: "POST",
+    headers: { Origin: wizard.origin },
+    body: JSON.stringify({ attemptId: "preview-attempt" }),
+  });
+  assert.equal(cancelResponse.status, 403);
   assert.equal(loginStarted, false);
 });
 

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -292,6 +292,36 @@ test("local OAuth prepares and navigates its popup before severing opener access
   assert.match(html, /id="login-link"[\s\S]*target="_blank"[\s\S]*rel="noopener noreferrer"/u);
 });
 
+test("OAuth UI offers an accessible stop control and rejects stale polling after replacement", async () => {
+  const [app, html] = await Promise.all([
+    readFile("src/ui/app.js", "utf8"),
+    readFile("src/ui/index.html", "utf8"),
+  ]);
+
+  assert.match(
+    html,
+    /<button id="stop-login-button" class="button secondary" type="button" hidden>\s*Stop ChatGPT sign-in\s*<\/button>/u,
+  );
+  assert.match(app, /async function waitForOAuthCompletion\(expectedAttemptId\)/u);
+  assert.match(
+    app,
+    /result\.retryBlocked === true[\s\S]*oauthRetryBlocked = true[\s\S]*result\.attemptId !== expectedAttemptId/u,
+  );
+  assert.match(
+    app,
+    /result\.attemptId !== expectedAttemptId[\s\S]*replaced by a newer attempt/u,
+  );
+  assert.match(
+    app,
+    /if \(error\.oauthRetryBlocked === true\) \{\s*blockOAuthRetry\(\);/u,
+  );
+  assert.match(app, /\/api\/oauth\/cancel/u);
+  assert.match(app, /body: \{ attemptId \}/u);
+  assert.match(app, /oauthLoginGeneration/u);
+  assert.match(app, /oauthRetryBlocked/u);
+  assert.match(app, /stop-login-button/u);
+});
+
 test("wizard theme preferences store only the selected color mode", async () => {
   const theme = await readFile("src/ui/theme.js", "utf8");
 


### PR DESCRIPTION
## Summary

- terminate the owned OpenAI OAuth helper process tree on manual cancellation and wizard shutdown
- add bounded POSIX and Windows cleanup fallbacks and block retries when termination cannot be confirmed
- make credential promotion attempt-local and atomic so cancelled or replaced attempts cannot overwrite the active credential
- add a manual **Stop sign-in** control and detect stale or replaced OAuth attempts

## Root cause

The OAuth helper was launched through a wrapper, but cancellation only targeted that direct child. A surviving descendant could keep callback port 1455 occupied, while replacement startup and shutdown could wait indefinitely on the previous attempt. OAuth status also lacked a stable attempt identity, so the UI could confuse results from restarted sign-ins.

## User impact

A rejected or interrupted ChatGPT sign-in can now be stopped and retried without leaving the owned helper on port 1455. If Relmio cannot prove that process cleanup or credential promotion completed safely, it fails closed and asks the user to close the helper and restart Relmio instead of launching another conflicting attempt.

## Validation

- `node --test test/oauth.test.js test/server.test.js test/ui.test.js`: 53 passed, 0 failed
- `npm test`: 249 passed, 6 skipped, 0 failed
- `npm run lint`: passed for 51 JavaScript files
- `git diff --check`: passed
- fresh high-effort Sol review: ship

## Residual testing notes

- Windows process-tree termination is covered through deterministic simulation rather than a native Windows run.
- Live Opera GX visual QA remains incomplete.
