### PR TITLE
release: Relmio v0.5.0

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Prepare, verify, and execute a safe Relmio release across the npm package, GitHub, Vercel, installers, and distribution surfaces. Use when planning or cutting a Relmio version, updating release metadata or curated notes, preparing a release PR, publishing through npm trusted publishing, verifying a deploy, or auditing installer and Homebrew availability.
+description: Prepare, verify, merge, and execute safe Relmio changes across main, the npm package, GitHub, Vercel, installers, and distribution surfaces. Use when a request says "merge to main" or otherwise asks to merge Relmio work into main, and when planning or cutting a version, updating release metadata or curated notes, preparing a release PR, publishing through npm trusted publishing, verifying a deploy, or auditing installer and Homebrew availability.
 ---
 
 # Ship Relmio safely
@@ -9,6 +9,44 @@ Use this workflow to produce evidence for a Relmio release. Treat every
 external write as a separately authorized step. Never use local npm tokens,
 never weaken branch protection, and never report a publish, release, tag, merge,
 or deploy that has not been verified.
+
+## 0. Select the SHIP lane
+
+- **Merge-only lane:** Use when the request says `merge to main`, asks to merge
+  a branch or commit into `main`, or asks whether Relmio work is ready for a
+  main merge. Audit every affected delivery surface, make needed repository
+  updates, verify the source and exact merged commit, and stop before remote
+  publication unless the user separately authorizes it.
+- **Release lane:** Use when the user explicitly asks to version, push, tag,
+  publish, deploy, create a GitHub release, or release everywhere. Follow the
+  complete release workflow below, including all authorization gates.
+
+A merge-only request does not authorize a push, npm publish, Vercel deploy,
+tag, GitHub release, Homebrew update, or installer publication. Do not invent a
+version bump merely to merge a compatible change.
+
+### Merge-only SHIP gate
+
+1. Inspect the source branch, `main`, worktrees, working-tree changes, merge
+   base, and `origin/main`. Preserve unrelated edits. If a dirty `main` path
+   overlaps the merge, stop; otherwise use an isolated candidate worktree when
+   practical and merge with the repository's protected flow or `--ff-only`.
+2. Classify the diff against the merge base using the applicability table in
+   section 2. Explicitly decide whether each of these needs a repository
+   update: `README.md`, `npm/README.md`, `CHANGELOG.md` under `Unreleased`, npm
+   package contents, `web/**`, `web/public/install.*`, Homebrew/distribution
+   metadata, and user-facing screenshots or guides. Update every applicable
+   surface before merging; record why every non-applicable surface is skipped.
+3. Run the published-baseline distribution audit, focused tests, the full root
+   gate, audit, package preview, diff/secret checks, and applicable web or
+   installer checks. A failed required check blocks the merge.
+4. Require review and required CI when a remote protected merge is in scope.
+   Local merge authorization does not imply remote merge authorization.
+5. Resolve and record the exact merged commit. Re-run the full root gate and
+   all affected-surface checks on `main`, then confirm the working tree still
+   contains every pre-existing unrelated edit.
+6. Report the exact merge commit, verification results, applicability matrix,
+   preserved user changes, and all external actions not performed.
 
 ## Distribution audit contract
 
@@ -38,6 +76,9 @@ completely, then use its deterministic audit as follows:
    evidence record, with every changed external system and unresolved surface.
 
 ## 1. Establish the release candidate
+
+Use sections 1, 4, and 5 only for the release lane, except where the merge-only
+gate explicitly references their inspection or verification rules.
 
 1. Start from a clean, isolated worktree on a short-lived release branch.
    - Run `git status --short`, `git branch --show-current`, and

--- a/.agents/skills/ship/agents/openai.yaml
+++ b/.agents/skills/ship/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Relmio Shipping"
-  short_description: "Release Relmio safely with evidence"
-  default_prompt: "Use $ship to prepare and verify a Relmio release."
+  short_description: "Merge or release Relmio with evidence"
+  default_prompt: "Use $ship to verify and safely merge or release Relmio changes."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+### Added
+
+- Add a **Rotate client credential** action for installed local endpoints that
+  shows the replacement capability before activation and preserves the upstream
+  Platform key or Codex credential/workspace volumes.
+
+### Changed
+
+- Keep System, Light, and Dark appearance controls plus Ko-fi, GitHub stars, and
+  the current package version available throughout the local install wizard.
+
+### Fixed
+
+- Install operating-system CA certificates in the isolated Codex image so the
+  official ChatGPT device-code sign-in can establish its trusted TLS connection.
+- Wrap local safety and error notifications instead of clipping longer text.
+
+### Security
+
+- Verify the generated Codex capability with a strict authenticated WebSocket
+  upgrade before reporting installation or rotation success.
+- Serialize installation, sign-in, restart, and credential rotation across
+  Relmio processes, with attested stale-lock recovery and fail-closed rollback.
+
 ## [0.4.1] - 2026-08-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+## [0.5.0] - 2026-08-15
+
 ### Added
 
 - Add a **Rotate client credential** action for installed local endpoints that
@@ -29,7 +31,8 @@ checks the registry separately after publication.
 - Verify the generated Codex capability with a strict authenticated WebSocket
   upgrade before reporting installation or rotation success.
 - Serialize installation, sign-in, restart, and credential rotation across
-  Relmio processes, with attested stale-lock recovery and fail-closed rollback.
+  Relmio processes, with attested stale-lock recovery and fail-closed rollback
+  that restores the prior verifier and re-attests endpoint readiness.
 
 ## [0.4.1] - 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -283,9 +283,10 @@ The bearer remains valid until it is rotated. After installation, use
 capability. Relmio shows the new one-time credential before activation, verifies
 the replacement endpoint, and preserves the upstream Platform API key or Codex
 credential/workspace volumes. If replacement cannot be verified, Relmio attempts
-to restore the previous capability. If rollback cannot be confirmed, it targets
-only the exact managed service for shutdown and reports whether that stopped
-state could be verified. Browser requests
+to restore the previous verifier and re-attest service readiness. It does not
+retain the previous raw client credential to replay it during rollback. If
+rollback cannot be confirmed, it targets only the exact managed service for
+shutdown and reports whether that stopped state could be verified. Browser requests
 must come from an exact origin entered during setup; wildcards are not allowed,
 and the capability must never be embedded in a public frontend bundle. Platform
 requests use that API project's billing, credits, limits, and permissions, not

--- a/README.md
+++ b/README.md
@@ -278,7 +278,14 @@ The OpenAI-compatible `/v1` endpoint is powered only by a Platform API key,
 which the wizard seeds over stdin into a private, labeled Docker volume; it
 does not create a host key file. Your app uses a
 separate Relmio capability that the wizard displays once.
-The bearer remains valid until it is rotated. Browser requests
+The bearer remains valid until it is rotated. After installation, use
+**Rotate client credential** on the Ready screen to replace only that local
+capability. Relmio shows the new one-time credential before activation, verifies
+the replacement endpoint, and preserves the upstream Platform API key or Codex
+credential/workspace volumes. If replacement cannot be verified, Relmio attempts
+to restore the previous capability. If rollback cannot be confirmed, it targets
+only the exact managed service for shutdown and reports whether that stopped
+state could be verified. Browser requests
 must come from an exact origin entered during setup; wildcards are not allowed,
 and the capability must never be embedded in a public frontend bundle. Platform
 requests use that API project's billing, credits, limits, and permissions, not
@@ -375,7 +382,8 @@ On desktop, the local wizard keeps progress and sidecar-only safety notes in a
 persistent rail beside the active task; its compact fixed-screen shell avoids
 document scrolling on common laptop screens. On narrow phones, it switches to
 a horizontal progress strip and keeps task scrolling inside the active panel.
-The hosted site keeps the live GitHub star/version control visible.
+Both the hosted site and local wizard keep Ko-fi support, GitHub stars, and the
+current Relmio version visible beside the appearance control.
 
 ## Choose a setup path
 

--- a/docs/local-endpoints.md
+++ b/docs/local-endpoints.md
@@ -77,19 +77,26 @@ Engine.
 
 ## Safe updates and credential rotation
 
-Rerun the browser wizard, select the same target and port, and review the plan
-again. Relmio verifies the existing marker and Docker resource ownership,
-reuses that installation's unique Compose identity, replaces only that managed
-service, and generates a new local client capability. Copy the new capability
-from the one-time result and update the client; the previous capability no
-longer authenticates.
+To replace only the credential used by your local client, select **Rotate client
+credential** on the installed endpoint's Ready screen. Relmio first stages and
+shows the new one-time capability while the previous capability remains active.
+It then updates and validates the managed Compose configuration, recreates only
+the attested service, and verifies the new bearer against `/v1/models` or the
+authenticated Codex WebSocket handshake before reporting success.
 
-For `openai-api`, every update requires the current Platform API key again. To
-rotate both credentials, supply the replacement Platform key during the update;
-Relmio atomically reseeds its private named volume and independently rotates the
-local client capability. For `codex-chatgpt`, an update retains the private
-Codex home and workspace volumes unless you explicitly delete them, but still
-rotates the local capability.
+This client-only rotation preserves the upstream Platform API key in its private
+named volume and preserves the Codex home and workspace volumes. If activation
+or verification fails, Relmio restores and verifies the previous capability. If
+that rollback cannot be confirmed, it attempts to stop only the exact managed
+service and reports whether the stopped state could be verified.
+
+Rerun the browser wizard with the same target and port when you need a complete
+managed update. Relmio verifies the marker and Docker resource ownership and
+reuses the installation's unique Compose identity. For `openai-api`, provide the
+current or replacement Platform API key during that full update; Relmio reseeds
+its private named volume independently from the local client capability. A full
+`codex-chatgpt` update retains the private Codex home and workspace volumes unless
+you explicitly delete them.
 
 Do not hand-edit the marker, Compose file, credential volume, or verifier. If
 the marker or resource labels do not attest as one Relmio installation, the

--- a/docs/local-endpoints.md
+++ b/docs/local-endpoints.md
@@ -86,9 +86,11 @@ authenticated Codex WebSocket handshake before reporting success.
 
 This client-only rotation preserves the upstream Platform API key in its private
 named volume and preserves the Codex home and workspace volumes. If activation
-or verification fails, Relmio restores and verifies the previous capability. If
-that rollback cannot be confirmed, it attempts to stop only the exact managed
-service and reports whether the stopped state could be verified.
+or verification fails, Relmio restores the previous verifier and re-attests its
+health and loopback publication. Relmio does not retain the previous raw client
+credential, so rollback does not replay an authenticated request with it. If
+that rollback cannot be confirmed, Relmio attempts to stop only the exact
+managed service and reports whether the stopped state could be verified.
 
 Rerun the browser wizard with the same target and port when you need a complete
 managed update. Relmio verifies the marker and Docker resource ownership and

--- a/npm/README.md
+++ b/npm/README.md
@@ -101,7 +101,8 @@ On desktop, the local wizard keeps progress and sidecar-only safety notes in a
 persistent rail beside the active task; its compact fixed-screen shell avoids
 document scrolling on common laptop screens. On narrow phones, it switches to
 a horizontal progress strip and keeps task scrolling inside the active panel.
-The hosted site keeps the live GitHub star/version control visible.
+Both the hosted site and local wizard keep Ko-fi support, GitHub stars, and the
+current Relmio version visible beside the appearance control.
 
 ## Local Docker endpoints
 
@@ -122,7 +123,14 @@ The OpenAI-compatible `/v1` endpoint is powered only by a Platform API key,
 which the wizard seeds over stdin into a private, labeled Docker volume; it
 does not create a host key file. Your app uses a
 separate Relmio capability that the wizard displays once.
-The bearer remains valid until it is rotated. Browser requests
+The bearer remains valid until it is rotated. After installation, use
+**Rotate client credential** on the Ready screen to replace only that local
+capability. Relmio shows the new one-time credential before activation, verifies
+the replacement endpoint, and preserves the upstream Platform API key or Codex
+credential/workspace volumes. If replacement cannot be verified, Relmio attempts
+to restore the previous capability. If rollback cannot be confirmed, it targets
+only the exact managed service for shutdown and reports whether that stopped
+state could be verified. Browser requests
 must come from an exact origin entered during setup; wildcards are not allowed,
 and the capability must never be embedded in a public frontend bundle. Platform
 requests use that API project's billing, credits, limits, and permissions, not

--- a/npm/README.md
+++ b/npm/README.md
@@ -128,9 +128,10 @@ The bearer remains valid until it is rotated. After installation, use
 capability. Relmio shows the new one-time credential before activation, verifies
 the replacement endpoint, and preserves the upstream Platform API key or Codex
 credential/workspace volumes. If replacement cannot be verified, Relmio attempts
-to restore the previous capability. If rollback cannot be confirmed, it targets
-only the exact managed service for shutdown and reports whether that stopped
-state could be verified. Browser requests
+to restore the previous verifier and re-attest service readiness. It does not
+retain the previous raw client credential to replay it during rollback. If
+rollback cannot be confirmed, it targets only the exact managed service for
+shutdown and reports whether that stopped state could be verified. Browser requests
 must come from an exact origin entered during setup; wildcards are not allowed,
 and the capability must never be embedded in a public frontend bundle. Platform
 requests use that API project's billing, credits, limits, and permissions, not

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relmio",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relmio",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ssh2": "1.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relmio",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Install private local OpenAI API and Codex endpoints with explicit provider credential boundaries, plus the existing isolated n8n sidecar.",
   "keywords": [
     "relmio",

--- a/src/domain/local-endpoints.js
+++ b/src/domain/local-endpoints.js
@@ -359,7 +359,10 @@ tool_suggest = false
 export function createCodexDockerfile() {
   return `FROM node:22-bookworm-slim
 
-RUN npm install --global --ignore-scripts @openai/codex@${CODEX_CLI_VERSION} \\
+RUN apt-get update \\
+    && apt-get install --no-install-recommends -y ca-certificates \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && npm install --global --ignore-scripts @openai/codex@${CODEX_CLI_VERSION} \\
     && npm cache clean --force \\
     && mkdir -p /etc/codex /home/node/.codex /workspace \\
     && chown -R node:node /home/node/.codex /workspace

--- a/src/services/local-installer.js
+++ b/src/services/local-installer.js
@@ -1593,7 +1593,7 @@ export async function activateLocalClientCredentialRotation(
     }
 
     throw new Error(
-      "Local credential rotation failed safely. The previous credential remains active.",
+      "Local credential rotation failed safely. The previous verifier was restored and the managed endpoint was re-attested.",
     );
   }
   } finally {

--- a/src/services/local-installer.js
+++ b/src/services/local-installer.js
@@ -1,6 +1,6 @@
 import { createHash, randomBytes as createRandomBytes, randomUUID } from "node:crypto";
 import * as defaultFileSystem from "node:fs/promises";
-import { createServer } from "node:net";
+import { createConnection, createServer } from "node:net";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 
@@ -27,6 +27,7 @@ const ROOT_MARKER = ".managed-by-relmio-root.json";
 const MARKER_SCHEMA_VERSION = 2;
 const ROOT_MARKER_SCHEMA_VERSION = 1;
 const COMPOSE_FILENAME = "docker-compose.yml";
+const INCOMPLETE_LOCK_STALE_MS = 30_000;
 const PROJECTS = Object.freeze({
   "openai-api": Object.freeze({
     projectPrefix: "relmio-openai-api",
@@ -291,10 +292,12 @@ async function writeManagedFile(fileSystem, path, contents, mode) {
   }
 
   const temporaryPath = `${path}.tmp-${randomUUID()}`;
+  let committed = false;
   try {
     await fileSystem.writeFile(temporaryPath, contents, { flag: "wx", mode });
     await fileSystem.chmod(temporaryPath, mode);
     await fileSystem.rename(temporaryPath, path);
+    committed = true;
     await fileSystem.chmod(path, mode);
   } catch {
     try {
@@ -302,8 +305,323 @@ async function writeManagedFile(fileSystem, path, contents, mode) {
     } catch {
       // The temporary file may not have been created.
     }
-    throw new Error("Relmio could not write its local managed files.");
+    const error = new Error("Relmio could not write its local managed files.");
+    error.committed = committed;
+    throw error;
   }
+}
+
+function createClientCredential(randomBytes) {
+  const capabilityBytes = randomBytes(32);
+  if (!Buffer.isBuffer(capabilityBytes) || capabilityBytes.length !== 32) {
+    throw new Error("Relmio could not generate a strong local capability.");
+  }
+  const clientCredential = capabilityBytes.toString("base64url");
+  const tokenSha256 = createHash("sha256")
+    .update(clientCredential)
+    .digest("hex");
+  return { clientCredential, tokenSha256 };
+}
+
+function validateClientCredentialVerifier(value) {
+  if (typeof value !== "string" || !/^[a-f0-9]{64}$/u.test(value)) {
+    throw new TypeError("The staged local client credential is invalid.");
+  }
+  return value;
+}
+
+function defaultIsProcessAlive(processId) {
+  try {
+    process.kill(processId, 0);
+    return true;
+  } catch (error) {
+    return error?.code !== "ESRCH";
+  }
+}
+
+function parseLockOwner(value) {
+  try {
+    const owner = JSON.parse(value);
+    if (
+      Number.isSafeInteger(owner?.processId) &&
+      owner.processId > 0 &&
+      typeof owner?.ownerToken === "string" &&
+      owner.ownerToken.length > 0 &&
+      owner.ownerToken.length <= 128
+    ) {
+      return owner;
+    }
+  } catch {
+    // An incomplete owner record is recoverable only after its metadata is stale.
+  }
+  return null;
+}
+
+async function readLockOwnerState(fileSystem, ownerPath, directoryPath) {
+  let serialized;
+  try {
+    serialized = await fileSystem.readFile(ownerPath, "utf8");
+  } catch (error) {
+    if (!isMissing(error)) {
+      throw error;
+    }
+  }
+  const metadata = await fileSystem.lstat(
+    serialized === undefined ? directoryPath : ownerPath,
+  );
+  return {
+    owner: serialized === undefined ? null : parseLockOwner(serialized),
+    serialized,
+    modifiedAtMs: metadata.mtimeMs,
+  };
+}
+
+function isIncompleteLockStale(state) {
+  return (
+    state.owner === null &&
+    Number.isFinite(state.modifiedAtMs) &&
+    Date.now() - state.modifiedAtMs >= INCOMPLETE_LOCK_STALE_MS
+  );
+}
+
+function lockOwnerStateMatches(left, right) {
+  if (left.owner && right.owner) {
+    return (
+      left.owner.processId === right.owner.processId &&
+      left.owner.ownerToken === right.owner.ownerToken
+    );
+  }
+  return left.owner === null && right.owner === null && left.serialized === right.serialized;
+}
+
+async function assertPublishedLockOwner(
+  fileSystem,
+  ownerPath,
+  directoryPath,
+  { processId, ownerToken },
+) {
+  const state = await readLockOwnerState(fileSystem, ownerPath, directoryPath);
+  if (
+    state.owner?.processId !== processId ||
+    state.owner?.ownerToken !== ownerToken
+  ) {
+    throw new Error("The local lock owner changed during publication.");
+  }
+}
+
+async function removeDetachedStaleLock(fileSystem, path) {
+  try {
+    await fileSystem.rm(path, { recursive: true, force: true });
+  } catch {
+    // A uniquely renamed stale artifact is outside the canonical lock path and
+    // must not strand the newly published owner when best-effort cleanup fails.
+  }
+}
+
+async function acquireLocalProjectLock(
+  { installRoot, target },
+  {
+    fileSystem = defaultFileSystem,
+    processId = process.pid,
+    isProcessAlive = defaultIsProcessAlive,
+  } = {},
+) {
+  const safeTarget = validateLocalTarget(target);
+  const safeInstallRoot = validateInstallDirectory(installRoot, safeTarget);
+  const lockPath = join(
+    dirname(resolve(safeInstallRoot, "..", "..")),
+    `.relmio-local-${safeTarget}.lock`,
+  );
+  const ownerPath = join(lockPath, "owner.json");
+  const ownerToken = randomUUID();
+
+  async function createLock() {
+    await fileSystem.mkdir(lockPath, { mode: 0o700 });
+    try {
+      await fileSystem.writeFile(
+        ownerPath,
+        `${JSON.stringify({ processId, ownerToken })}\n`,
+        { flag: "wx", mode: 0o600 },
+      );
+      await assertPublishedLockOwner(fileSystem, ownerPath, lockPath, {
+        processId,
+        ownerToken,
+      });
+    } catch {
+      // Leave an incomplete directory for stale recovery. Removing the shared
+      // path here could delete a successor lock after this creator was paused.
+      throw new Error("Relmio could not create its local project lock.");
+    }
+  }
+
+  try {
+    await createLock();
+  } catch (error) {
+    if (error?.code !== "EEXIST") {
+      throw error;
+    }
+
+    let ownerState;
+    try {
+      ownerState = await readLockOwnerState(fileSystem, ownerPath, lockPath);
+    } catch {
+      throw new Error("Another Relmio process is changing this local endpoint.");
+    }
+    const owner = ownerState.owner;
+    if (
+      (owner === null && !isIncompleteLockStale(ownerState)) ||
+      (owner !== null &&
+        (owner.ownerToken === ownerToken ||
+          owner.processId === processId ||
+          isProcessAlive(owner.processId)))
+    ) {
+      throw new Error("Another Relmio process is changing this local endpoint.");
+    }
+
+    const reclaimPath = join(lockPath, ".reclaim");
+    const reclaimOwnerPath = join(reclaimPath, "owner.json");
+    let reclaimClaimed = false;
+    async function createReclaimClaim() {
+      await fileSystem.mkdir(reclaimPath, { mode: 0o700 });
+      try {
+        await fileSystem.writeFile(
+          reclaimOwnerPath,
+          `${JSON.stringify({ processId, ownerToken })}\n`,
+          { flag: "wx", mode: 0o600 },
+        );
+        await assertPublishedLockOwner(
+          fileSystem,
+          reclaimOwnerPath,
+          reclaimPath,
+          { processId, ownerToken },
+        );
+      } catch {
+        // The same identity rule applies to reclaim publication: never remove
+        // a shared path after an owner write that may have lost a race.
+        throw new Error("Relmio could not create its reclaim lock.");
+      }
+    }
+    try {
+      try {
+        await createReclaimClaim();
+      } catch (error) {
+        if (error?.code !== "EEXIST") {
+          throw error;
+        }
+        const reclaimState = await readLockOwnerState(
+          fileSystem,
+          reclaimOwnerPath,
+          reclaimPath,
+        );
+        const reclaimOwner = reclaimState.owner;
+        if (
+          (reclaimOwner === null && !isIncompleteLockStale(reclaimState)) ||
+          (reclaimOwner !== null &&
+            (reclaimOwner.processId === processId ||
+              isProcessAlive(reclaimOwner.processId)))
+        ) {
+          throw new Error("Another process owns the reclaim lock.");
+        }
+        const staleReclaimPath = `${reclaimPath}.stale-${randomUUID()}`;
+        await fileSystem.rename(reclaimPath, staleReclaimPath);
+        await createReclaimClaim();
+        await removeDetachedStaleLock(fileSystem, staleReclaimPath);
+      }
+      reclaimClaimed = true;
+      const reclaimOwner = JSON.parse(
+        await fileSystem.readFile(reclaimOwnerPath, "utf8"),
+      );
+      if (reclaimOwner?.ownerToken !== ownerToken) {
+        throw new Error("The reclaim lock owner changed.");
+      }
+      const currentOwnerState = await readLockOwnerState(
+        fileSystem,
+        ownerPath,
+        lockPath,
+      );
+      if (!lockOwnerStateMatches(currentOwnerState, ownerState)) {
+        throw new Error("The local project lock owner changed.");
+      }
+      const stalePath = `${lockPath}.stale-${randomUUID()}`;
+      await fileSystem.rename(lockPath, stalePath);
+      reclaimClaimed = false;
+      await createLock();
+      await removeDetachedStaleLock(fileSystem, stalePath);
+    } catch {
+      if (reclaimClaimed) {
+        try {
+          const reclaimState = await readLockOwnerState(
+            fileSystem,
+            reclaimOwnerPath,
+            reclaimPath,
+          );
+          if (
+            reclaimState.owner?.processId === processId &&
+            reclaimState.owner?.ownerToken === ownerToken
+          ) {
+            await fileSystem.rm(reclaimPath, { recursive: true, force: true });
+          }
+        } catch {
+          // A changed or contended lock remains owned by the other process.
+        }
+      }
+      throw new Error("Another Relmio process is changing this local endpoint.");
+    }
+  }
+
+  return async () => {
+    try {
+      const owner = JSON.parse(await fileSystem.readFile(ownerPath, "utf8"));
+      if (owner?.ownerToken === ownerToken) {
+        await fileSystem.rm(lockPath, { recursive: true, force: true });
+      }
+    } catch {
+      // Never hide a completed endpoint operation because lock cleanup failed.
+    }
+  };
+}
+
+export async function acquireLocalEndpointChangeLock(
+  { target },
+  {
+    fileSystem = defaultFileSystem,
+    env = process.env,
+    homeDirectory = homedir(),
+    platform = process.platform,
+    processId = process.pid,
+    isProcessAlive = defaultIsProcessAlive,
+  } = {},
+) {
+  assertSupportedPlatform(platform);
+  rejectDockerEnvironmentOverrides(env);
+  const safeTarget = validateLocalTarget(target);
+  const installRoot = await resolveLocalInstallRoot({
+    target: safeTarget,
+    env,
+    homeDirectory,
+    fileSystem,
+    platform,
+  });
+  return acquireLocalProjectLock(
+    { installRoot, target: safeTarget },
+    { fileSystem, processId, isProcessAlive },
+  );
+}
+
+function replaceClientCredentialVerifier({ target, composeFile, tokenSha256 }) {
+  if (typeof composeFile !== "string" || composeFile.length > 512 * 1024) {
+    throw new Error("The managed local endpoint configuration is invalid.");
+  }
+
+  const pattern =
+    target === "openai-api"
+      ? /^([ \t]*RELMIO_GATEWAY_TOKEN_SHA256:[ \t]*)[a-f0-9]{64}([ \t]*)$/gmu
+      : /^([ \t]*-[ \t]+--ws-token-sha256[ \t]*\n[ \t]*-[ \t]+)[a-f0-9]{64}([ \t]*)$/gmu;
+  const matches = [...composeFile.matchAll(pattern)];
+  if (matches.length !== 1) {
+    throw new Error("The managed local endpoint configuration is invalid.");
+  }
+  return composeFile.replace(pattern, `$1${tokenSha256}$2`);
 }
 
 export function isLoopbackPortAvailable(port) {
@@ -431,6 +749,13 @@ export async function restartLocalCodex(
   dependencies = {},
 ) {
   const runProcess = dependencies.runProcess ?? runLocalProcess;
+  const releaseLock = dependencies.changeLockHeld === true
+    ? async () => {}
+    : await acquireLocalProjectLock(
+        { installRoot: installDirectory, target: "codex-chatgpt" },
+        dependencies,
+      );
+  try {
   const attested = await attestLocalCodexInstallation(
     { installDirectory },
     dependencies,
@@ -464,6 +789,34 @@ export async function restartLocalCodex(
     dockerHost: attested.dockerHost,
   });
   return { restarted: true };
+  } finally {
+    await releaseLock();
+  }
+}
+
+function createServiceRecreateSpec({
+  target,
+  installRoot,
+  dockerHost,
+  projectName,
+}) {
+  const project = PROJECTS[target];
+  return {
+    label: "Local client credential rotation",
+    file: "docker",
+    args: createComposeArgs(target, projectName, [
+      "up",
+      "-d",
+      "--wait",
+      "--wait-timeout",
+      "90",
+      "--force-recreate",
+      "--no-deps",
+      project.serviceName,
+    ]),
+    cwd: installRoot,
+    dockerHost,
+  };
 }
 
 function createProjectName(target, installId) {
@@ -773,7 +1126,7 @@ async function verifyHttpEndpoint({ plan, clientCredential, fetchImpl }) {
     throw new Error("The local endpoint did not pass its readiness check.");
   }
 
-  if (plan.target !== "openai-api") {
+  if (plan.target !== "openai-api" || clientCredential === undefined) {
     return [];
   }
 
@@ -800,6 +1153,121 @@ async function verifyHttpEndpoint({ plan, clientCredential, fetchImpl }) {
   }
 }
 
+export function verifyCodexWebSocketCapability(
+  { port, clientCredential },
+  {
+    connectSocket = createConnection,
+    randomBytes = createRandomBytes,
+    timeoutMs = 10_000,
+  } = {},
+) {
+  const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port });
+  if (
+    typeof clientCredential !== "string" ||
+    !/^[A-Za-z0-9_-]{43}$/u.test(clientCredential)
+  ) {
+    throw new TypeError("The staged local client credential is invalid.");
+  }
+  const keyBytes = randomBytes(16);
+  if (!Buffer.isBuffer(keyBytes) || keyBytes.length !== 16) {
+    throw new Error("Relmio could not verify the Codex client capability.");
+  }
+  const websocketKey = keyBytes.toString("base64");
+  const expectedAccept = createHash("sha1")
+    .update(`${websocketKey}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+    .digest("base64");
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    let settled = false;
+    let response = "";
+    const socket = connectSocket(
+      { host: "127.0.0.1", port: plan.port },
+      () => {
+        socket.write(
+          [
+            "GET / HTTP/1.1",
+            `Host: 127.0.0.1:${plan.port}`,
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            `Sec-WebSocket-Key: ${websocketKey}`,
+            "Sec-WebSocket-Version: 13",
+            `Authorization: Bearer ${clientCredential}`,
+            "",
+            "",
+          ].join("\r\n"),
+        );
+      },
+    );
+
+    const finish = (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socket.destroy();
+      if (error) {
+        rejectPromise(
+          new Error("The Codex client credential could not be verified."),
+        );
+      } else {
+        resolvePromise();
+      }
+    };
+
+    socket.setTimeout(timeoutMs, () => finish(new Error("timeout")));
+    socket.on("error", finish);
+    socket.on("close", () => finish(new Error("closed")));
+    socket.on("data", (chunk) => {
+      response += chunk.toString("latin1");
+      if (response.length > 16 * 1024) {
+        finish(new Error("oversized"));
+        return;
+      }
+      const headerEnd = response.indexOf("\r\n\r\n");
+      if (headerEnd === -1) {
+        return;
+      }
+      const lines = response.slice(0, headerEnd).split("\r\n");
+      if (!/^HTTP\/1\.1 101(?: |$)/u.test(lines.shift() ?? "")) {
+        finish(new Error("unauthorized"));
+        return;
+      }
+      const headers = new Map();
+      for (const line of lines) {
+        const separator = line.indexOf(":");
+        if (separator <= 0) {
+          finish(new Error("malformed"));
+          return;
+        }
+        const rawName = line.slice(0, separator);
+        if (!/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/u.test(rawName)) {
+          finish(new Error("malformed"));
+          return;
+        }
+        const name = rawName.toLowerCase();
+        const value = line.slice(separator + 1).trim();
+        if (headers.has(name)) {
+          finish(new Error("duplicate"));
+          return;
+        }
+        headers.set(name, value);
+      }
+      if (
+        headers.get("upgrade")?.toLowerCase() !== "websocket" ||
+        !headers
+          .get("connection")
+          ?.split(",")
+          .some((value) => value.trim().toLowerCase() === "upgrade") ||
+        headers.get("sec-websocket-accept") !== expectedAccept
+      ) {
+        finish(new Error("invalid upgrade"));
+        return;
+      }
+      finish();
+    });
+  });
+}
+
 async function defaultReadGatewaySource() {
   return defaultFileSystem.readFile(
     new URL("../gateway/openai.js", import.meta.url),
@@ -807,8 +1275,8 @@ async function defaultReadGatewaySource() {
   );
 }
 
-export async function attestLocalCodexInstallation(
-  { installDirectory },
+async function attestManagedLocalEndpoint(
+  { target, installDirectory, missingMessage, notRunningMessage },
   {
     fileSystem = defaultFileSystem,
     runProcess = runLocalProcess,
@@ -816,22 +1284,23 @@ export async function attestLocalCodexInstallation(
   } = {},
 ) {
   assertSupportedPlatform(platform);
+  const safeTarget = validateLocalTarget(target);
   const safeDirectory = validateInstallDirectory(
     installDirectory,
-    "codex-chatgpt",
+    safeTarget,
   );
   const relmioHome = resolve(safeDirectory, "..", "..");
   const managed = await inspectManagedRoot({
     fileSystem,
     relmioHome,
     installRoot: safeDirectory,
-    target: "codex-chatgpt",
+    target: safeTarget,
   });
   if (managed.deploymentMode !== "updated" || !managed.marker) {
-    throw new Error("Install the local Codex endpoint before signing in.");
+    throw new Error(missingMessage);
   }
   await attestDockerOwnership({
-    target: "codex-chatgpt",
+    target: safeTarget,
     installRoot: safeDirectory,
     dockerHost: managed.marker.dockerHost,
     installId: managed.marker.installId,
@@ -839,24 +1308,297 @@ export async function attestLocalCodexInstallation(
     runProcess,
   });
   const verification = createVerificationSpecs({
-    target: "codex-chatgpt",
+    target: safeTarget,
     installRoot: safeDirectory,
     dockerHost: managed.marker.dockerHost,
     projectName: managed.marker.projectName,
   });
   const running = await runOrThrow(runProcess, verification.running);
-  if (!running.stdout.split(/\s+/u).includes("codex")) {
-    throw new Error("The managed local Codex endpoint is not running.");
+  if (!running.stdout.split(/\s+/u).includes(PROJECTS[safeTarget].serviceName)) {
+    throw new Error(
+      notRunningMessage ?? "The managed local endpoint is not running.",
+    );
   }
   const publication = await runOrThrow(runProcess, verification.publication);
   validatePublishedEndpoint(publication.stdout, {
-    target: "codex-chatgpt",
+    target: safeTarget,
     port: managed.marker.port,
   });
   return {
+    target: safeTarget,
+    installDirectory: safeDirectory,
+    port: managed.marker.port,
     dockerHost: managed.marker.dockerHost,
     projectName: managed.marker.projectName,
   };
+}
+
+export async function attestLocalCodexInstallation(
+  { installDirectory },
+  dependencies = {},
+) {
+  const attested = await attestManagedLocalEndpoint(
+    {
+      target: "codex-chatgpt",
+      installDirectory,
+      missingMessage: "Install the local Codex endpoint before signing in.",
+      notRunningMessage: "The managed local Codex endpoint is not running.",
+    },
+    dependencies,
+  );
+  return {
+    dockerHost: attested.dockerHost,
+    projectName: attested.projectName,
+  };
+}
+
+export async function prepareLocalClientCredentialRotation(
+  { target },
+  {
+    fileSystem = defaultFileSystem,
+    env = process.env,
+    homeDirectory = homedir(),
+    runProcess = runLocalProcess,
+    randomBytes = createRandomBytes,
+    platform = process.platform,
+  } = {},
+) {
+  assertSupportedPlatform(platform);
+  rejectDockerEnvironmentOverrides(env);
+  const safeTarget = validateLocalTarget(target);
+  const installDirectory = await resolveLocalInstallRoot({
+    target: safeTarget,
+    env,
+    homeDirectory,
+    fileSystem,
+    platform,
+  });
+  const attested = await attestManagedLocalEndpoint(
+    {
+      target: safeTarget,
+      installDirectory,
+      missingMessage:
+        "Install the local endpoint before rotating its client credential.",
+    },
+    { fileSystem, runProcess, platform },
+  );
+  const { clientCredential, tokenSha256 } = createClientCredential(randomBytes);
+  const plan = createLocalDeploymentPlan({
+    target: safeTarget,
+    port: attested.port,
+    allowedOrigins: [],
+  });
+  return {
+    target: plan.target,
+    endpoint: plan.endpoint,
+    protocol: plan.protocol,
+    clientCredential,
+    tokenSha256,
+    credentialShownOnce: true,
+    models: [],
+    deploymentMode: "staged",
+    experimental: plan.experimental,
+    browserClients: plan.browserClients,
+  };
+}
+
+export async function activateLocalClientCredentialRotation(
+  { target, clientCredential, tokenSha256 },
+  {
+    fileSystem = defaultFileSystem,
+    env = process.env,
+    homeDirectory = homedir(),
+    runProcess = runLocalProcess,
+    fetchImpl = fetch,
+    verifyCodexCapability = verifyCodexWebSocketCapability,
+    platform = process.platform,
+    processId = process.pid,
+    isProcessAlive = defaultIsProcessAlive,
+  } = {},
+) {
+  assertSupportedPlatform(platform);
+  rejectDockerEnvironmentOverrides(env);
+  const safeTarget = validateLocalTarget(target);
+  const safeVerifier = validateClientCredentialVerifier(tokenSha256);
+  if (
+    typeof clientCredential !== "string" ||
+    createHash("sha256").update(clientCredential).digest("hex") !== safeVerifier
+  ) {
+    throw new TypeError("The staged local client credential is invalid.");
+  }
+  const installDirectory = await resolveLocalInstallRoot({
+    target: safeTarget,
+    env,
+    homeDirectory,
+    fileSystem,
+    platform,
+  });
+  const releaseLock = await acquireLocalProjectLock(
+    { installRoot: installDirectory, target: safeTarget },
+    { fileSystem, processId, isProcessAlive },
+  );
+  try {
+  const attested = await attestManagedLocalEndpoint(
+    {
+      target: safeTarget,
+      installDirectory,
+      missingMessage:
+        "Install the local endpoint before rotating its client credential.",
+    },
+    { fileSystem, runProcess, platform },
+  );
+  const composePath = join(installDirectory, COMPOSE_FILENAME);
+  await assertRegularManagedMarker(
+    fileSystem,
+    composePath,
+    "The managed local endpoint configuration is invalid.",
+  );
+  let previousCompose;
+  try {
+    previousCompose = await fileSystem.readFile(composePath, "utf8");
+  } catch {
+    throw new Error("The managed local endpoint configuration is invalid.");
+  }
+
+  const replacementCompose = replaceClientCredentialVerifier({
+    target: safeTarget,
+    composeFile: previousCompose,
+    tokenSha256: safeVerifier,
+  });
+  const plan = createLocalDeploymentPlan({
+    target: safeTarget,
+    port: attested.port,
+    allowedOrigins: [],
+  });
+  const validateCompose = () =>
+    runOrThrow(runProcess, {
+      label: "Local Compose validation",
+      file: "docker",
+      args: createComposeArgs(safeTarget, attested.projectName, [
+        "config",
+        "--quiet",
+      ]),
+      cwd: installDirectory,
+      dockerHost: attested.dockerHost,
+    });
+  let configurationWritten = false;
+
+  try {
+    await writeManagedFile(fileSystem, composePath, replacementCompose, 0o600);
+    configurationWritten = true;
+    await validateCompose();
+    await runOrThrow(
+      runProcess,
+      createServiceRecreateSpec({
+        target: safeTarget,
+        installRoot: installDirectory,
+        dockerHost: attested.dockerHost,
+        projectName: attested.projectName,
+      }),
+    );
+    await attestManagedLocalEndpoint(
+      {
+        target: safeTarget,
+        installDirectory,
+        missingMessage:
+          "Install the local endpoint before rotating its client credential.",
+      },
+      { fileSystem, runProcess, platform },
+    );
+    const models = await verifyHttpEndpoint({
+      plan,
+      clientCredential,
+      fetchImpl,
+    });
+    if (safeTarget === "codex-chatgpt") {
+      await verifyCodexCapability({
+        port: plan.port,
+        clientCredential,
+      });
+    }
+    return {
+      target: plan.target,
+      endpoint: plan.endpoint,
+      protocol: plan.protocol,
+      models,
+      deploymentMode: "updated",
+      experimental: plan.experimental,
+      browserClients: plan.browserClients,
+    };
+  } catch (error) {
+    if (error?.committed === true) {
+      configurationWritten = true;
+    }
+    if (!configurationWritten) {
+      throw new Error("Relmio could not rotate the local client credential.");
+    }
+
+    try {
+      await writeManagedFile(fileSystem, composePath, previousCompose, 0o600);
+      await validateCompose();
+      await runOrThrow(
+        runProcess,
+        createServiceRecreateSpec({
+          target: safeTarget,
+          installRoot: installDirectory,
+          dockerHost: attested.dockerHost,
+          projectName: attested.projectName,
+        }),
+      );
+      await attestManagedLocalEndpoint(
+        {
+          target: safeTarget,
+          installDirectory,
+          missingMessage:
+            "Install the local endpoint before rotating its client credential.",
+        },
+        { fileSystem, runProcess, platform },
+      );
+      await verifyHttpEndpoint({ plan, fetchImpl });
+    } catch {
+      let stopped = false;
+      try {
+        await runOrThrow(
+          runProcess,
+          createCleanupSpec({
+            target: safeTarget,
+            installRoot: installDirectory,
+            dockerHost: attested.dockerHost,
+            projectName: attested.projectName,
+          }),
+        );
+        const remaining = await runOrThrow(
+          runProcess,
+          createCleanupVerificationSpec({
+            target: safeTarget,
+            installRoot: installDirectory,
+            dockerHost: attested.dockerHost,
+            projectName: attested.projectName,
+          }),
+        );
+        stopped = !remaining.stdout
+          .split(/\s+/u)
+          .includes(PROJECTS[safeTarget].serviceName);
+      } catch {
+        // The endpoint is left stopped only when Docker confirms the exact service is gone.
+      }
+      if (stopped) {
+        throw new Error(
+          "Local credential rotation failed safely. The local endpoint was stopped.",
+        );
+      }
+      throw new Error(
+        "Relmio could not confirm that the failed credential rotation was stopped. Inspect the Relmio Docker project before retrying.",
+      );
+    }
+
+    throw new Error(
+      "Local credential rotation failed safely. The previous credential remains active.",
+    );
+  }
+  } finally {
+    await releaseLock();
+  }
 }
 
 export async function installLocalEndpoint(
@@ -870,7 +1612,10 @@ export async function installLocalEndpoint(
     isPortAvailable = isLoopbackPortAvailable,
     readGatewaySource = defaultReadGatewaySource,
     fetchImpl = fetch,
+    verifyCodexCapability = verifyCodexWebSocketCapability,
     platform = process.platform,
+    processId = process.pid,
+    isProcessAlive = defaultIsProcessAlive,
   } = {},
 ) {
   if (confirmed !== true) {
@@ -895,6 +1640,11 @@ export async function installLocalEndpoint(
     fileSystem,
     platform,
   });
+  const releaseLock = await acquireLocalProjectLock(
+    { installRoot, target: normalizedPlan.target },
+    { fileSystem, processId, isProcessAlive },
+  );
+  try {
   const relmioHome = resolve(installRoot, "..", "..");
   const managed = await inspectManagedRoot({
     fileSystem,
@@ -1069,6 +1819,12 @@ export async function installLocalEndpoint(
       clientCredential,
       fetchImpl,
     });
+    if (normalizedPlan.target === "codex-chatgpt") {
+      await verifyCodexCapability({
+        port: normalizedPlan.port,
+        clientCredential,
+      });
+    }
   } catch (error) {
     if (deploymentStarted) {
       let cleanupConfirmed = false;
@@ -1117,4 +1873,7 @@ export async function installLocalEndpoint(
     experimental: normalizedPlan.experimental,
     browserClients: normalizedPlan.browserClients,
   };
+  } finally {
+    await releaseLock();
+  }
 }

--- a/src/ui/local.css
+++ b/src/ui/local.css
@@ -18,6 +18,128 @@
   grid-column: 2;
 }
 
+.local-wizard .header-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.local-wizard .local-support-button,
+.local-wizard .local-repository-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  text-decoration: none;
+  transition:
+    border-color 180ms var(--ease),
+    background 180ms var(--ease),
+    color 180ms var(--ease),
+    transform 180ms var(--ease);
+}
+
+.local-wizard .local-support-button {
+  width: 2.5rem;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  background: var(--surface);
+  color: var(--text);
+}
+
+.local-wizard .local-support-button svg {
+  width: 1.125rem;
+  height: 1.125rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.local-wizard .local-repository-button {
+  min-height: 2.5rem;
+  gap: 0.5rem;
+  padding: 0.3125rem 0.375rem 0.3125rem 0.75rem;
+  border-color: var(--text);
+  background: var(--text);
+  color: var(--background);
+  font-size: 0.75rem;
+}
+
+.local-wizard .local-repository-button > svg {
+  width: 1.125rem;
+  height: 1.125rem;
+  flex: none;
+}
+
+.local-wizard .local-repository-action,
+.local-wizard .package-version {
+  min-height: 1.75rem;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.5625rem;
+  border-radius: 999px;
+  white-space: nowrap;
+  font: 700 0.6875rem/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.local-wizard .local-repository-action {
+  background: var(--background);
+  color: var(--text);
+}
+
+.local-wizard .package-version {
+  background: var(--background);
+  color: var(--text);
+}
+
+.local-wizard .local-support-button:hover,
+.local-wizard .local-repository-button:hover {
+  border-color: var(--accent);
+  color: var(--accent-deep);
+  transform: translateY(-1px);
+}
+
+.local-wizard .local-repository-button:hover {
+  background: var(--accent);
+  color: #fff;
+}
+
+.local-wizard .local-support-button:focus-visible,
+.local-wizard .local-repository-button:focus-visible {
+  outline: 3px solid #f2a94a;
+  outline-offset: 2px;
+}
+
+.local-wizard .toast-stack {
+  display: grid;
+  min-width: 0;
+  overflow: visible;
+}
+
+.local-wizard .toast-stack .toast {
+  width: 100%;
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
+.local-wizard .safety-note > span {
+  display: block;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.local-wizard #global-message-text,
+.local-wizard .error > span {
+  min-width: 0;
+  overflow: visible;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
+  word-break: break-word;
+}
+
 .target-picker {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -137,7 +259,8 @@
 .policy-note,
 .high-trust-warning,
 .one-time-note,
-.codex-login {
+.codex-login,
+.credential-rotation-note {
   margin-top: 1rem;
   padding: 0.875rem 1rem;
   border: 1px solid var(--accent-border);
@@ -148,7 +271,8 @@
 .policy-note p,
 .high-trust-warning p,
 .one-time-note p,
-.codex-login p {
+.codex-login p,
+.credential-rotation-note p {
   margin: 0.35rem 0 0;
   color: var(--text-muted);
   font-size: 0.875rem;
@@ -173,6 +297,20 @@
 .one-time-note strong,
 .one-time-note p {
   color: var(--warning);
+}
+
+.credential-rotation-note {
+  border-color: var(--warning-border);
+  background: var(--warning-soft);
+}
+
+.credential-rotation-note strong,
+.credential-rotation-note p {
+  color: var(--warning);
+}
+
+.credential-rotation-note .button {
+  margin-top: 0.875rem;
 }
 
 .local-review-grid {

--- a/src/ui/local.html
+++ b/src/ui/local.html
@@ -14,6 +14,7 @@
     />
     <link rel="stylesheet" href="/styles.css" />
     <link rel="stylesheet" href="/local.css" />
+    <script src="/theme.js" type="module"></script>
     <script src="/local.js" type="module"></script>
   </head>
   <body class="local-wizard" data-current-step="1">
@@ -32,7 +33,58 @@
         </svg>
         <span>Relmio</span>
       </div>
-      <span class="local-badge">Bound to this computer only</span>
+      <div class="header-actions">
+        <fieldset class="theme-picker">
+          <legend class="visually-hidden">Color theme</legend>
+          <label title="Use system appearance">
+            <input type="radio" name="color-theme" value="system" checked />
+            <span class="theme-icon theme-icon-system" aria-hidden="true"></span>
+            <span class="visually-hidden">System</span>
+          </label>
+          <label title="Use light appearance">
+            <input type="radio" name="color-theme" value="light" />
+            <span class="theme-icon theme-icon-light" aria-hidden="true"></span>
+            <span class="visually-hidden">Light</span>
+          </label>
+          <label title="Use dark appearance">
+            <input type="radio" name="color-theme" value="dark" />
+            <span class="theme-icon theme-icon-dark" aria-hidden="true"></span>
+            <span class="visually-hidden">Dark</span>
+          </label>
+        </fieldset>
+        <a
+          class="local-support-button"
+          href="https://ko-fi.com/paldogies"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Support Relmio on Ko-fi (opens in a new tab)"
+          title="Support Relmio on Ko-fi"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M5 8h12v5a6 6 0 0 1-12 0V8Z" />
+            <path d="M17 9h1.5a2.5 2.5 0 0 1 0 5H17M8 3v2m4-2v2m4-2v2" />
+          </svg>
+        </a>
+        <a
+          id="local-repository-button"
+          class="local-repository-button"
+          href="https://github.com/Demonbane18/relmio"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Open Relmio version __RELMIO_PACKAGE_VERSION__ on GitHub to leave a star (opens in a new tab)"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M12 .7a11.5 11.5 0 0 0-3.64 22.41c.58.11.79-.25.79-.56v-2.23c-3.22.7-3.9-1.37-3.9-1.37-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.71.08-.71 1.16.08 1.77 1.19 1.77 1.19 1.04 1.77 2.72 1.26 3.38.96.1-.75.4-1.26.73-1.55-2.57-.29-5.28-1.29-5.28-5.69 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.16 1.18a10.9 10.9 0 0 1 5.76 0c2.19-1.49 3.16-1.18 3.16-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.83 1.19 3.09 0 4.42-2.71 5.4-5.29 5.69.42.36.79 1.06.79 2.14v3.17c0 .31.21.68.8.56A11.5 11.5 0 0 0 12 .7Z" />
+          </svg>
+          <strong>GitHub</strong>
+          <span class="local-repository-action">
+            <span aria-hidden="true">★</span>
+            <span id="local-repository-stars">?</span>
+          </span>
+          <span class="package-version">v__RELMIO_PACKAGE_VERSION__</span>
+        </a>
+        <span class="local-badge">Bound to this computer only</span>
+      </div>
     </header>
 
     <main id="main-content" class="shell" tabindex="-1">
@@ -341,6 +393,22 @@
             Relmio shows the generated client credential only in this install
             response. It cannot recover it after you leave this page.
           </p>
+        </aside>
+
+        <aside class="credential-rotation-note">
+          <strong>Rotate client credential</strong>
+          <p>
+            Rotating replaces the credential and permanently revokes the previous
+            one. Relmio shows the replacement first, then activates and verifies
+            it. Copy it before leaving this page.
+          </p>
+          <button
+            id="rotate-credential-button"
+            class="button secondary"
+            type="button"
+          >
+            Rotate client credential
+          </button>
         </aside>
 
         <dl class="result-list">

--- a/src/ui/local.html
+++ b/src/ui/local.html
@@ -398,9 +398,9 @@
         <aside class="credential-rotation-note">
           <strong>Rotate client credential</strong>
           <p>
-            Rotating replaces the credential and permanently revokes the previous
-            one. Relmio shows the replacement first, then activates and verifies
-            it. Copy it before leaving this page.
+            Relmio shows the replacement first, then activates and verifies it.
+            After successful activation, the previous credential no longer works.
+            Copy the replacement before leaving this page.
           </p>
           <button
             id="rotate-credential-button"

--- a/src/ui/local.js
+++ b/src/ui/local.js
@@ -9,6 +9,7 @@ const state = {
   dockerAvailable: false,
   planId: null,
   plan: null,
+  installedTarget: null,
 };
 
 const messageBox = element("global-message");
@@ -221,6 +222,7 @@ function renderInstallResult(result) {
   }
 
   const isOpenAiApi = result.target === "openai-api";
+  state.installedTarget = result.target;
   element("result-endpoint").textContent = result.endpoint;
   element("result-credential").textContent = result.clientCredential;
   element("codex-production-warning").hidden = isOpenAiApi;
@@ -444,6 +446,44 @@ element("install-button").addEventListener("click", async (event) => {
   }
 });
 
+element("rotate-credential-button").addEventListener("click", async (event) => {
+  const button = event.currentTarget;
+  clearError();
+  if (!state.installedTarget) {
+    showError(new Error("Install a local endpoint before rotating its credential."));
+    return;
+  }
+
+  setBusy(button, true, "Rotating credential…");
+  setMessage(
+    "Generating a replacement credential before activating it…",
+  );
+  try {
+    const staged = await api("/api/local/client-credential/rotate", {
+      method: "POST",
+      body: { target: state.installedTarget },
+    });
+    renderInstallResult(staged);
+    setMessage("Replacement credential received. Activating and verifying it now…");
+    await new Promise((resolvePromise) => window.requestAnimationFrame(resolvePromise));
+    await new Promise((resolvePromise) => window.requestAnimationFrame(resolvePromise));
+    const activated = await api("/api/local/client-credential/activate", {
+      method: "POST",
+      body: {
+        rotationId: staged.rotationId,
+        clientCredential: staged.clientCredential,
+      },
+    });
+    renderInstallResult({ ...staged, ...activated });
+    setMessage("Client credential rotated. Copy the new one now; the previous one no longer works.");
+  } catch (error) {
+    setMessage("The replacement credential was not confirmed active. Follow the error guidance before retrying.");
+    showError(error);
+  } finally {
+    setBusy(button, false);
+  }
+});
+
 element("codex-login-button").addEventListener("click", async (event) => {
   const button = event.currentTarget;
   const resultBox = element("device-code-result");
@@ -546,5 +586,23 @@ async function refreshDockerStatus() {
   }
 }
 
+async function refreshProjectMeta() {
+  const result = await api("/api/local/project-meta");
+  const stars = Number.isSafeInteger(result.stars) && result.stars >= 0
+    ? new Intl.NumberFormat("en", {
+        notation: result.stars >= 1_000 ? "compact" : "standard",
+        maximumFractionDigits: 1,
+      }).format(result.stars)
+    : "?";
+  element("local-repository-stars").textContent = stars;
+  element("local-repository-button").setAttribute(
+    "aria-label",
+    `Open Relmio version ${result.version} on GitHub. ${
+      stars === "?" ? "GitHub star count is unavailable." : `${result.stars} GitHub stars.`
+    } Opens in a new tab.`,
+  );
+}
+
 renderTarget();
 refreshDockerStatus().catch(showError);
+refreshProjectMeta().catch(() => {});

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -1,6 +1,7 @@
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { createServer } from "node:http";
+import packageManifest from "../../package.json" with { type: "json" };
 
 import { discoverN8n, discoverNetworks } from "../services/discovery.js";
 import { installSidecar } from "../services/installer.js";
@@ -18,13 +19,19 @@ import {
   validatePort,
 } from "../domain/validation.js";
 import { SIDECAR_HOSTNAME } from "../domain/templates.js";
-import { createLocalDeploymentPlan } from "../domain/local-endpoints.js";
 import {
+  createLocalDeploymentPlan,
+  validateLocalTarget,
+} from "../domain/local-endpoints.js";
+import {
+  acquireLocalEndpointChangeLock,
+  activateLocalClientCredentialRotation,
   attestLocalCodexInstallation,
   getLocalDockerStatus,
   installLocalEndpoint,
   resolveLocalInstallRoot,
   restartLocalCodex,
+  prepareLocalClientCredentialRotation,
 } from "../services/local-installer.js";
 import { startCodexDeviceLogin } from "../services/codex-login.js";
 
@@ -32,6 +39,34 @@ const MAX_BODY_BYTES = 32 * 1024;
 const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 const RATE_LIMIT_MAX = 10;
 const OAUTH_SHUTDOWN_WAIT_MS = 2_000;
+const LOCAL_ROTATION_STAGE_TTL_MS = 2 * 60 * 1000;
+const PACKAGE_VERSION = packageManifest.version;
+
+async function getProjectMeta({ fetchImpl = fetch } = {}) {
+  let stars = null;
+  try {
+    const response = await fetchImpl(
+      "https://api.github.com/repos/Demonbane18/relmio",
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "User-Agent": `relmio/${PACKAGE_VERSION}`,
+        },
+        redirect: "error",
+        signal: AbortSignal.timeout(5_000),
+      },
+    );
+    if (response.ok) {
+      const value = (await response.json())?.stargazers_count;
+      if (Number.isSafeInteger(value) && value >= 0) {
+        stars = value;
+      }
+    }
+  } catch {
+    // The local control keeps a visible fallback when GitHub is unavailable.
+  }
+  return { stars, version: PACKAGE_VERSION };
+}
 
 const defaultServices = {
   getAuthStatus,
@@ -44,7 +79,11 @@ const defaultServices = {
   installSidecar,
   attestLocalCodexInstallation,
   getLocalDockerStatus,
+  getProjectMeta,
   installLocalEndpoint,
+  acquireLocalEndpointChangeLock,
+  activateLocalClientCredentialRotation,
+  prepareLocalClientCredentialRotation,
   resolveLocalInstallRoot,
   restartLocalCodex,
   startCodexDeviceLogin,
@@ -268,7 +307,7 @@ async function loadDefaultUiFiles() {
 
   return {
     "/": files[0],
-    "/local": files[1],
+    "/local": files[1].replaceAll("__RELMIO_PACKAGE_VERSION__", PACKAGE_VERSION),
     "/app.js": files[2],
     "/local.js": files[3],
     "/oauth-popup.js": files[4],
@@ -310,6 +349,38 @@ function createSafeLocalInstallResult(result) {
     experimental: result.experimental === true,
     browserClients: result.browserClients === true,
   };
+}
+
+function createSafeLocalActivationResult(result) {
+  return {
+    target: result.target,
+    endpoint: result.endpoint,
+    protocol: result.protocol,
+    models: Array.isArray(result.models) ? [...result.models] : [],
+    deploymentMode: result.deploymentMode,
+    experimental: result.experimental === true,
+    browserClients: result.browserClients === true,
+  };
+}
+
+function createSafeProjectMeta(result) {
+  return {
+    stars:
+      Number.isSafeInteger(result?.stars) && result.stars >= 0
+        ? result.stars
+        : null,
+    version: PACKAGE_VERSION,
+  };
+}
+
+function getPendingLocalCredentialRotation(state) {
+  if (
+    state.localCredentialRotationPending &&
+    state.localCredentialRotationPending.expiresAt <= Date.now()
+  ) {
+    state.localCredentialRotationPending = null;
+  }
+  return state.localCredentialRotationPending;
 }
 
 function createSafeDockerStatus(status, previewMode) {
@@ -377,6 +448,15 @@ async function handleApi(request, response, path, state) {
       response,
       200,
       createSafeDockerStatus(status, state.previewMode),
+    );
+    return;
+  }
+
+  if (request.method === "GET" && path === "/api/local/project-meta") {
+    sendJson(
+      response,
+      200,
+      createSafeProjectMeta(await state.services.getProjectMeta()),
     );
     return;
   }
@@ -568,9 +648,15 @@ async function handleApi(request, response, path, state) {
     try {
       requireLiveLocalAction(state, "Local endpoint installation");
       enforceRateLimit(state, path);
-      if (state.localInstallInFlight) {
+      if (
+        state.localInstallInFlight ||
+        state.localCredentialRotationInFlight ||
+        getPendingLocalCredentialRotation(state) ||
+        state.codexLoginStartInFlight ||
+        state.codexLogin?.status === "pending"
+      ) {
         throw Object.assign(
-          new Error("A local endpoint installation is already in progress."),
+          new Error("A local endpoint change is already in progress."),
           { statusCode: 409 },
         );
       }
@@ -600,26 +686,105 @@ async function handleApi(request, response, path, state) {
     return;
   }
 
+  if (path === "/api/local/client-credential/rotate") {
+    requireLiveLocalAction(state, "Local client credential rotation");
+    enforceRateLimit(state, path);
+    if (
+      state.localCredentialRotationInFlight ||
+      state.localInstallInFlight ||
+      getPendingLocalCredentialRotation(state) ||
+      state.codexLoginStartInFlight ||
+      state.codexLogin?.status === "pending"
+    ) {
+      throw Object.assign(
+        new Error("A local endpoint change is already in progress."),
+        { statusCode: 409 },
+      );
+    }
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      throw new Error("Choose the installed local endpoint before rotating its credential.");
+    }
+
+    state.localCredentialRotationInFlight = true;
+    try {
+      const result = await state.services.prepareLocalClientCredentialRotation({
+        target: validateLocalTarget(body.target),
+      });
+      const rotationId = randomUUID();
+      state.localCredentialRotationPending = {
+        rotationId,
+        target: result.target,
+        tokenSha256: result.tokenSha256,
+        expiresAt: Date.now() + LOCAL_ROTATION_STAGE_TTL_MS,
+      };
+      sendJson(response, 200, {
+        ...createSafeLocalInstallResult(result),
+        rotationId,
+      });
+    } finally {
+      state.localCredentialRotationInFlight = false;
+    }
+    return;
+  }
+
+  if (path === "/api/local/client-credential/activate") {
+    requireLiveLocalAction(state, "Local client credential activation");
+    enforceRateLimit(state, path);
+    if (
+      state.localCredentialRotationInFlight ||
+      state.localInstallInFlight ||
+      state.codexLoginStartInFlight ||
+      state.codexLogin?.status === "pending"
+    ) {
+      throw Object.assign(
+        new Error("A local endpoint change is already in progress."),
+        { statusCode: 409 },
+      );
+    }
+    const pending = getPendingLocalCredentialRotation(state);
+    if (!pending || !tokenMatches(body?.rotationId, pending.rotationId)) {
+      throw new Error("Stage a fresh local client credential before activating it.");
+    }
+
+    state.localCredentialRotationPending = null;
+    state.localCredentialRotationInFlight = true;
+    try {
+      const result = await state.services.activateLocalClientCredentialRotation({
+        target: pending.target,
+        clientCredential: body.clientCredential,
+        tokenSha256: pending.tokenSha256,
+      });
+      sendJson(response, 200, createSafeLocalActivationResult(result));
+    } finally {
+      state.localCredentialRotationInFlight = false;
+    }
+    return;
+  }
+
   if (path === "/api/local/codex/login") {
     requireLiveLocalAction(state, "Local Codex sign-in");
     enforceRateLimit(state, path);
-    if (state.codexLoginStartInFlight) {
+    if (
+      state.codexLoginStartInFlight ||
+      state.localInstallInFlight ||
+      state.localCredentialRotationInFlight ||
+      getPendingLocalCredentialRotation(state)
+    ) {
       throw Object.assign(
-        new Error("A local Codex sign-in start is already in progress."),
+        new Error("A local endpoint change is already in progress."),
         { statusCode: 409 },
       );
     }
 
     state.codexLoginStartInFlight = true;
+    let finishStart;
+    const startPromise = new Promise((resolvePromise) => {
+      finishStart = resolvePromise;
+    });
+    state.codexLoginStartPromise = startPromise;
+    let releaseChangeLock;
+    let lockTransferred = false;
     try {
-      const installDirectory = await state.services.resolveLocalInstallRoot({
-        target: "codex-chatgpt",
-      });
-      const { dockerHost, projectName } =
-        await state.services.attestLocalCodexInstallation({
-          installDirectory,
-        });
-
       const previous = state.codexLogin;
       if (previous?.status === "pending") {
         state.codexLogin = null;
@@ -630,26 +795,61 @@ async function handleApi(request, response, path, state) {
           // A fresh attempt intentionally supersedes the old device-code login.
         }
       }
+      if (state.closing) {
+        throw Object.assign(new Error("The local wizard is closing."), {
+          statusCode: 409,
+        });
+      }
+
+      releaseChangeLock = await state.services.acquireLocalEndpointChangeLock({
+        target: "codex-chatgpt",
+      });
+      if (state.closing) {
+        throw Object.assign(new Error("The local wizard is closing."), {
+          statusCode: 409,
+        });
+      }
+      const installDirectory = await state.services.resolveLocalInstallRoot({
+        target: "codex-chatgpt",
+      });
+      const { dockerHost, projectName } =
+        await state.services.attestLocalCodexInstallation({
+          installDirectory,
+        });
 
       const attempt = await state.services.startCodexDeviceLogin({
         installDirectory,
         dockerHost,
         projectName,
       });
+      if (state.closing) {
+        attempt.cancel();
+        try {
+          await attempt.completion;
+        } catch {
+          // Shutdown intentionally cancels a helper that finished starting late.
+        }
+        throw Object.assign(new Error("The local wizard is closing."), {
+          statusCode: 409,
+        });
+      }
       const login = {
         cancel: attempt.cancel,
-        completion: attempt.completion,
+        completion: null,
         error: null,
         status: "pending",
       };
       state.codexLogin = login;
-      void (async () => {
+      login.completion = (async () => {
         try {
-          await login.completion;
+          await attempt.completion;
           if (state.codexLogin !== login || state.closing) {
             return;
           }
-          await state.services.restartLocalCodex({ installDirectory });
+          await state.services.restartLocalCodex(
+            { installDirectory },
+            { changeLockHeld: true },
+          );
           if (state.codexLogin === login && !state.closing) {
             login.status = "success";
           }
@@ -658,14 +858,24 @@ async function handleApi(request, response, path, state) {
             login.status = "error";
             login.error = safeErrorMessage(error);
           }
+        } finally {
+          await releaseChangeLock();
         }
       })();
+      lockTransferred = true;
       sendJson(response, 200, {
         verificationUrl: attempt.verificationUrl,
         userCode: attempt.userCode,
       });
     } finally {
+      if (!lockTransferred && releaseChangeLock) {
+        await releaseChangeLock();
+      }
       state.codexLoginStartInFlight = false;
+      finishStart();
+      if (state.codexLoginStartPromise === startPromise) {
+        state.codexLoginStartPromise = null;
+      }
     }
     return;
   }
@@ -877,8 +1087,11 @@ export async function startWizardServer({
     oauthLoginStartPromise: null,
     localPlan: null,
     localInstallInFlight: false,
+    localCredentialRotationInFlight: false,
+    localCredentialRotationPending: null,
     codexLogin: null,
     codexLoginStartInFlight: false,
+    codexLoginStartPromise: null,
     rateLimits: new Map(),
     previewMode: previewMode === true,
     oauthShutdownWaitMs,
@@ -915,6 +1128,14 @@ export async function startWizardServer({
       const codexLogin = state.codexLogin;
       state.codexLogin = null;
       codexLogin?.cancel();
+      await waitForBoundedResult(
+        state.codexLoginStartPromise,
+        state.oauthShutdownWaitMs,
+      );
+      await waitForBoundedResult(
+        codexLogin?.completion,
+        state.oauthShutdownWaitMs,
+      );
       state.connection?.close();
       state.connection = null;
       await waitForBoundedResult(

--- a/test/documentation.test.js
+++ b/test/documentation.test.js
@@ -74,6 +74,28 @@ test("README keeps every local install path and layman diagrams visible", async 
   }
 });
 
+test("local endpoint guides document safe standalone client credential rotation", async () => {
+  const [readme, npmReadme, localGuide] = await Promise.all([
+    readFile("README.md", "utf8"),
+    readFile("npm/README.md", "utf8"),
+    readFile("docs/local-endpoints.md", "utf8"),
+  ]);
+
+  for (const guide of [readme, npmReadme]) {
+    assert.match(guide, /\*\*Rotate client credential\*\*/u);
+    assert.match(guide, /preserves the upstream Platform API key/u);
+    assert.match(
+      guide,
+      /targets\s+only the exact managed service for shutdown and reports whether that stopped\s+state could be verified/u,
+    );
+  }
+
+  assert.match(localGuide, /previous capability remains active/u);
+  assert.match(localGuide, /authenticated Codex WebSocket handshake/u);
+  assert.match(localGuide, /preserves the upstream Platform API key/u);
+  assert.match(localGuide, /restores and verifies the previous capability/u);
+});
+
 test("beginner documentation states the critical safety and product limits", async () => {
   const files = await Promise.all(
     [

--- a/test/documentation.test.js
+++ b/test/documentation.test.js
@@ -86,14 +86,21 @@ test("local endpoint guides document safe standalone client credential rotation"
     assert.match(guide, /preserves the upstream Platform API key/u);
     assert.match(
       guide,
-      /targets\s+only the exact managed service for shutdown and reports whether that stopped\s+state could be verified/u,
+      /targets\s+only\s+the\s+exact\s+managed\s+service\s+for\s+shutdown\s+and\s+reports\s+whether\s+that\s+stopped\s+state\s+could\s+be\s+verified/u,
     );
   }
 
   assert.match(localGuide, /previous capability remains active/u);
   assert.match(localGuide, /authenticated Codex WebSocket handshake/u);
   assert.match(localGuide, /preserves the upstream Platform API key/u);
-  assert.match(localGuide, /restores and verifies the previous capability/u);
+  assert.match(
+    localGuide,
+    /restores\s+the\s+previous\s+verifier\s+and\s+re-attests\s+its\s+health\s+and\s+loopback\s+publication/u,
+  );
+  assert.match(
+    localGuide,
+    /does\s+not\s+retain\s+the\s+previous\s+raw\s+client\s+credential/u,
+  );
 });
 
 test("beginner documentation states the critical safety and product limits", async () => {

--- a/test/local-endpoints.test.js
+++ b/test/local-endpoints.test.js
@@ -242,6 +242,9 @@ test("Codex image and config pin the official App Server and ChatGPT login", () 
 
   assert.match(dockerfile, /@openai\/codex@0\.147\.0/);
   assert.match(dockerfile, /--ignore-scripts/);
+  assert.match(dockerfile, /apt-get update/);
+  assert.match(dockerfile, /apt-get install --no-install-recommends -y ca-certificates/);
+  assert.match(dockerfile, /rm -rf \/var\/lib\/apt\/lists\/\*/);
   assert.match(dockerfile, /COPY --chown=node:node config\.toml/);
   assert.match(
     dockerfile,

--- a/test/local-installer.test.js
+++ b/test/local-installer.test.js
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { EventEmitter } from "node:events";
+import * as nodeFileSystem from "node:fs/promises";
 import {
   lstat,
   mkdir,
@@ -8,6 +11,7 @@ import {
   rm,
   stat,
   symlink,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -16,11 +20,15 @@ import test from "node:test";
 
 import { createLocalDeploymentPlan } from "../src/domain/local-endpoints.js";
 import {
+  acquireLocalEndpointChangeLock,
+  activateLocalClientCredentialRotation,
   attestLocalCodexInstallation,
   getLocalDockerStatus,
   installLocalEndpoint,
   restartLocalCodex,
+  prepareLocalClientCredentialRotation,
   resolveLocalInstallRoot,
+  verifyCodexWebSocketCapability,
 } from "../src/services/local-installer.js";
 
 const platformKey = `sk-${"p".repeat(48)}`;
@@ -42,8 +50,10 @@ function createRunner({
   foreignOwnership = false,
   publisherHost = "127.0.0.1",
   publishedPort = 12435,
+  replaceFailureCount = 0,
 } = {}) {
   const calls = [];
+  let replacementFailures = replaceFailureCount;
   const runner = async (spec) => {
     calls.push(spec);
     const args = spec.args.join(" ");
@@ -84,12 +94,21 @@ function createRunner({
         code: 0,
       };
     }
+    if (args.includes("up -d --wait") && args.includes("--force-recreate")) {
+      if (replacementFailures > 0) {
+        replacementFailures -= 1;
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    }
     if (args.includes("rm --force --stop")) {
       return { stdout: "", stderr: "", code: cleanupCode };
     }
     if (args.includes("ps --all --services")) {
       return {
-        stdout: cleanupStillRunning ? "gateway\n" : "",
+        stdout: cleanupStillRunning
+          ? `${args.endsWith(" codex") ? "codex" : "gateway"}\n`
+          : "",
         stderr: "",
         code: 0,
       };
@@ -130,6 +149,118 @@ function createFetch() {
   fetchImpl.calls = calls;
   return fetchImpl;
 }
+
+function createCodexCapabilityVerifier({ error } = {}) {
+  const calls = [];
+  const verify = async (input) => {
+    calls.push(input);
+    if (error) {
+      throw error;
+    }
+  };
+  verify.calls = calls;
+  return verify;
+}
+
+test("Codex capability verification performs an authenticated WebSocket upgrade", async () => {
+  const socket = new EventEmitter();
+  let connectionOptions;
+  let request;
+  let destroyed = false;
+  socket.setTimeout = () => {};
+  socket.destroy = () => {
+    destroyed = true;
+  };
+  socket.write = (value) => {
+    request = value;
+    const websocketKey = /^Sec-WebSocket-Key: (.+)$/mu.exec(value)?.[1];
+    const accept = createHash("sha1")
+      .update(`${websocketKey}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+      .digest("base64");
+    queueMicrotask(() => {
+      socket.emit(
+        "data",
+        Buffer.from(
+          [
+            "HTTP/1.1 101 Switching Protocols",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            `Sec-WebSocket-Accept: ${accept}`,
+            "",
+            "",
+          ].join("\r\n"),
+          "latin1",
+        ),
+      );
+    });
+  };
+
+  await verifyCodexWebSocketCapability(
+    { port: 14500, clientCredential: capability },
+    {
+      connectSocket(options, onConnect) {
+        connectionOptions = options;
+        queueMicrotask(onConnect);
+        return socket;
+      },
+      randomBytes: () => Buffer.alloc(16, 5),
+    },
+  );
+
+  assert.deepEqual(connectionOptions, { host: "127.0.0.1", port: 14500 });
+  assert.match(request, new RegExp(`^Authorization: Bearer ${capability}$`, "mu"));
+  assert.equal(destroyed, true);
+});
+
+test("Codex capability verification rejects non-RFC WebSocket handshakes", async (t) => {
+  for (const [name, statusLine, upgradeHeader] of [
+    ["HTTP 1.0", "HTTP/1.0 101 Switching Protocols", "Upgrade: websocket"],
+    ["whitespace before colon", "HTTP/1.1 101 Switching Protocols", "Upgrade : websocket"],
+  ]) {
+    await t.test(name, async () => {
+      const socket = new EventEmitter();
+      socket.setTimeout = () => {};
+      socket.destroy = () => {};
+      socket.write = (value) => {
+        const websocketKey = /^Sec-WebSocket-Key: (.+)$/mu.exec(value)?.[1];
+        const accept = createHash("sha1")
+          .update(`${websocketKey}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+          .digest("base64");
+        queueMicrotask(() => {
+          socket.emit(
+            "data",
+            Buffer.from(
+              [
+                statusLine,
+                upgradeHeader,
+                "Connection: Upgrade",
+                `Sec-WebSocket-Accept: ${accept}`,
+                "",
+                "",
+              ].join("\r\n"),
+              "latin1",
+            ),
+          );
+        });
+      };
+
+      await assert.rejects(
+        () =>
+          verifyCodexWebSocketCapability(
+            { port: 14500, clientCredential: capability },
+            {
+              connectSocket(_options, onConnect) {
+                queueMicrotask(onConnect);
+                return socket;
+              },
+              randomBytes: () => Buffer.alloc(16, 5),
+            },
+          ),
+        /Codex client credential could not be verified/u,
+      );
+    });
+  }
+});
 
 test("local Docker discovery is read-only and sanitizes versions", async () => {
   const runProcess = createRunner();
@@ -200,6 +331,7 @@ test("Codex credential reload attests, restarts, and waits for only the managed 
       randomBytes: () => Buffer.alloc(32, 7),
       isPortAvailable: async () => true,
       fetchImpl: createFetch(),
+      verifyCodexCapability: createCodexCapabilityVerifier(),
     },
   );
   const installDirectory = await resolveLocalInstallRoot({
@@ -232,6 +364,1059 @@ test("Codex credential reload attests, restarts, and waits for only the managed 
     () => restartLocalCodex({ installDirectory: "/tmp/not-managed" }, { runProcess }),
     /invalid/i,
   );
+});
+
+test("credential rotation recreates and verifies the managed Codex service before returning a fresh capability", async (t) => {
+  const home = await createTestHome(t);
+  const runProcess = createRunner({ publishedPort: 14500 });
+  const fetchImpl = createFetch();
+  const verifyCodexCapability = createCodexCapabilityVerifier();
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const randomValues = [
+    Buffer.alloc(32, 1),
+    Buffer.alloc(32, 7),
+    Buffer.alloc(32, 9),
+  ];
+  const randomBytes = () => randomValues.shift();
+  const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port: 14500 });
+  const installed = await installLocalEndpoint(
+    { plan, confirmed: true },
+    {
+      env,
+      runProcess,
+      randomBytes,
+      isPortAvailable: async () => true,
+      fetchImpl,
+      verifyCodexCapability,
+    },
+  );
+  const installDirectory = await resolveLocalInstallRoot({
+    target: "codex-chatgpt",
+    env,
+  });
+  const composePath = join(installDirectory, "docker-compose.yml");
+  const originalCompose = await readFile(composePath, "utf8");
+  runProcess.calls.length = 0;
+  fetchImpl.calls.length = 0;
+  verifyCodexCapability.calls.length = 0;
+
+  const staged = await prepareLocalClientCredentialRotation(
+    { target: "codex-chatgpt" },
+    { env, runProcess, randomBytes, fetchImpl },
+  );
+  assert.equal(await readFile(composePath, "utf8"), originalCompose);
+  const activated = await activateLocalClientCredentialRotation(
+    staged,
+    { env, runProcess, fetchImpl, verifyCodexCapability },
+  );
+  const rotated = { ...staged, ...activated };
+
+  assert.equal(rotated.target, "codex-chatgpt");
+  assert.equal(rotated.endpoint, "ws://127.0.0.1:14500");
+  assert.equal(rotated.protocol, "codex-app-server-json-rpc");
+  assert.equal(rotated.credentialShownOnce, true);
+  assert.notEqual(rotated.clientCredential, installed.clientCredential);
+  assert.deepEqual(rotated.models, []);
+  assert.equal(rotated.deploymentMode, "updated");
+  assert.equal(rotated.experimental, true);
+  assert.equal(rotated.browserClients, false);
+  assert.match(
+    await readFile(composePath, "utf8"),
+    /--ws-token-sha256\n\s+- [a-f0-9]{64}/u,
+  );
+  assert.notEqual(await readFile(composePath, "utf8"), originalCompose);
+  assert.ok(
+    runProcess.calls.some(({ args }) =>
+      args.join(" ").includes("config --quiet"),
+    ),
+  );
+  assert.ok(
+    runProcess.calls.some(({ args }) =>
+      args
+        .join(" ")
+        .includes("up -d --wait --wait-timeout 90 --force-recreate --no-deps codex"),
+    ),
+  );
+  assert.equal(
+    runProcess.calls.some(({ args }) => args.includes("credential-seed")),
+    false,
+  );
+  assert.equal(fetchImpl.calls.length, 1);
+  assert.equal(fetchImpl.calls[0].options.headers, undefined);
+  assert.deepEqual(verifyCodexCapability.calls, [
+    { port: 14500, clientCredential: rotated.clientCredential },
+  ]);
+});
+
+test("Codex credential rotation rolls back when the fresh WebSocket capability is rejected", async (t) => {
+  const home = await createTestHome(t);
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const runProcess = createRunner({ publishedPort: 14500 });
+  const randomValues = [
+    Buffer.alloc(32, 3),
+    Buffer.alloc(32, 7),
+    Buffer.alloc(32, 9),
+  ];
+  const randomBytes = () => randomValues.shift();
+  const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port: 14500 });
+  await installLocalEndpoint(
+    { plan, confirmed: true },
+    {
+      env,
+      runProcess,
+      randomBytes,
+      isPortAvailable: async () => true,
+      fetchImpl: createFetch(),
+      verifyCodexCapability: createCodexCapabilityVerifier(),
+    },
+  );
+  const installDirectory = await resolveLocalInstallRoot({
+    target: "codex-chatgpt",
+    env,
+  });
+  const composePath = join(installDirectory, "docker-compose.yml");
+  const originalCompose = await readFile(composePath, "utf8");
+  const staged = await prepareLocalClientCredentialRotation(
+    { target: "codex-chatgpt" },
+    { env, runProcess, randomBytes },
+  );
+  runProcess.calls.length = 0;
+
+  await assert.rejects(
+    () =>
+      activateLocalClientCredentialRotation(staged, {
+        env,
+        runProcess,
+        fetchImpl: createFetch(),
+        verifyCodexCapability: createCodexCapabilityVerifier({
+          error: new Error("rejected capability"),
+        }),
+      }),
+    /previous credential remains active/u,
+  );
+
+  assert.equal(await readFile(composePath, "utf8"), originalCompose);
+  assert.equal(
+    runProcess.calls.filter(({ args }) => args.includes("--force-recreate")).length,
+    2,
+  );
+});
+
+test("credential rotation preserves the OpenAI upstream volume and verifies the fresh local credential", async (t) => {
+  const home = await createTestHome(t);
+  const runProcess = createRunner();
+  const fetchImpl = createFetch();
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const randomValues = [
+    Buffer.alloc(32, 2),
+    Buffer.alloc(32, 7),
+    Buffer.alloc(32, 9),
+  ];
+  const randomBytes = () => randomValues.shift();
+  const plan = createLocalDeploymentPlan({
+    target: "openai-api",
+    port: 12435,
+    allowedOrigins: ["http://localhost:3000"],
+  });
+  const installed = await installLocalEndpoint(
+    { plan, apiKey: platformKey, confirmed: true },
+    { env, runProcess, randomBytes, isPortAvailable: async () => true, fetchImpl },
+  );
+  runProcess.calls.length = 0;
+  fetchImpl.calls.length = 0;
+
+  const staged = await prepareLocalClientCredentialRotation(
+    { target: "openai-api" },
+    { env, runProcess, randomBytes, fetchImpl },
+  );
+  const activated = await activateLocalClientCredentialRotation(
+    staged,
+    { env, runProcess, fetchImpl },
+  );
+  const rotated = { ...staged, ...activated };
+
+  assert.equal(rotated.target, "openai-api");
+  assert.equal(rotated.endpoint, "http://127.0.0.1:12435/v1");
+  assert.notEqual(rotated.clientCredential, installed.clientCredential);
+  assert.deepEqual(rotated.models, ["gpt-5.6-terra"]);
+  assert.equal(rotated.deploymentMode, "updated");
+  assert.equal(rotated.experimental, false);
+  assert.equal(rotated.browserClients, true);
+  assert.equal(
+    runProcess.calls.some(({ args, input }) =>
+      args.includes("credential-seed") || input !== undefined,
+    ),
+    false,
+  );
+  const modelRequest = fetchImpl.calls.find(({ url }) =>
+    String(url).endsWith("/v1/models"),
+  );
+  assert.equal(
+    modelRequest.options.headers.Authorization,
+    `Bearer ${rotated.clientCredential}`,
+  );
+});
+
+test("credential rotation restores the prior verifier when service recreation fails", async (t) => {
+  const home = await createTestHome(t);
+  const runProcess = createRunner({
+    publishedPort: 14500,
+    replaceFailureCount: 1,
+  });
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const randomValues = [
+    Buffer.alloc(32, 3),
+    Buffer.alloc(32, 7),
+    Buffer.alloc(32, 9),
+  ];
+  const randomBytes = () => randomValues.shift();
+  const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port: 14500 });
+  await installLocalEndpoint(
+    { plan, confirmed: true },
+    {
+      env,
+      runProcess,
+      randomBytes,
+      isPortAvailable: async () => true,
+      fetchImpl: createFetch(),
+      verifyCodexCapability: createCodexCapabilityVerifier(),
+    },
+  );
+  const installDirectory = await resolveLocalInstallRoot({
+    target: "codex-chatgpt",
+    env,
+  });
+  const composePath = join(installDirectory, "docker-compose.yml");
+  const originalCompose = await readFile(composePath, "utf8");
+  runProcess.calls.length = 0;
+
+  await assert.rejects(
+    () =>
+      prepareLocalClientCredentialRotation(
+        { target: "codex-chatgpt" },
+        { env, runProcess, randomBytes, fetchImpl: createFetch() },
+      ).then((staged) =>
+        activateLocalClientCredentialRotation(staged, {
+          env,
+          runProcess,
+          fetchImpl: createFetch(),
+        }),
+      ),
+    /rotation failed safely/u,
+  );
+
+  assert.equal(await readFile(composePath, "utf8"), originalCompose);
+  assert.equal(
+    runProcess.calls.filter(({ args }) => args.includes("--force-recreate")).length,
+    2,
+  );
+});
+
+test("credential rotation removes only the exact service when replacement and rollback recreation both fail", async (t) => {
+  const home = await createTestHome(t);
+  const runProcess = createRunner({
+    publishedPort: 14500,
+    replaceFailureCount: 2,
+  });
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const randomValues = [
+    Buffer.alloc(32, 3),
+    Buffer.alloc(32, 7),
+    Buffer.alloc(32, 9),
+  ];
+  const randomBytes = () => randomValues.shift();
+  const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port: 14500 });
+  await installLocalEndpoint(
+    { plan, confirmed: true },
+    {
+      env,
+      runProcess,
+      randomBytes,
+      isPortAvailable: async () => true,
+      fetchImpl: createFetch(),
+      verifyCodexCapability: createCodexCapabilityVerifier(),
+    },
+  );
+  const installDirectory = await resolveLocalInstallRoot({
+    target: "codex-chatgpt",
+    env,
+  });
+  const composePath = join(installDirectory, "docker-compose.yml");
+  const originalCompose = await readFile(composePath, "utf8");
+  runProcess.calls.length = 0;
+
+  await assert.rejects(
+    () =>
+      prepareLocalClientCredentialRotation(
+        { target: "codex-chatgpt" },
+        { env, runProcess, randomBytes, fetchImpl: createFetch() },
+      ).then((staged) =>
+        activateLocalClientCredentialRotation(staged, {
+          env,
+          runProcess,
+          fetchImpl: createFetch(),
+        }),
+      ),
+    /local endpoint was stopped/u,
+  );
+
+  assert.equal(await readFile(composePath, "utf8"), originalCompose);
+  assert.equal(
+    runProcess.calls.filter(({ args }) => args.includes("--force-recreate")).length,
+    2,
+  );
+  const cleanup = runProcess.calls.find(({ args }) => args.includes("rm"));
+  const verification = runProcess.calls.find(
+    ({ args }) => args.includes("--all") && args.includes("--services"),
+  );
+  assert.deepEqual(cleanup.args.slice(-4), ["rm", "--force", "--stop", "codex"]);
+  assert.deepEqual(verification.args.slice(-4), [
+    "ps",
+    "--all",
+    "--services",
+    "codex",
+  ]);
+});
+
+test("credential rotation reports uncertainty when exact-service removal cannot be confirmed", async (t) => {
+  const home = await createTestHome(t);
+  const runProcess = createRunner({
+    cleanupStillRunning: true,
+    publishedPort: 14500,
+    replaceFailureCount: 2,
+  });
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const randomValues = [
+    Buffer.alloc(32, 3),
+    Buffer.alloc(32, 7),
+    Buffer.alloc(32, 9),
+  ];
+  const randomBytes = () => randomValues.shift();
+  const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port: 14500 });
+  await installLocalEndpoint(
+    { plan, confirmed: true },
+    {
+      env,
+      runProcess,
+      randomBytes,
+      isPortAvailable: async () => true,
+      fetchImpl: createFetch(),
+      verifyCodexCapability: createCodexCapabilityVerifier(),
+    },
+  );
+  runProcess.calls.length = 0;
+
+  await assert.rejects(
+    () =>
+      prepareLocalClientCredentialRotation(
+        { target: "codex-chatgpt" },
+        { env, runProcess, randomBytes, fetchImpl: createFetch() },
+      ).then((staged) =>
+        activateLocalClientCredentialRotation(staged, {
+          env,
+          runProcess,
+          fetchImpl: createFetch(),
+        }),
+      ),
+    /could not confirm that the failed credential rotation was stopped/u,
+  );
+
+  const cleanup = runProcess.calls.find(({ args }) => args.includes("rm"));
+  const verification = runProcess.calls.find(
+    ({ args }) => args.includes("--all") && args.includes("--services"),
+  );
+  assert.deepEqual(cleanup.args.slice(-4), ["rm", "--force", "--stop", "codex"]);
+  assert.deepEqual(verification.args.slice(-4), [
+    "ps",
+    "--all",
+    "--services",
+    "codex",
+  ]);
+});
+
+test("credential rotation rolls back when managed-file permission repair fails after rename", async (t) => {
+  const home = await createTestHome(t);
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const runProcess = createRunner({ publishedPort: 14500 });
+  const randomValues = [
+    Buffer.alloc(32, 3),
+    Buffer.alloc(32, 7),
+    Buffer.alloc(32, 9),
+  ];
+  const randomBytes = () => randomValues.shift();
+  const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port: 14500 });
+  await installLocalEndpoint(
+    { plan, confirmed: true },
+    {
+      env,
+      runProcess,
+      randomBytes,
+      isPortAvailable: async () => true,
+      fetchImpl: createFetch(),
+      verifyCodexCapability: createCodexCapabilityVerifier(),
+    },
+  );
+  const installDirectory = await resolveLocalInstallRoot({
+    target: "codex-chatgpt",
+    env,
+  });
+  const composePath = join(installDirectory, "docker-compose.yml");
+  const originalCompose = await readFile(composePath, "utf8");
+  const staged = await prepareLocalClientCredentialRotation(
+    { target: "codex-chatgpt" },
+    { env, runProcess, randomBytes },
+  );
+  runProcess.calls.length = 0;
+
+  let replacementRenamed = false;
+  let injectedFailure = false;
+  const fileSystem = {
+    ...nodeFileSystem,
+    async rename(source, destination) {
+      await nodeFileSystem.rename(source, destination);
+      if (destination === composePath && !injectedFailure) {
+        replacementRenamed = true;
+      }
+    },
+    async chmod(path, mode) {
+      if (path === composePath && replacementRenamed && !injectedFailure) {
+        injectedFailure = true;
+        throw new Error("injected post-rename chmod failure");
+      }
+      return nodeFileSystem.chmod(path, mode);
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      activateLocalClientCredentialRotation(staged, {
+        env,
+        fileSystem,
+        runProcess,
+        fetchImpl: createFetch(),
+      }),
+    /previous credential remains active/u,
+  );
+
+  assert.equal(injectedFailure, true);
+  assert.equal(await readFile(composePath, "utf8"), originalCompose);
+  assert.equal(
+    runProcess.calls.filter(({ args }) => args.includes("--force-recreate")).length,
+    1,
+  );
+});
+
+test("project lock prevents independent Relmio processes from installing during credential activation", async (t) => {
+  const home = await createTestHome(t);
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port: 14500 });
+  await installLocalEndpoint(
+    { plan, confirmed: true },
+    {
+      env,
+      runProcess: createRunner({ publishedPort: 14500 }),
+      randomBytes: () => Buffer.alloc(32, 7),
+      isPortAvailable: async () => true,
+      fetchImpl: createFetch(),
+      verifyCodexCapability: createCodexCapabilityVerifier(),
+      processId: 40_001,
+      isProcessAlive: () => true,
+    },
+  );
+  const staged = await prepareLocalClientCredentialRotation(
+    { target: "codex-chatgpt" },
+    {
+      env,
+      runProcess: createRunner({ publishedPort: 14500 }),
+      randomBytes: () => Buffer.alloc(32, 9),
+    },
+  );
+
+  let releaseActivation;
+  let notifyActivationStarted;
+  const activationStarted = new Promise((resolvePromise) => {
+    notifyActivationStarted = resolvePromise;
+  });
+  const activationGate = new Promise((resolvePromise) => {
+    releaseActivation = resolvePromise;
+  });
+  t.after(() => releaseActivation());
+  const baseRunner = createRunner({ publishedPort: 14500 });
+  let blocked = false;
+  const blockingRunner = async (spec) => {
+    if (!blocked && spec.args.includes("--force-recreate")) {
+      blocked = true;
+      notifyActivationStarted();
+      await activationGate;
+    }
+    return baseRunner(spec);
+  };
+
+  const activation = activateLocalClientCredentialRotation(staged, {
+    env,
+    runProcess: blockingRunner,
+    fetchImpl: createFetch(),
+    verifyCodexCapability: createCodexCapabilityVerifier(),
+    processId: 40_002,
+    isProcessAlive: () => true,
+  });
+  await activationStarted;
+
+  await assert.rejects(
+    () =>
+      installLocalEndpoint(
+        { plan, confirmed: true },
+        {
+          env,
+          runProcess: createRunner({ publishedPort: 14500 }),
+          randomBytes: () => Buffer.alloc(32, 11),
+          isPortAvailable: async () => true,
+          fetchImpl: createFetch(),
+          processId: 40_003,
+          isProcessAlive: () => true,
+        },
+      ),
+    /Another Relmio process is changing this local endpoint/u,
+  );
+
+  releaseActivation();
+  assert.equal((await activation).deploymentMode, "updated");
+});
+
+test("Codex sign-in project lock excludes independent installation, activation, and restart", async (t) => {
+  const home = await createTestHome(t);
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port: 14500 });
+  const runProcess = createRunner({ publishedPort: 14500 });
+  await installLocalEndpoint(
+    { plan, confirmed: true },
+    {
+      env,
+      runProcess,
+      randomBytes: () => Buffer.alloc(32, 7),
+      isPortAvailable: async () => true,
+      fetchImpl: createFetch(),
+      verifyCodexCapability: createCodexCapabilityVerifier(),
+      processId: 41_001,
+      isProcessAlive: () => true,
+    },
+  );
+  const staged = await prepareLocalClientCredentialRotation(
+    { target: "codex-chatgpt" },
+    {
+      env,
+      runProcess,
+      randomBytes: () => Buffer.alloc(32, 9),
+    },
+  );
+  const installDirectory = await resolveLocalInstallRoot({
+    target: "codex-chatgpt",
+    env,
+  });
+  const releaseLoginLock = await acquireLocalEndpointChangeLock(
+    { target: "codex-chatgpt" },
+    {
+      env,
+      processId: 41_002,
+      isProcessAlive: () => true,
+    },
+  );
+
+  const lockError = /Another Relmio process is changing this local endpoint/u;
+  await assert.rejects(
+    () =>
+      installLocalEndpoint(
+        { plan, confirmed: true },
+        {
+          env,
+          runProcess,
+          randomBytes: () => Buffer.alloc(32, 11),
+          isPortAvailable: async () => true,
+          fetchImpl: createFetch(),
+          processId: 41_003,
+          isProcessAlive: () => true,
+        },
+      ),
+    lockError,
+  );
+  await assert.rejects(
+    () =>
+      activateLocalClientCredentialRotation(staged, {
+        env,
+        runProcess,
+        fetchImpl: createFetch(),
+        processId: 41_004,
+        isProcessAlive: () => true,
+      }),
+    lockError,
+  );
+  await assert.rejects(
+    () =>
+      restartLocalCodex(
+        { installDirectory },
+        {
+          env,
+          runProcess,
+          processId: 41_005,
+          isProcessAlive: () => true,
+        },
+      ),
+    lockError,
+  );
+
+  await releaseLoginLock();
+  assert.equal(
+    (await activateLocalClientCredentialRotation(staged, {
+      env,
+      runProcess,
+      fetchImpl: createFetch(),
+      verifyCodexCapability: createCodexCapabilityVerifier(),
+      processId: 41_006,
+      isProcessAlive: () => true,
+    })).deploymentMode,
+    "updated",
+  );
+});
+
+test("only one independent process can reclaim the same stale project lock", async (t) => {
+  const home = await createTestHome(t);
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const lockPath = join(home, ".relmio-local-codex-chatgpt.lock");
+  const ownerPath = join(lockPath, "owner.json");
+  await mkdir(lockPath, { mode: 0o700 });
+  await writeFile(
+    ownerPath,
+    `${JSON.stringify({ processId: 39_999, ownerToken: "stale-owner" })}\n`,
+    { mode: 0o600 },
+  );
+
+  let ownerReads = 0;
+  let releaseOwnerReads;
+  const bothOwnersRead = new Promise((resolvePromise) => {
+    releaseOwnerReads = resolvePromise;
+  });
+  const fileSystem = {
+    ...nodeFileSystem,
+    async readFile(path, ...args) {
+      const contents = await nodeFileSystem.readFile(path, ...args);
+      if (path === ownerPath && ownerReads < 2) {
+        ownerReads += 1;
+        if (ownerReads === 2) {
+          releaseOwnerReads();
+        }
+        await bothOwnersRead;
+      }
+      return contents;
+    },
+  };
+  const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port: 14500 });
+  const createInstall = (processId) =>
+    installLocalEndpoint(
+      { plan, confirmed: true },
+      {
+        env,
+        fileSystem,
+        runProcess: createRunner({ publishedPort: 14500 }),
+        randomBytes: () => Buffer.alloc(32, processId % 255),
+        isPortAvailable: async () => true,
+        fetchImpl: createFetch(),
+        verifyCodexCapability: createCodexCapabilityVerifier(),
+        processId,
+        isProcessAlive: () => false,
+      },
+    );
+
+  const results = await Promise.allSettled([
+    createInstall(40_010),
+    createInstall(40_011),
+  ]);
+  assert.equal(results.filter(({ status }) => status === "fulfilled").length, 1);
+  const rejected = results.find(({ status }) => status === "rejected");
+  assert.match(
+    rejected.reason.message,
+    /Another Relmio process is changing this local endpoint/u,
+  );
+});
+
+test("a crashed stale-lock reclaimer can be recovered by a later process", async (t) => {
+  const home = await createTestHome(t);
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const lockPath = join(home, ".relmio-local-codex-chatgpt.lock");
+  const reclaimPath = join(lockPath, ".reclaim");
+  await mkdir(reclaimPath, { recursive: true, mode: 0o700 });
+  await writeFile(
+    join(lockPath, "owner.json"),
+    `${JSON.stringify({ processId: 39_990, ownerToken: "stale-owner" })}\n`,
+    { mode: 0o600 },
+  );
+  await writeFile(
+    join(reclaimPath, "owner.json"),
+    `${JSON.stringify({ processId: 39_991, ownerToken: "crashed-reclaimer" })}\n`,
+    { mode: 0o600 },
+  );
+  const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port: 14500 });
+  const result = await installLocalEndpoint(
+    { plan, confirmed: true },
+    {
+      env,
+      runProcess: createRunner({ publishedPort: 14500 }),
+      randomBytes: () => Buffer.alloc(32, 13),
+      isPortAvailable: async () => true,
+      fetchImpl: createFetch(),
+      verifyCodexCapability: createCodexCapabilityVerifier(),
+      processId: 41_010,
+      isProcessAlive: () => false,
+    },
+  );
+  assert.equal(result.deploymentMode, "installed");
+});
+
+test("detached stale-lock cleanup failures do not orphan the new canonical lock", async (t) => {
+  for (const branch of ["primary", "reclaim"]) {
+    await t.test(branch, async (subtest) => {
+      const home = await createTestHome(subtest);
+      const env = { RELMIO_HOME: join(home, ".relmio") };
+      const lockPath = join(home, ".relmio-local-codex-chatgpt.lock");
+      const reclaimPath = join(lockPath, ".reclaim");
+      await mkdir(branch === "reclaim" ? reclaimPath : lockPath, {
+        recursive: true,
+        mode: 0o700,
+      });
+      await writeFile(
+        join(lockPath, "owner.json"),
+        `${JSON.stringify({ processId: 39_970, ownerToken: "stale-owner" })}\n`,
+        { mode: 0o600 },
+      );
+      if (branch === "reclaim") {
+        await writeFile(
+          join(reclaimPath, "owner.json"),
+          `${JSON.stringify({ processId: 39_971, ownerToken: "stale-reclaimer" })}\n`,
+          { mode: 0o600 },
+        );
+      }
+
+      let injectedFailures = 0;
+      const fileSystem = {
+        ...nodeFileSystem,
+        async rm(path, options) {
+          const shouldFail = branch === "primary"
+            ? path.startsWith(`${lockPath}.stale-`)
+            : path.startsWith(`${reclaimPath}.stale-`);
+          if (shouldFail && injectedFailures === 0) {
+            injectedFailures += 1;
+            throw new Error("injected detached stale cleanup failure");
+          }
+          return nodeFileSystem.rm(path, options);
+        },
+      };
+
+      const releaseLock = await acquireLocalEndpointChangeLock(
+        { target: "codex-chatgpt" },
+        {
+          env,
+          fileSystem,
+          processId: branch === "primary" ? 41_011 : 41_012,
+          isProcessAlive: () => false,
+        },
+      );
+      assert.equal(injectedFailures, 1);
+      await releaseLock();
+      await assert.rejects(() => lstat(lockPath), /ENOENT/u);
+    });
+  }
+});
+
+test("stale primary locks recover from missing and truncated owner metadata", async (t) => {
+  for (const variant of ["missing", "truncated"]) {
+    await t.test(variant, async (subtest) => {
+      const home = await createTestHome(subtest);
+      const env = { RELMIO_HOME: join(home, ".relmio") };
+      const lockPath = join(home, ".relmio-local-codex-chatgpt.lock");
+      const ownerPath = join(lockPath, "owner.json");
+      await mkdir(lockPath, { mode: 0o700 });
+      if (variant === "truncated") {
+        await writeFile(ownerPath, '{"processId":', { mode: 0o600 });
+      }
+      const staleTime = new Date(Date.now() - 60_000);
+      await utimes(variant === "missing" ? lockPath : ownerPath, staleTime, staleTime);
+
+      const releaseLock = await acquireLocalEndpointChangeLock(
+        { target: "codex-chatgpt" },
+        {
+          env,
+          processId: variant === "missing" ? 41_020 : 41_021,
+          isProcessAlive: () => false,
+        },
+      );
+      await releaseLock();
+      await assert.rejects(() => lstat(lockPath), /ENOENT/u);
+    });
+  }
+});
+
+test("stale reclaim locks recover from missing and truncated owner metadata", async (t) => {
+  for (const variant of ["missing", "truncated"]) {
+    await t.test(variant, async (subtest) => {
+      const home = await createTestHome(subtest);
+      const env = { RELMIO_HOME: join(home, ".relmio") };
+      const lockPath = join(home, ".relmio-local-codex-chatgpt.lock");
+      const ownerPath = join(lockPath, "owner.json");
+      const reclaimPath = join(lockPath, ".reclaim");
+      const reclaimOwnerPath = join(reclaimPath, "owner.json");
+      await mkdir(reclaimPath, { recursive: true, mode: 0o700 });
+      await writeFile(
+        ownerPath,
+        `${JSON.stringify({ processId: 39_980, ownerToken: "stale-owner" })}\n`,
+        { mode: 0o600 },
+      );
+      if (variant === "truncated") {
+        await writeFile(reclaimOwnerPath, '{"processId":', { mode: 0o600 });
+      }
+      const staleTime = new Date(Date.now() - 60_000);
+      await utimes(
+        variant === "missing" ? reclaimPath : reclaimOwnerPath,
+        staleTime,
+        staleTime,
+      );
+
+      const releaseLock = await acquireLocalEndpointChangeLock(
+        { target: "codex-chatgpt" },
+        {
+          env,
+          processId: variant === "missing" ? 41_022 : 41_023,
+          isProcessAlive: () => false,
+        },
+      );
+      await releaseLock();
+      await assert.rejects(() => lstat(lockPath), /ENOENT/u);
+    });
+  }
+});
+
+test("a paused primary-lock creator cannot delete a successor lock after stale recovery", async (t) => {
+  const home = await createTestHome(t);
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const lockPath = join(home, ".relmio-local-codex-chatgpt.lock");
+  const ownerPath = join(lockPath, "owner.json");
+  let resumeOwnerWrite;
+  let notifyOwnerWrite;
+  const ownerWriteStarted = new Promise((resolvePromise) => {
+    notifyOwnerWrite = resolvePromise;
+  });
+  const ownerWriteGate = new Promise((resolvePromise) => {
+    resumeOwnerWrite = resolvePromise;
+  });
+  const pausedFileSystem = {
+    ...nodeFileSystem,
+    async writeFile(path, ...args) {
+      if (path === ownerPath) {
+        notifyOwnerWrite();
+        await ownerWriteGate;
+      }
+      return nodeFileSystem.writeFile(path, ...args);
+    },
+  };
+
+  const pausedAcquisition = acquireLocalEndpointChangeLock(
+    { target: "codex-chatgpt" },
+    {
+      env,
+      fileSystem: pausedFileSystem,
+      processId: 41_030,
+      isProcessAlive: () => false,
+    },
+  );
+  void pausedAcquisition.catch(() => {});
+  await ownerWriteStarted;
+  const staleTime = new Date(Date.now() - 60_000);
+  await utimes(lockPath, staleTime, staleTime);
+
+  const releaseSuccessor = await acquireLocalEndpointChangeLock(
+    { target: "codex-chatgpt" },
+    { env, processId: 41_031, isProcessAlive: () => false },
+  );
+  resumeOwnerWrite();
+  await assert.rejects(pausedAcquisition, /could not create its local project lock/u);
+  assert.equal(JSON.parse(await readFile(ownerPath, "utf8")).processId, 41_031);
+  await releaseSuccessor();
+});
+
+test("a paused reclaim creator cannot delete a successor lock after stale recovery", async (t) => {
+  const home = await createTestHome(t);
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const lockPath = join(home, ".relmio-local-codex-chatgpt.lock");
+  const ownerPath = join(lockPath, "owner.json");
+  const reclaimPath = join(lockPath, ".reclaim");
+  const reclaimOwnerPath = join(reclaimPath, "owner.json");
+  await mkdir(lockPath, { mode: 0o700 });
+  await writeFile(
+    ownerPath,
+    `${JSON.stringify({ processId: 39_970, ownerToken: "stale-owner" })}\n`,
+    { mode: 0o600 },
+  );
+  let resumeReclaimWrite;
+  let notifyReclaimWrite;
+  const reclaimWriteStarted = new Promise((resolvePromise) => {
+    notifyReclaimWrite = resolvePromise;
+  });
+  const reclaimWriteGate = new Promise((resolvePromise) => {
+    resumeReclaimWrite = resolvePromise;
+  });
+  const pausedFileSystem = {
+    ...nodeFileSystem,
+    async writeFile(path, ...args) {
+      if (path === reclaimOwnerPath) {
+        notifyReclaimWrite();
+        await reclaimWriteGate;
+      }
+      return nodeFileSystem.writeFile(path, ...args);
+    },
+  };
+
+  const pausedAcquisition = acquireLocalEndpointChangeLock(
+    { target: "codex-chatgpt" },
+    {
+      env,
+      fileSystem: pausedFileSystem,
+      processId: 41_032,
+      isProcessAlive: () => false,
+    },
+  );
+  void pausedAcquisition.catch(() => {});
+  await reclaimWriteStarted;
+  const staleTime = new Date(Date.now() - 60_000);
+  await utimes(reclaimPath, staleTime, staleTime);
+
+  const releaseSuccessor = await acquireLocalEndpointChangeLock(
+    { target: "codex-chatgpt" },
+    { env, processId: 41_033, isProcessAlive: () => false },
+  );
+  resumeReclaimWrite();
+  await assert.rejects(
+    pausedAcquisition,
+    /Another Relmio process is changing this local endpoint/u,
+  );
+  assert.equal(JSON.parse(await readFile(ownerPath, "utf8")).processId, 41_033);
+  await releaseSuccessor();
+});
+
+test("a post-open primary owner write cannot survive stale lock replacement", async (t) => {
+  const home = await createTestHome(t);
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const lockPath = join(home, ".relmio-local-codex-chatgpt.lock");
+  const ownerPath = join(lockPath, "owner.json");
+  let resumeOwnerWrite;
+  let notifyOwnerOpened;
+  const ownerOpened = new Promise((resolvePromise) => {
+    notifyOwnerOpened = resolvePromise;
+  });
+  const ownerWriteGate = new Promise((resolvePromise) => {
+    resumeOwnerWrite = resolvePromise;
+  });
+  const pausedFileSystem = {
+    ...nodeFileSystem,
+    async writeFile(path, contents, options) {
+      if (path !== ownerPath) {
+        return nodeFileSystem.writeFile(path, contents, options);
+      }
+      const handle = await nodeFileSystem.open(path, options.flag, options.mode);
+      notifyOwnerOpened();
+      await ownerWriteGate;
+      try {
+        await handle.writeFile(contents);
+      } finally {
+        await handle.close();
+      }
+    },
+  };
+
+  const pausedAcquisition = acquireLocalEndpointChangeLock(
+    { target: "codex-chatgpt" },
+    {
+      env,
+      fileSystem: pausedFileSystem,
+      processId: 41_034,
+      isProcessAlive: () => false,
+    },
+  );
+  void pausedAcquisition.catch(() => {});
+  await ownerOpened;
+  const staleTime = new Date(Date.now() - 60_000);
+  await utimes(ownerPath, staleTime, staleTime);
+
+  const releaseSuccessor = await acquireLocalEndpointChangeLock(
+    { target: "codex-chatgpt" },
+    { env, processId: 41_035, isProcessAlive: () => false },
+  );
+  resumeOwnerWrite();
+  await assert.rejects(pausedAcquisition, /could not create its local project lock/u);
+  assert.equal(JSON.parse(await readFile(ownerPath, "utf8")).processId, 41_035);
+  await releaseSuccessor();
+});
+
+test("a post-open reclaim owner write cannot survive stale lock replacement", async (t) => {
+  const home = await createTestHome(t);
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const lockPath = join(home, ".relmio-local-codex-chatgpt.lock");
+  const ownerPath = join(lockPath, "owner.json");
+  const reclaimPath = join(lockPath, ".reclaim");
+  const reclaimOwnerPath = join(reclaimPath, "owner.json");
+  await mkdir(lockPath, { mode: 0o700 });
+  await writeFile(
+    ownerPath,
+    `${JSON.stringify({ processId: 39_960, ownerToken: "stale-owner" })}\n`,
+    { mode: 0o600 },
+  );
+  let resumeReclaimWrite;
+  let notifyReclaimOpened;
+  const reclaimOpened = new Promise((resolvePromise) => {
+    notifyReclaimOpened = resolvePromise;
+  });
+  const reclaimWriteGate = new Promise((resolvePromise) => {
+    resumeReclaimWrite = resolvePromise;
+  });
+  const pausedFileSystem = {
+    ...nodeFileSystem,
+    async writeFile(path, contents, options) {
+      if (path !== reclaimOwnerPath) {
+        return nodeFileSystem.writeFile(path, contents, options);
+      }
+      const handle = await nodeFileSystem.open(path, options.flag, options.mode);
+      notifyReclaimOpened();
+      await reclaimWriteGate;
+      try {
+        await handle.writeFile(contents);
+      } finally {
+        await handle.close();
+      }
+    },
+  };
+
+  const pausedAcquisition = acquireLocalEndpointChangeLock(
+    { target: "codex-chatgpt" },
+    {
+      env,
+      fileSystem: pausedFileSystem,
+      processId: 41_036,
+      isProcessAlive: () => false,
+    },
+  );
+  void pausedAcquisition.catch(() => {});
+  await reclaimOpened;
+  const staleTime = new Date(Date.now() - 60_000);
+  await utimes(reclaimOwnerPath, staleTime, staleTime);
+
+  const releaseSuccessor = await acquireLocalEndpointChangeLock(
+    { target: "codex-chatgpt" },
+    { env, processId: 41_037, isProcessAlive: () => false },
+  );
+  resumeReclaimWrite();
+  await assert.rejects(
+    pausedAcquisition,
+    /Another Relmio process is changing this local endpoint/u,
+  );
+  assert.equal(JSON.parse(await readFile(ownerPath, "utf8")).processId, 41_037);
+  await releaseSuccessor();
 });
 
 test("install refuses missing confirmation before filesystem or Docker actions", async (t) => {
@@ -418,6 +1603,7 @@ test("OpenAI install keeps the Platform key only in a private seeded Docker volu
 test("Codex install has no Platform secret and returns native App Server details", async (t) => {
   const home = await createTestHome(t);
   const runProcess = createRunner({ publishedPort: 14500 });
+  const verifyCodexCapability = createCodexCapabilityVerifier();
   const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port: 14500 });
 
   const result = await installLocalEndpoint(
@@ -428,6 +1614,7 @@ test("Codex install has no Platform secret and returns native App Server details
       randomBytes: () => Buffer.alloc(32, 7),
       isPortAvailable: async () => true,
       fetchImpl: createFetch(),
+      verifyCodexCapability,
     },
   );
 
@@ -442,6 +1629,9 @@ test("Codex install has no Platform secret and returns native App Server details
     experimental: true,
     browserClients: false,
   });
+  assert.deepEqual(verifyCodexCapability.calls, [
+    { port: 14500, clientCredential: capability },
+  ]);
   const installRoot = await resolveLocalInstallRoot({
     target: "codex-chatgpt",
     env: { RELMIO_HOME: join(home, ".relmio") },
@@ -461,6 +1651,46 @@ test("Codex install has no Platform secret and returns native App Server details
   assert.match(requirements, /"relmio-workspace" = true/);
   assert.doesNotMatch(requirements, /allowed_sandbox_modes/);
   assert.equal((await stat(join(installRoot, "requirements.toml"))).mode & 0o777, 0o600);
+});
+
+test("Codex install removes only its exact service when capability authentication fails", async (t) => {
+  const home = await createTestHome(t);
+  const runProcess = createRunner({ publishedPort: 14500 });
+  const verifyCodexCapability = createCodexCapabilityVerifier({
+    error: new Error("The Codex client credential could not be verified."),
+  });
+  const plan = createLocalDeploymentPlan({ target: "codex-chatgpt", port: 14500 });
+
+  await assert.rejects(
+    () =>
+      installLocalEndpoint(
+        { plan, confirmed: true },
+        {
+          env: { RELMIO_HOME: join(home, ".relmio") },
+          runProcess,
+          randomBytes: () => Buffer.alloc(32, 7),
+          isPortAvailable: async () => true,
+          fetchImpl: createFetch(),
+          verifyCodexCapability,
+        },
+      ),
+    /Codex client credential could not be verified/u,
+  );
+
+  assert.deepEqual(verifyCodexCapability.calls, [
+    { port: 14500, clientCredential: capability },
+  ]);
+  const cleanup = runProcess.calls.find(({ args }) => args.includes("rm"));
+  const verification = runProcess.calls.find(
+    ({ args }) => args.includes("--all") && args.includes("--services"),
+  );
+  assert.deepEqual(cleanup.args.slice(-4), ["rm", "--force", "--stop", "codex"]);
+  assert.deepEqual(verification.args.slice(-4), [
+    "ps",
+    "--all",
+    "--services",
+    "codex",
+  ]);
 });
 
 test("installer refuses unmanaged and symlinked managed roots", async (t) => {

--- a/test/local-installer.test.js
+++ b/test/local-installer.test.js
@@ -492,7 +492,7 @@ test("Codex credential rotation rolls back when the fresh WebSocket capability i
           error: new Error("rejected capability"),
         }),
       }),
-    /previous credential remains active/u,
+    /previous verifier was restored and the managed endpoint was re-attested/u,
   );
 
   assert.equal(await readFile(composePath, "utf8"), originalCompose);
@@ -795,7 +795,7 @@ test("credential rotation rolls back when managed-file permission repair fails a
         runProcess,
         fetchImpl: createFetch(),
       }),
-    /previous credential remains active/u,
+    /previous verifier was restored and the managed endpoint was re-attested/u,
   );
 
   assert.equal(injectedFailure, true);

--- a/test/local-server.test.js
+++ b/test/local-server.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import { startWizardServer } from "../src/web/server.js";
@@ -11,7 +12,12 @@ const codexProjectName = `relmio-codex-chatgpt-${"01".repeat(16)}`;
 async function startLocalWizard(t, services, { previewMode = false } = {}) {
   const wizard = await startWizardServer({
     sessionToken,
-    services,
+    services: {
+      async acquireLocalEndpointChangeLock() {
+        return async () => {};
+      },
+      ...services,
+    },
     previewMode,
     uiFiles: {
       "/": "",
@@ -58,6 +64,8 @@ test("default wizard assets include the local endpoint flow", async (t) => {
   const page = await fetch(`${wizard.origin}/local`);
   assert.equal(page.status, 200);
   assert.match(page.headers.get("content-type") ?? "", /^text\/html/u);
+  const packageManifest = JSON.parse(await readFile("package.json", "utf8"));
+  assert.ok((await page.text()).includes(`v${packageManifest.version}`));
 
   const script = await fetch(`${wizard.origin}/local.js`);
   assert.equal(script.status, 200);
@@ -87,6 +95,22 @@ test("local Docker status exposes the native Windows support boundary", async (t
   assert.deepEqual(await response.json(), {
     dockerAvailable: false,
     unsupportedPlatform: true,
+  });
+});
+
+test("local project metadata exposes only the public GitHub star count and package version", async (t) => {
+  const wizard = await startLocalWizard(t, {
+    async getProjectMeta() {
+      return { stars: 28, version: "untrusted", credential: "must-not-leak" };
+    },
+  });
+  const response = await api(wizard, "/api/local/project-meta");
+  assert.equal(response.status, 200);
+  const text = await response.text();
+  assert.equal(text.includes("must-not-leak"), false);
+  assert.deepEqual(JSON.parse(text), {
+    stars: 28,
+    version: JSON.parse(await readFile("package.json", "utf8")).version,
   });
 });
 
@@ -198,10 +222,124 @@ test("local Docker status, planning, and installation expose only safe fields", 
   assert.match((await replay.json()).error, /fresh local endpoint plan/iu);
 });
 
+test("local credential rotation is setup-token protected, live-only, rate-limited, and redacts upstream credentials", async (t) => {
+  const prepareCalls = [];
+  const activationCalls = [];
+  const wizard = await startLocalWizard(t, {
+    async prepareLocalClientCredentialRotation(input) {
+      prepareCalls.push(input);
+      return {
+        target: "codex-chatgpt",
+        endpoint: "ws://127.0.0.1:14500",
+        protocol: "codex-app-server-json-rpc",
+        clientCredential: "fresh-local-capability-shown-once",
+        credentialShownOnce: true,
+        models: [],
+        tokenSha256: "a".repeat(64),
+        deploymentMode: "staged",
+        experimental: true,
+        browserClients: false,
+        upstreamChatGptCredential: "must-not-be-returned",
+      };
+    },
+    async activateLocalClientCredentialRotation(input) {
+      activationCalls.push(input);
+      return {
+        target: input.target,
+        endpoint: "ws://127.0.0.1:14500",
+        protocol: "codex-app-server-json-rpc",
+        models: [],
+        deploymentMode: "updated",
+        experimental: true,
+        browserClients: false,
+        upstreamChatGptCredential: "must-not-be-returned",
+      };
+    },
+  });
+
+  const first = await postJson(wizard, "/api/local/client-credential/rotate", {
+    target: "codex-chatgpt",
+  });
+  assert.equal(first.status, 200);
+  const firstText = await first.text();
+  assert.equal(firstText.includes("must-not-be-returned"), false);
+  const firstBody = JSON.parse(firstText);
+  assert.deepEqual(firstBody, {
+    target: "codex-chatgpt",
+    endpoint: "ws://127.0.0.1:14500",
+    protocol: "codex-app-server-json-rpc",
+    clientCredential: "fresh-local-capability-shown-once",
+    credentialShownOnce: true,
+    models: [],
+    deploymentMode: "staged",
+    experimental: true,
+    browserClients: false,
+    rotationId: firstBody.rotationId,
+  });
+  assert.equal(typeof firstBody.rotationId, "string");
+  assert.equal(firstText.includes("tokenSha256"), false);
+  assert.deepEqual(prepareCalls, [{ target: "codex-chatgpt" }]);
+
+  const firstActivation = await postJson(
+    wizard,
+    "/api/local/client-credential/activate",
+    {
+      rotationId: firstBody.rotationId,
+      clientCredential: firstBody.clientCredential,
+    },
+  );
+  assert.equal(firstActivation.status, 200);
+  const activationText = await firstActivation.text();
+  assert.equal(activationText.includes("must-not-be-returned"), false);
+  assert.equal(activationText.includes("fresh-local-capability"), false);
+
+  for (let attempt = 0; attempt < 9; attempt += 1) {
+    const response = await postJson(
+      wizard,
+      "/api/local/client-credential/rotate",
+      { target: "codex-chatgpt" },
+    );
+    assert.equal(response.status, 200);
+    const staged = await response.json();
+    const activated = await postJson(
+      wizard,
+      "/api/local/client-credential/activate",
+      {
+        rotationId: staged.rotationId,
+        clientCredential: staged.clientCredential,
+      },
+    );
+    assert.equal(activated.status, 200);
+  }
+  const limited = await postJson(wizard, "/api/local/client-credential/rotate", {
+    target: "codex-chatgpt",
+  });
+  assert.equal(limited.status, 429);
+  assert.match((await limited.json()).error, /too many attempts/iu);
+  assert.equal(prepareCalls.length, 10);
+  assert.equal(activationCalls.length, 10);
+
+  const preview = await startLocalWizard(
+    t,
+    {
+      async prepareLocalClientCredentialRotation() {
+        throw new Error("should not run");
+      },
+    },
+    { previewMode: true },
+  );
+  const disabled = await postJson(preview, "/api/local/client-credential/rotate", {
+    target: "codex-chatgpt",
+  });
+  assert.equal(disabled.status, 403);
+  assert.match((await disabled.json()).error, /disabled in sanitized preview mode/iu);
+});
+
 test("local installation rejects concurrent attempts and releases its lock after failure", async (t) => {
   let releaseFirstInstall;
   let notifyFirstInstallStarted;
   let installCalls = 0;
+  let rotationCalls = 0;
   const firstInstallStarted = new Promise((resolve) => {
     notifyFirstInstallStarted = resolve;
   });
@@ -229,6 +367,10 @@ test("local installation rejects concurrent attempts and releases its lock after
         experimental: plan.experimental,
         browserClients: plan.browserClients,
       };
+    },
+    async prepareLocalClientCredentialRotation() {
+      rotationCalls += 1;
+      throw new Error("rotation should remain locked");
     },
   });
 
@@ -258,6 +400,18 @@ test("local installation rejects concurrent attempts and releases its lock after
   assert.match((await concurrent.json()).error, /already in progress/iu);
   assert.equal(installCalls, 1);
 
+  const concurrentRotation = await postJson(
+    wizard,
+    "/api/local/client-credential/rotate",
+    { target: "openai-api" },
+  );
+  assert.equal(concurrentRotation.status, 409);
+  assert.match(
+    (await concurrentRotation.json()).error,
+    /already in progress/iu,
+  );
+  assert.equal(rotationCalls, 0);
+
   releaseFirstInstall();
   assert.equal((await firstInstall).status, 400);
 
@@ -268,6 +422,107 @@ test("local installation rejects concurrent attempts and releases its lock after
   });
   assert.equal(retried.status, 200);
   assert.equal(installCalls, 2);
+});
+
+test("credential rotation blocks installation until the managed service change completes", async (t) => {
+  let releaseRotation;
+  let notifyRotationStarted;
+  let installCalls = 0;
+  const rotationStarted = new Promise((resolve) => {
+    notifyRotationStarted = resolve;
+  });
+  const rotationGate = new Promise((resolve) => {
+    releaseRotation = resolve;
+  });
+  t.after(() => releaseRotation());
+
+  const wizard = await startLocalWizard(t, {
+    async prepareLocalClientCredentialRotation() {
+      notifyRotationStarted();
+      await rotationGate;
+      return {
+        target: "codex-chatgpt",
+        endpoint: "ws://127.0.0.1:14500",
+        protocol: "codex-app-server-json-rpc",
+        clientCredential,
+        tokenSha256: "b".repeat(64),
+        credentialShownOnce: true,
+        models: [],
+        deploymentMode: "staged",
+        experimental: true,
+        browserClients: false,
+      };
+    },
+    async activateLocalClientCredentialRotation({ target }) {
+      return {
+        target,
+        endpoint: "ws://127.0.0.1:14500",
+        protocol: "codex-app-server-json-rpc",
+        models: [],
+        deploymentMode: "updated",
+        experimental: true,
+        browserClients: false,
+      };
+    },
+    async installLocalEndpoint({ plan }) {
+      installCalls += 1;
+      return {
+        target: plan.target,
+        endpoint: plan.endpoint,
+        protocol: plan.protocol,
+        clientCredential,
+        credentialShownOnce: true,
+        models: [],
+        deploymentMode: "updated",
+        experimental: plan.experimental,
+        browserClients: plan.browserClients,
+      };
+    },
+  });
+
+  const rotation = postJson(
+    wizard,
+    "/api/local/client-credential/rotate",
+    { target: "codex-chatgpt" },
+  );
+  await rotationStarted;
+
+  const plan = await createPlan(wizard, {
+    target: "codex-chatgpt",
+    port: 14500,
+    allowedOrigins: [],
+  });
+  const concurrentInstall = await postJson(wizard, "/api/local/install", {
+    planId: plan.planId,
+    confirmed: true,
+  });
+  assert.equal(concurrentInstall.status, 409);
+  assert.match(
+    (await concurrentInstall.json()).error,
+    /already in progress/iu,
+  );
+  assert.equal(installCalls, 0);
+
+  releaseRotation();
+  const stagedResponse = await rotation;
+  assert.equal(stagedResponse.status, 200);
+  const staged = await stagedResponse.json();
+  const activation = await postJson(
+    wizard,
+    "/api/local/client-credential/activate",
+    {
+      rotationId: staged.rotationId,
+      clientCredential: staged.clientCredential,
+    },
+  );
+  assert.equal(activation.status, 200);
+
+  const retriedInstall = await postJson(wizard, "/api/local/install", {
+    planId: plan.planId,
+    confirmed: true,
+  });
+  assert.equal(retriedInstall.status, 200);
+  assert.equal(installCalls, 1);
 });
 
 test("a local plan is consumed before a failed install and errors redact secrets and paths", async (t) => {
@@ -354,8 +609,8 @@ test("Codex device-code sign-in requires installation and restarts only its loca
         },
       };
     },
-    async restartLocalCodex(input) {
-      restartInput = input;
+    async restartLocalCodex(input, dependencies) {
+      restartInput = { input, dependencies };
     },
   });
 
@@ -411,7 +666,10 @@ test("Codex device-code sign-in requires installation and restarts only its loca
     await new Promise((resolve) => setImmediate(resolve));
   }
   assert.deepEqual(restartInput, {
-    installDirectory: "/Users/fixture/.relmio/local/codex-chatgpt",
+    input: {
+      installDirectory: "/Users/fixture/.relmio/local/codex-chatgpt",
+    },
+    dependencies: { changeLockHeld: true },
   });
   const completed = await api(
     wizard,
@@ -419,6 +677,75 @@ test("Codex device-code sign-in requires installation and restarts only its loca
   );
   assert.deepEqual(await completed.json(), { status: "success" });
   assert.equal(cancelCalls, 0);
+});
+
+test("pending Codex sign-in blocks installation and credential rotation in the same wizard", async (t) => {
+  let finishLogin;
+  let releases = 0;
+  let installCalls = 0;
+  let rotationCalls = 0;
+  const completion = new Promise((resolvePromise) => {
+    finishLogin = resolvePromise;
+  });
+  const wizard = await startLocalWizard(t, {
+    async acquireLocalEndpointChangeLock() {
+      return async () => {
+        releases += 1;
+      };
+    },
+    resolveLocalInstallRoot() {
+      return "/Users/fixture/.relmio/local/codex-chatgpt";
+    },
+    async attestLocalCodexInstallation() {
+      return {
+        dockerHost: "unix:///Users/fixture/.docker/run/docker.sock",
+        projectName: codexProjectName,
+      };
+    },
+    async startCodexDeviceLogin() {
+      return {
+        verificationUrl: "https://auth.openai.com/codex/device",
+        userCode: "LOCK-CODE",
+        completion,
+        cancel() {},
+      };
+    },
+    async restartLocalCodex() {},
+    async installLocalEndpoint() {
+      installCalls += 1;
+    },
+    async prepareLocalClientCredentialRotation() {
+      rotationCalls += 1;
+    },
+  });
+  assert.equal(
+    (await postJson(wizard, "/api/local/codex/login", {})).status,
+    200,
+  );
+  const plan = await createPlan(wizard, {
+    target: "codex-chatgpt",
+    port: 14500,
+    allowedOrigins: [],
+  });
+  const install = await postJson(wizard, "/api/local/install", {
+    planId: plan.planId,
+    confirmed: true,
+  });
+  assert.equal(install.status, 409);
+  const rotation = await postJson(
+    wizard,
+    "/api/local/client-credential/rotate",
+    { target: "codex-chatgpt" },
+  );
+  assert.equal(rotation.status, 409);
+  assert.equal(installCalls, 0);
+  assert.equal(rotationCalls, 0);
+
+  finishLogin({ success: true });
+  for (let attempt = 0; attempt < 10 && releases === 0; attempt += 1) {
+    await new Promise((resolvePromise) => setImmediate(resolvePromise));
+  }
+  assert.equal(releases, 1);
 });
 
 test("a fresh wizard server can sign in an attested existing Codex installation", async (t) => {
@@ -528,6 +855,45 @@ test("Codex sign-in rejects a concurrent start and releases its start lock", asy
   });
   assert.equal(attestationCalls, 2);
   assert.equal(loginCalls, 1);
+});
+
+test("wizard shutdown waits for Codex sign-in startup and releases its project lock", async (t) => {
+  let releaseAcquisition;
+  let notifyAcquisitionStarted;
+  let lockReleases = 0;
+  let loginCalls = 0;
+  const acquisitionStarted = new Promise((resolvePromise) => {
+    notifyAcquisitionStarted = resolvePromise;
+  });
+  const acquisitionGate = new Promise((resolvePromise) => {
+    releaseAcquisition = resolvePromise;
+  });
+  const wizard = await startLocalWizard(t, {
+    async acquireLocalEndpointChangeLock() {
+      notifyAcquisitionStarted();
+      await acquisitionGate;
+      return async () => {
+        lockReleases += 1;
+      };
+    },
+    resolveLocalInstallRoot() {
+      return "/Users/fixture/.relmio/local/codex-chatgpt";
+    },
+    async attestLocalCodexInstallation() {
+      throw new Error("attestation must not run while closing");
+    },
+    async startCodexDeviceLogin() {
+      loginCalls += 1;
+    },
+  });
+  const login = postJson(wizard, "/api/local/codex/login", {});
+  await acquisitionStarted;
+  const closing = wizard.close();
+  releaseAcquisition();
+  await closing;
+  assert.equal((await login).status, 409);
+  assert.equal(lockReleases, 1);
+  assert.equal(loginCalls, 0);
 });
 
 test("Codex sign-in releases its start lock and preserves pending-login replacement", async (t) => {

--- a/test/local-ui.test.js
+++ b/test/local-ui.test.js
@@ -236,6 +236,11 @@ test("local wizard makes credential rotation explicit and replaces only DOM text
     html,
     /Relmio shows the replacement first, then activates and verifies\s+it/u,
   );
+  assert.match(
+    html,
+    /After successful activation, the previous credential no longer works/u,
+  );
+  assert.doesNotMatch(html, /permanently revokes the previous/u);
   assert.match(script, /api\("\/api\/local\/client-credential\/rotate"/u);
   assert.match(script, /api\("\/api\/local\/client-credential\/activate"/u);
   assert.match(script, /setBusy\(button, true, "Rotating credential…"\)/u);

--- a/test/local-ui.test.js
+++ b/test/local-ui.test.js
@@ -2,6 +2,28 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+function relativeLuminance(hex) {
+  const channels = hex
+    .match(/[\da-f]{2}/giu)
+    .map((channel) => Number.parseInt(channel, 16) / 255)
+    .map((channel) =>
+      channel <= 0.04045
+        ? channel / 12.92
+        : ((channel + 0.055) / 1.055) ** 2.4,
+    );
+  return (
+    0.2126 * channels[0] +
+    0.7152 * channels[1] +
+    0.0722 * channels[2]
+  );
+}
+
+function contrastRatio(first, second) {
+  const light = Math.max(relativeLuminance(first), relativeLuminance(second));
+  const dark = Math.min(relativeLuminance(first), relativeLuminance(second));
+  return (light + 0.05) / (dark + 0.05);
+}
+
 test("local endpoint wizard exposes an accessible four-step flow", async () => {
   const html = await readFile("src/ui/local.html", "utf8");
 
@@ -32,7 +54,42 @@ test("local endpoint wizard exposes an accessible four-step flow", async () => {
   assert.match(html, /id="device-code-link"[\s\S]*target="_blank"[\s\S]*rel="noopener noreferrer"/u);
   assert.doesNotMatch(html, /<script(?![^>]*\bsrc=)/u);
   assert.doesNotMatch(html, /\sonclick=/iu);
-  assert.doesNotMatch(html, /theme\.js/u);
+});
+
+test("local wizard header always exposes persistent theme controls, support links, and the package version placeholder", async () => {
+  const [html, theme, localStyles] = await Promise.all([
+    readFile("src/ui/local.html", "utf8"),
+    readFile("src/ui/theme.js", "utf8"),
+    readFile("src/ui/local.css", "utf8"),
+  ]);
+
+  assert.match(html, /<script src="\/theme\.js" type="module"><\/script>/u);
+  assert.match(
+    html,
+    /class="header-actions"[\s\S]*name="color-theme" value="system"[\s\S]*name="color-theme" value="light"[\s\S]*name="color-theme" value="dark"/u,
+  );
+  assert.match(
+    html,
+    /class="local-repository-button"[\s\S]*href="https:\/\/github\.com\/Demonbane18\/relmio"[\s\S]*GitHub[\s\S]*id="local-repository-stars">\?</u,
+  );
+  assert.match(
+    html,
+    /class="local-support-button"[\s\S]*href="https:\/\/ko-fi\.com\/paldogies"/u,
+  );
+  assert.match(html, /v__RELMIO_PACKAGE_VERSION__/u);
+  assert.match(theme, /relmio-color-mode/u);
+  assert.match(theme, /localStorage\.getItem/u);
+  assert.match(theme, /localStorage\.setItem/u);
+  assert.doesNotMatch(
+    theme,
+    /password|credential|token|fingerprint/iu,
+  );
+  assert.match(
+    localStyles,
+    /\.local-repository-action\s*\{[^}]*background:\s*var\(--background\);[^}]*color:\s*var\(--text\);/u,
+  );
+  assert.ok(contrastRatio("#f4f2ec", "#0d1b18") >= 4.5);
+  assert.ok(contrastRatio("#101513", "#edf3f0") >= 4.5);
 });
 
 test("local wizard states the OpenAI and Codex credential boundaries", async () => {
@@ -145,8 +202,11 @@ test("local wizard calls only the dedicated local API contract", async () => {
 
   for (const path of [
     "/api/local/docker/status",
+    "/api/local/project-meta",
     "/api/local/plan",
     "/api/local/install",
+    "/api/local/client-credential/rotate",
+    "/api/local/client-credential/activate",
     "/api/local/codex/login",
     "/api/local/codex/login/status",
   ]) {
@@ -156,12 +216,33 @@ test("local wizard calls only the dedicated local API contract", async () => {
   assert.match(script, /result\.previewMode === true/u);
   assert.match(script, /result\.planId/u);
   assert.match(script, /result\.clientCredential/u);
+  assert.match(script, /new Intl\.NumberFormat/u);
   assert.match(script, /result\.verificationUrl/u);
   assert.match(script, /result\.userCode/u);
   assert.match(script, /recover that container's ChatGPT session credential/u);
   assert.match(script, /Treat it like your ChatGPT password/u);
   assert.doesNotMatch(script, /\/api\/oauth\/login/u);
   assert.doesNotMatch(script, /\/api\/install["']/u);
+});
+
+test("local wizard makes credential rotation explicit and replaces only DOM text after a fresh response", async () => {
+  const [html, script] = await Promise.all([
+    readFile("src/ui/local.html", "utf8"),
+    readFile("src/ui/local.js", "utf8"),
+  ]);
+
+  assert.match(html, /id="rotate-credential-button"/u);
+  assert.match(
+    html,
+    /Relmio shows the replacement first, then activates and verifies\s+it/u,
+  );
+  assert.match(script, /api\("\/api\/local\/client-credential\/rotate"/u);
+  assert.match(script, /api\("\/api\/local\/client-credential\/activate"/u);
+  assert.match(script, /setBusy\(button, true, "Rotating credential…"\)/u);
+  assert.match(script, /renderInstallResult\(staged\)/u);
+  assert.match(script, /requestAnimationFrame/u);
+  assert.match(script, /result-credential"\)\.textContent = result\.clientCredential/u);
+  assert.doesNotMatch(script, /\.innerHTML\b/u);
 });
 
 test("main wizard offers token-preserving local endpoint navigation", async () => {
@@ -189,4 +270,11 @@ test("local CSS preserves responsive, visible security controls", async () => {
   assert.match(css, /@media \(max-width: 48rem\)/u);
   assert.match(css, /@media \(prefers-reduced-motion: reduce\)/u);
   assert.doesNotMatch(css, /position:\s*fixed/u);
+  assert.match(css, /\.local-wizard \.toast-stack\s*\{[\s\S]*overflow:\s*visible/u);
+  assert.match(
+    css,
+    /\.local-wizard #global-message-text,[\s\S]*white-space:\s*normal[\s\S]*overflow-wrap:\s*anywhere/u,
+  );
+  assert.match(css, /\.local-wizard \.safety-note > span\s*\{[\s\S]*display:\s*block/u);
+  assert.doesNotMatch(css, /text-overflow:\s*ellipsis/u);
 });


### PR DESCRIPTION
## Summary

- fix isolated Codex App Server ChatGPT sign-in by installing operating-system CA certificates
- add authenticated local client-credential rotation with cross-process locking and fail-closed rollback
- restore persistent theme, GitHub, Ko-fi, and version controls and wrap long notification text
- synchronize Relmio package, lockfile, changelog, GitHub README, npm README, local endpoint guide, and regression coverage at `0.5.0`

## Security boundaries

- Codex stays capability-authenticated and bound to literal loopback publication
- ChatGPT/Codex credentials remain separate from OpenAI Platform API keys
- rotation preserves upstream credential/workspace volumes and never retains the prior raw capability for rollback
- npm publication remains GitHub Actions trusted-publisher OIDC only

## Validation

- `npm run check`: 292 tests, 286 passed, 0 failed, 6 expected platform skips
- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm pack --dry-run`: 68 files at `relmio@0.5.0`
- web lint, typecheck, 14 tests, Vercel build, and web audit passed
- staged diff check and common secret-shape scan passed
- pre-publication distribution audit passed every already-public surface; only expected unpublished `0.5.0` registry/release/Homebrew/asset checks remain
- Astral Orchestrator fresh Sol reviewer verdict: `ship`, no findings

## Release applicability

| Surface | Required action |
|---|---|
| GitHub main/tag/release | merge through protected PR, tag merged commit, publish curated release |
| npm | publish only through the release-triggered OIDC workflow |
| Vercel | verify production deployment and public install page after merge |
| curl/PowerShell/CMD/NPX installers | verify hosted and registry-backed paths at `0.5.0` |
| Homebrew | update and verify the public tap against the exact npm tarball |
| WinGet | remain explicitly not public until catalog acceptance |

## Notes

- This is a pre-1.0 feature milestone and preserves the existing n8n safety boundaries.
- The final distribution audit will run after publication and must report every required public surface as passing.
