### PR TITLE
Add local Codex Chat adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+### Added
+
+- Add an experimental loopback-only Codex Chat Adapter for trusted local
+  backends and development servers, with bearer authentication, multi-turn
+  conversation IDs, strict resource bounds, and a small Relmio-specific
+  `POST /chat` contract.
+
+### Changed
+
+- Make Codex device sign-in target-aware so both the native App Server and the
+  chat adapter retain isolated, persistent ChatGPT credentials.
+
+### Security
+
+- Reject browser-origin adapter requests, keep the adapter separate from
+  OpenAI-compatible `/v1` semantics, explicitly deny model turns access to the
+  private Codex credential store, run chat turns read-only without network
+  access, and preserve loopback-only publication plus credential rotation.
+
 ## [0.5.0] - 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="docs/images/brand/relmio-mark.svg" alt="Relmio logo" width="88">
   <h1>Relmio</h1>
-  <p>Set up private n8n relays, Platform-key OpenAI-compatible local endpoints, and experimental Codex App Server sessions.</p>
+  <p>Set up private n8n relays, Platform-key OpenAI-compatible endpoints, and experimental local Codex chat or App Server sessions.</p>
   <p>
     <a href="#choose-a-setup-path">Get started</a>
     &nbsp;·&nbsp;
@@ -78,8 +78,9 @@ Relmio is a local browser wizard with separate setup paths. Its existing
 VPS/n8n path installs
 [`openai-oauth@2.0.0`](https://github.com/EvanZhouDev/openai-oauth/releases/tag/v2.0.0)
 as a separate Docker sidecar beside a self-hosted n8n instance. Its local
-Docker path can install either an OpenAI-compatible gateway backed by a
-Platform API key or the official Codex App Server backed by ChatGPT sign-in.
+Docker path can install an OpenAI-compatible gateway backed by a Platform API
+key, the official Codex App Server, or a small server-side Codex chat adapter
+backed by ChatGPT sign-in.
 
 The existing n8n image, Compose file, container, and workflows stay untouched.
 
@@ -250,7 +251,8 @@ flowchart LR
 **Available now:** Relmio's existing path signs in locally, verifies a VPS over
 SSH, and deploys a private sidecar beside self-hosted n8n. A separate local
 Docker path offers an OpenAI-compatible endpoint backed only by a Platform API
-key and the official Codex App Server protocol backed by ChatGPT sign-in.
+key, the official Codex App Server protocol, and a deliberately smaller
+Relmio-specific chat adapter backed by ChatGPT sign-in.
 
 **Designed to grow:** the Relmio name, mark, and package are client-neutral
 so later releases can add providers and client types without weakening each
@@ -273,6 +275,14 @@ The existing VPS/n8n wizard remains available from native Windows.
 |---|---|---|---|
 | **OpenAI API: compatible clients** | `http://127.0.0.1:12435/v1` by default | Server-side OpenAI Platform API key only | Private local app, SDK, or same-owner development web app |
 | **Codex with ChatGPT: agent clients** | `ws://127.0.0.1:14500` by default | ChatGPT sign-in through Codex | Trusted native Codex/App Server client |
+| **Codex Chat Adapter: development backends** | `http://127.0.0.1:14501/chat` by default | ChatGPT sign-in through Codex | Trusted local backend or development server |
+
+The Chat Adapter starts each model turn with network access disabled and an
+explicit filesystem policy that permits only Codex's minimal runtime files and
+the empty private workspace. The model-accessible sandbox denies
+`/home/node/.codex`, where the official Codex client keeps its ChatGPT session.
+The adapter bearer must stay in your server-side development environment,
+never browser code.
 
 The OpenAI-compatible `/v1` endpoint is powered only by a Platform API key,
 which the wizard seeds over stdin into a private, labeled Docker volume; it
@@ -292,18 +302,24 @@ and the capability must never be embedded in a public frontend bundle. Platform
 requests use that API project's billing, credits, limits, and permissions, not
 a ChatGPT subscription.
 
-ChatGPT sign-in powers only the official experimental Codex App Server JSON-RPC
-protocol. It does not expose `/v1`, and Relmio never translates a ChatGPT
-OAuth/session token into a general API credential. OpenAI documents the WebSocket transport as
-experimental and unsupported for production, and it rejects browser-origin
-connections. Use it only with a trusted native client owned by the same person.
-Its capability is high-trust because it can operate the signed-in
-Codex session and files inside the isolated container workspace.
+ChatGPT sign-in powers Codex, not the OpenAI Platform API. The native target
+keeps the official experimental App Server JSON-RPC protocol. The separate
+adapter offers only Relmio's `POST /chat` request and returns a conversation ID
+plus final text; it is not `/v1/chat/completions`, `/v1/responses`, or an
+OpenAI SDK replacement. A local backend can keep its Relmio bearer secret while
+a browser calls that backend. Direct browser-origin requests to both Codex
+targets are rejected.
 
-Both services bind exactly to `127.0.0.1`, require the generated capability,
-and mount no host directory or Docker socket. The Codex service gets private
-named credential and workspace volumes. This local path does not connect to a
-VPS or modify n8n.
+OpenAI documents the underlying App Server WebSocket transport as experimental
+and unsupported for production. The raw App Server capability is especially
+high-trust because it can operate the signed-in Codex session and files inside
+the isolated container workspace. Keep either target loopback-only, same-owner,
+and limited to local development.
+
+All three services bind exactly to `127.0.0.1`, require the generated capability,
+and mount no host directory or Docker socket. Each Codex target gets its own
+private named credential and workspace volumes. This local path does not
+connect to a VPS or modify n8n.
 
 Read [Local Docker endpoints](docs/local-endpoints.md) before installing. It
 includes the wizard steps, client settings, exact-origin rules, billing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,28 +29,37 @@ flowchart LR
   W --> D["Local Docker Engine"]
   D --> G["OpenAI-compatible gateway<br>127.0.0.1:12435/v1"]
   D --> A["Codex App Server<br>127.0.0.1:14500"]
+  D --> H["Codex Chat Adapter<br>127.0.0.1:14501/chat"]
   G -->|"Platform API key"| P["OpenAI Platform API"]
   A -->|"Official Codex sign-in"| C["ChatGPT/Codex service"]
+  H -->|"Official App Server lifecycle"| C
 ```
 
-The two services are intentionally not interchangeable:
+The three services are intentionally not interchangeable:
 
 | Target | Wire protocol | Upstream credential |
 |---|---|---|
 | `openai-api` | OpenAI-compatible HTTP `/v1` | OpenAI Platform API key |
 | `codex-chatgpt` | Official Codex App Server JSON-RPC | ChatGPT sign-in managed by Codex |
+| `codex-chat` | Relmio-specific HTTP `POST /chat` | ChatGPT sign-in managed by Codex |
 
 Relmio never adapts a ChatGPT/Codex credential into the local `/v1` gateway.
 The OpenAI gateway replaces the caller's Relmio capability with the
-protected Platform key only at the upstream boundary. The Codex service keeps
-the native initialization, thread, turn, approval, and event protocol.
+protected Platform key only at the upstream boundary. The native Codex service
+keeps the initialization, thread, turn, approval, and event protocol. The
+adapter invokes that same official lifecycle behind a bounded, read-only
+conversational contract without claiming OpenAI API compatibility. Its model
+sandbox denies network access and uses a root-deny filesystem policy with only
+minimal runtime paths plus `/workspace` readable; `/home/node/.codex` is
+explicitly denied so a model turn cannot read the persisted ChatGPT session.
 
-Both projects publish exactly one literal `127.0.0.1` binding and require a
+Each project publishes exactly one literal `127.0.0.1` binding and requires a
 generated bearer capability. Their managed roots are
-`~/.relmio/local/openai-api` and `~/.relmio/local/codex-chatgpt`. The Codex
-credential and workspace use private named Docker volumes; no host directory
-or Docker socket is mounted. See [Local Docker endpoints](local-endpoints.md)
-for setup and trust limitations.
+`~/.relmio/local/openai-api`, `~/.relmio/local/codex-chatgpt`, and
+`~/.relmio/local/codex-chat`. The Codex credentials and workspaces use
+target-specific private named Docker volumes; no host directory or Docker
+socket is mounted. See [Local Docker endpoints](local-endpoints.md) for setup
+and trust limitations.
 
 Before installation, Relmio resolves the selected Docker context to a local
 Unix socket and pins that exact socket on every later Docker command. Remote
@@ -182,3 +191,6 @@ sidecar authenticates upstream with the mounted OAuth file.
   or mismatched managed identity blocks local mutation.
 - A Codex login failure returns a sanitized status without returning App
   Server output or ChatGPT tokens.
+- A chat adapter request with a browser Origin, invalid bearer, malformed body,
+  protocol overflow, timeout, or failed turn is rejected with a sanitized
+  response and its App Server helper is terminated.

--- a/docs/local-endpoints-spec.md
+++ b/docs/local-endpoints-spec.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Approved for implementation on `codex/local-openai-endpoint` on 2026-08-13.
+Originally approved on 2026-08-13 and extended for the additive
+`codex/local-codex-chat-adapter` target on 2026-08-15.
 
 This spec is product and engineering guidance based on the current official
 OpenAI documentation. It is not a legal opinion. Relmio must not claim that
@@ -13,16 +14,19 @@ OpenAI has endorsed, certified, or pre-approved the project.
 Add a local Docker installation path to the Relmio browser wizard without
 weakening the existing VPS/n8n safety boundary.
 
-Relmio offers two intentionally different local providers:
+Relmio offers three intentionally different local client contracts:
 
 1. `openai-api` is an OpenAI-compatible HTTP gateway backed by the user's
    OpenAI Platform API key.
 2. `codex-chatgpt` is the official Codex App Server protocol backed by the
    user's ChatGPT/Codex sign-in.
+3. `codex-chat` is a small Relmio-specific HTTP chat adapter backed by the
+   same official App Server lifecycle and ChatGPT/Codex sign-in.
 
 Relmio must never exchange, translate, or present a ChatGPT/Codex credential as
-a general OpenAI API bearer credential. The Codex provider must not expose an
-OpenAI-shaped `/v1` compatibility surface.
+a general OpenAI API bearer credential. Neither Codex target may expose an
+OpenAI-shaped `/v1` compatibility surface. The adapter owns only its narrow
+`POST /chat` contract.
 
 ## Official-source boundary
 
@@ -53,7 +57,7 @@ The existing VPS/n8n wizard remains a separate legacy setup path. The wizard
 landing experience adds a prominent **Local endpoints** option which opens a
 dedicated local installer.
 
-The local installer starts with two provider cards:
+The local installer starts with three provider cards:
 
 ### OpenAI API
 
@@ -81,7 +85,21 @@ The local installer starts with two provider cards:
   - An explicit statement that this is Codex JSON-RPC, not OpenAI `/v1`
   - An explicit experimental/non-production notice
 
-Both flows show a review screen and require a final confirmation before any
+### Codex Chat Adapter
+
+- Label: **Codex Chat Adapter — development backends**
+- Default HTTP port: `14501`
+- Uses the same pinned official Codex CLI and official device-code sign-in.
+- Result:
+  - Endpoint: `http://127.0.0.1:<port>`
+  - A newly generated Relmio bearer token, displayed once
+  - A device-code sign-in action
+  - An explicit server-side-only statement
+  - An explicit statement that `POST /chat` is Relmio-specific, not OpenAI
+    `/v1`
+  - An explicit experimental/non-production notice
+
+All three flows show a review screen and require a final confirmation before any
 filesystem or Docker write.
 
 This release supports macOS, Linux, and Linux under WSL2. Native Windows is
@@ -143,7 +161,9 @@ is released in a `finally` path after both success and failure.
 ### `POST /api/local/codex/login`
 
 Starts an official Codex App Server device-code login through a one-shot stdio
-App Server process attached to the same persistent Codex home volume.
+App Server process attached to the selected Codex target's persistent home
+volume. The request identifies either `codex-chatgpt` or `codex-chat`;
+every other target is rejected before process construction.
 
 Every login attempt resolves the managed Codex directory and attests its
 schema-2 marker and matching Docker resources, even in a fresh wizard process.
@@ -249,12 +269,77 @@ The host mapping is exactly `127.0.0.1:<selected-port>:4500`.
   The capability is therefore password-equivalent and limited to a trusted,
   same-owner native client.
 
+## Codex Chat Adapter contract
+
+The adapter container starts a dependency-free Node HTTP service and launches
+the pinned official `codex app-server --strict-config --stdio` process only
+for a bounded chat operation. It uses the target's private Codex home and
+workspace volumes and never exposes the App Server transport on the host.
+
+### Listener and authentication
+
+- Container listener: `0.0.0.0:14501`
+- Host publication: `127.0.0.1:<selected-port>:14501`
+- `GET /health` is the only unauthenticated, non-forwarding route.
+- Every route except `GET /health` requires exactly one
+  `Authorization: Bearer <Relmio capability>` header.
+- Only the SHA-256 verifier is persisted and comparison is constant-time.
+- Requests with an `Origin` header are rejected and no CORS permission is
+  emitted.
+
+### Request and response
+
+The accepted JSON object contains only:
+
+```json
+{
+  "input": "Required nonempty conversational input",
+  "conversationId": "Optional App Server thread ID"
+}
+```
+
+The successful response contains only:
+
+```json
+{
+  "conversationId": "The started or resumed thread ID",
+  "output": "The authoritative final agent message"
+}
+```
+
+The adapter performs `initialize`, `initialized`, `thread/start` or
+`thread/resume`, and `turn/start`. The turn is constrained to the empty
+private workspace with a read-only sandbox. Its filesystem policy denies root
+by default, permits only Codex's minimal runtime paths and `/workspace`, and
+explicitly denies `/home/node/.codex`; turn network access is disabled. The
+instruction not to inspect or modify files, run commands, call tools, or access
+external resources remains defense in depth, not the credential boundary.
+`item/completed` agent-message text is authoritative; bounded deltas are kept
+separate by `itemId`, with only the most recent item's text used as a
+compatibility fallback. Success requires `turn/completed` with
+`status: completed`.
+
+### Resource and failure bounds
+
+- Header, body, input, conversation ID, stdout, stderr, line, and output sizes
+  are bounded.
+- Concurrent chats, turn duration, child-process termination grace, and the
+  final wait for an unreaped process are bounded. The concurrency slot remains
+  occupied until the helper closes or that final bound expires.
+- Client disconnect, timeout, malformed protocol, overflow, and failed turns
+  terminate the helper.
+- HTTP errors are generic and never include App Server output, process errors,
+  ChatGPT credentials, or stderr.
+- Installation and credential rotation verify readiness/authentication without
+  starting a model turn or requiring sign-in before the device-code step.
+
 ## Local filesystem and process boundary
 
 Managed roots:
 
 - `~/.relmio/local/openai-api`
 - `~/.relmio/local/codex-chatgpt`
+- `~/.relmio/local/codex-chat`
 
 `RELMIO_HOME` may replace `~/.relmio` for testing or advanced use, but it must
 be an absolute path whose final component is `.relmio`.
@@ -282,7 +367,7 @@ Controls:
 
 ## Container hardening
 
-Both long-running endpoint services:
+All three long-running endpoint services:
 
 - run as a non-root user;
 - set `no-new-privileges`;
@@ -326,26 +411,29 @@ gateway; it is removed immediately after seeding.
 | LAN/public exposure | literal `127.0.0.1` Compose binding plus template and runtime inspection tests |
 | Local cross-site request | bearer capability, exact Origin allowlist, strict preflight, Host validation |
 | Upstream key disclosure | separate local/upstream credentials, stdin-seeded private named volume, redacted errors, no body logging |
-| ChatGPT token repurposing | official App Server only; no `/v1` adapter for Codex |
+| ChatGPT token repurposing | official App Server lifecycle only; the adapter is Relmio-specific and exposes no `/v1` route |
 | Command injection | validated scalar values, spawn argument arrays, no shell |
 | Managed-path takeover | refuse unmanaged roots and every symlinked component |
 | Streaming resource exhaustion | header/body/concurrency/time bounds and backpressure |
 | Docker privilege compromise | document Docker control as a privileged local boundary; mount no Docker socket into services |
 | Secret recovery from UI | show capabilities once; never use browser storage; rotate on reinstall |
-| Codex capability compromise | explicit credential-equivalent warning; trusted same-owner native clients only; private container volumes and no host mounts |
+| Codex capability compromise | explicit trust warning; target-specific least-privilege interfaces, private container volumes, no host mounts, and server-side-only adapter use |
+| Model-induced credential read | root-deny model filesystem profile, minimal runtime read allowlist, explicit `/home/node/.codex` deny, empty private workspace, and no turn network access |
 
 ## Acceptance criteria
 
-- The browser wizard visibly offers both local providers and the legacy VPS
+- The browser wizard visibly offers all three local contracts and the legacy VPS
   path remains separate.
-- Platform keys are accepted only by `openai-api`; ChatGPT auth is accepted only
-  by official App Server.
+- Platform keys are accepted only by `openai-api`; both Codex targets use only
+  official App Server-backed ChatGPT authentication.
 - Generated Compose files publish only literal loopback bindings.
 - Every non-health gateway operation that can reach OpenAI and every App Server
   WebSocket handshake is capability-authenticated; exact-origin CORS preflight
   is a non-forwarding metadata exception.
 - Gateway unit/integration tests cover auth, origins, Host validation,
   streaming, cancellation, upstream errors, and secret redaction.
+- Adapter tests cover auth, Origin rejection, request/protocol validation,
+  process cleanup, bounds, concurrency, final-output selection, and redaction.
 - Local installer tests prove confirmation, unmanaged-root refusal, symlink
   refusal, port collision behavior, exact Docker arguments, file modes, and
   absence of n8n commands.

--- a/docs/local-endpoints.md
+++ b/docs/local-endpoints.md
@@ -1,18 +1,20 @@
 # Local Docker endpoints
 
 Relmio can install a provider endpoint in Docker on the same computer as your
-app. The local installer is deliberately split into two protocols with two
-different authentication methods:
+app. The local installer keeps three explicit client contracts across two
+different provider authentication methods:
 
 | Wizard option | Local interface | Upstream sign-in | Intended client |
 |---|---|---|---|
 | **OpenAI API: compatible clients** | OpenAI-compatible HTTP under `/v1` | Server-side OpenAI Platform API key only | A private local app, SDK, or same-owner development web app |
 | **Codex with ChatGPT: agent clients** | Official Codex App Server JSON-RPC over WebSocket | ChatGPT sign-in through Codex | A trusted native Codex/App Server client owned by the same person |
+| **Codex Chat Adapter: development backends** | Relmio-specific HTTP `POST /chat` | ChatGPT sign-in through Codex | A trusted local backend or development server owned by the same person |
 
 Relmio does not exchange or translate a ChatGPT OAuth/session credential into
-an OpenAI-compatible `/v1` bearer credential. The Codex option keeps Codex's
-thread, turn, approval, and streamed-event semantics instead of pretending to
-be the OpenAI API.
+an OpenAI-compatible `/v1` bearer credential. The native Codex option keeps
+Codex's thread, turn, approval, and streamed-event semantics. The adapter
+translates only a small Relmio-owned `/chat` contract into that official
+protocol; it does not imitate the OpenAI API.
 
 This is a documentation-backed engineering boundary, not legal advice or a
 guarantee that a particular account or use case is permitted. Review the
@@ -24,10 +26,11 @@ agreements and policies that apply to your account.
   this release depends on POSIX owner-only directory and file permissions for
   local credentials.
 - Docker Engine or Docker Desktop with Docker Compose v2 on the local computer
-- A free loopback port (`12435` by default for OpenAI API or `14500` for Codex)
+- A free loopback port (`12435` for OpenAI API, `14500` for native Codex,
+  or `14501` for the Codex Chat Adapter by default)
 - One of these provider credentials:
   - an OpenAI Platform API key for the OpenAI-compatible endpoint; or
-  - a ChatGPT account eligible for Codex for the App Server endpoint
+  - a ChatGPT account eligible for Codex for either Codex target
 - A trusted local app that can keep the Relmio capability secret
 
 The local path does not need a VPS or SSH access and does not modify the
@@ -45,8 +48,8 @@ project on the local computer.
 
 2. Open the one-time local wizard URL printed in the terminal and choose
    **Local endpoints**.
-3. Choose **OpenAI API: compatible clients** or **Codex with ChatGPT: agent
-   clients**.
+3. Choose **OpenAI API: compatible clients**, **Codex with ChatGPT: agent
+   clients**, or **Codex Chat Adapter: development backends**.
 4. Keep the default port or select another unused local port. For the OpenAI
    API option, add any browser origins that must be allowed and enter your
    Platform API key.
@@ -64,6 +67,7 @@ inside its managed path. Its local files live under:
 ```text
 ~/.relmio/local/openai-api
 ~/.relmio/local/codex-chatgpt
+~/.relmio/local/codex-chat
 ```
 
 Advanced or test environments can set `RELMIO_HOME` before starting the
@@ -81,8 +85,9 @@ To replace only the credential used by your local client, select **Rotate client
 credential** on the installed endpoint's Ready screen. Relmio first stages and
 shows the new one-time capability while the previous capability remains active.
 It then updates and validates the managed Compose configuration, recreates only
-the attested service, and verifies the new bearer against `/v1/models` or the
-authenticated Codex WebSocket handshake before reporting success.
+the attested service, and verifies the new bearer against `/v1/models`, the
+authenticated Codex WebSocket handshake, or the adapter's authenticated probe
+before reporting success.
 
 This client-only rotation preserves the upstream Platform API key in its private
 named volume and preserves the Codex home and workspace volumes. If activation
@@ -97,8 +102,8 @@ managed update. Relmio verifies the marker and Docker resource ownership and
 reuses the installation's unique Compose identity. For `openai-api`, provide the
 current or replacement Platform API key during that full update; Relmio reseeds
 its private named volume independently from the local client capability. A full
-`codex-chatgpt` update retains the private Codex home and workspace volumes unless
-you explicitly delete them.
+`codex-chatgpt` or `codex-chat` update retains the private Codex home and
+workspace volumes unless you explicitly delete them.
 
 Do not hand-edit the marker, Compose file, credential volume, or verifier. If
 the marker or resource labels do not attest as one Relmio installation, the
@@ -205,9 +210,61 @@ workspace and credential volume. The service receives no host directory,
 Docker socket, SSH key, browser profile, or host home-directory mount. This
 reduces host exposure; it does not make an untrusted App Server client safe.
 
+## Codex Chat Adapter: development backends
+
+The adapter result screen provides:
+
+```text
+Endpoint: http://127.0.0.1:14501
+Authorization: Bearer <the Relmio capability shown once by the wizard>
+Protocol: Relmio Codex Chat HTTP
+```
+
+After completing the same official Codex device-code sign-in, a local backend
+can start a conversation with:
+
+```bash
+export RELMIO_CODEX_CHAT_KEY="<capability shown once by the wizard>"
+curl http://127.0.0.1:14501/chat \
+  -H "Authorization: Bearer $RELMIO_CODEX_CHAT_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{"input":"Reply with a short hello."}'
+```
+
+The response contains only the App Server thread ID and final conversational
+text:
+
+```json
+{
+  "conversationId": "thread-id-from-the-first-response",
+  "output": "Hello!"
+}
+```
+
+Send that `conversationId` with the next `input` to continue the same
+conversation. The adapter initializes the official App Server, starts or
+resumes the thread, runs a read-only conversational turn, and returns the
+authoritative final agent message. The model sandbox has no network access and
+uses a root-deny filesystem policy that reads only Codex's minimal runtime
+paths and the empty private workspace. It explicitly denies
+`/home/node/.codex`, the private volume containing the ChatGPT session.
+
+This route is deliberately not `/v1/chat/completions` or `/v1/responses`.
+OpenAI SDKs and tools that require those schemas still need the Platform-backed
+OpenAI API target. The adapter rejects every request carrying an `Origin`
+header and sends no CORS permission, so browser JavaScript must not call it
+directly. Keep the bearer in a trusted local backend or development server and
+let the browser call that server's own session-aware route.
+
+The adapter is experimental because it depends on the experimental App Server
+interface. It is loopback-only, single-owner development tooling, not a hosted,
+LAN, multi-user, or production service. It enforces bounded request bodies,
+output, concurrency, process lifetime, and sanitized failures, but those
+controls do not create a general-purpose API entitlement.
+
 ## Network and container boundary
 
-Both local Compose projects publish exactly one host mapping:
+Every local Compose project publishes exactly one host mapping:
 
 ```text
 127.0.0.1:<selected-port>:<container-port>
@@ -216,12 +273,13 @@ Both local Compose projects publish exactly one host mapping:
 They are not available through the computer's LAN address. Each long-running
 service runs as a non-root user, drops Linux capabilities, sets
 `no-new-privileges`, uses a read-only root filesystem, and has bounded
-temporary storage and resource limits. Neither service mounts the Docker
+temporary storage and resource limits. None of the services mounts the Docker
 socket or a general host directory. The one-shot OpenAI seed helper has no
 network, port, or logs and retains only `CHOWN` while running as root long
 enough to atomically set ownership on the volume entry.
 The OpenAI gateway receives only its private API-key named volume, mounted
-read-only; Codex receives no host path and uses separate private named volumes.
+read-only; both Codex targets receive no host path and use target-specific
+private named volumes.
 
 The loopback binding and capability are complementary controls. Other
 processes running as the same local user may still be able to reach a loopback
@@ -244,7 +302,8 @@ literal values only after confirming all of these conditions:
 In every example, manually replace each angle-bracket placeholder with the
 already-validated literal. Do not use `eval`, source the JSON, or construct a
 Docker command from unvalidated marker text. The only valid service name is
-`gateway` for `openai-api` or `codex` for `codex-chatgpt`.
+`gateway` for `openai-api`, `codex` for `codex-chatgpt`, or `codex-chat`
+for `codex-chat`.
 
 ### Recover from a failed install
 
@@ -285,7 +344,7 @@ service:
 docker --host <dockerHost> compose \
   --project-name <projectName> \
   --file <absolute-managed-compose> \
-  rm --stop --force <gateway-or-codex>
+  rm --stop --force <gateway-or-codex-or-codex-chat>
 ```
 
 This recovery command does not target other services, remove the project
@@ -344,7 +403,8 @@ docker --host <dockerHost> compose \
 `--volumes` irreversibly deletes the managed Codex home and workspace volumes,
 including the container's ChatGPT credentials. After Docker confirms the
 matching resources are gone, you may remove only the exact
-`~/.relmio/local/codex-chatgpt` managed directory through your file manager.
+`~/.relmio/local/codex-chatgpt` or `~/.relmio/local/codex-chat` managed
+directory for the target you verified through your file manager.
 
 ## Troubleshooting
 
@@ -358,8 +418,9 @@ matching resources are gone, you may remove only the exact
 - **Browser request rejected:** enter the exact page origin, including scheme
   and port, then update the managed endpoint. Wildcards are intentionally not
   supported.
-- **Browser cannot connect to Codex:** this is expected. App Server's raw
-  WebSocket is for trusted native clients, not browser-origin connections.
+- **Browser cannot connect to Codex:** this is expected. Both Codex targets
+  reject browser-origin requests. Use the raw App Server from a trusted native
+  client or keep the Chat Adapter bearer in a local backend.
 - **Codex reports signed out:** repeat the device-code sign-in in the local
   wizard. Never copy a Codex credential file between users.
 - **Native Windows:** this local Docker feature is unsupported. Run Relmio in a
@@ -373,6 +434,7 @@ credentials and Codex/ChatGPT authentication:
 
 - [OpenAI API authentication](https://developers.openai.com/api/reference/overview#authentication)
 - [Codex authentication](https://learn.chatgpt.com/docs/auth)
+- [Codex permission profiles](https://learn.chatgpt.com/docs/permissions)
 - [Codex App Server protocol and WebSocket limitations](https://learn.chatgpt.com/docs/app-server)
 - [Codex for Open Source program terms](https://learn.chatgpt.com/docs/codex-for-oss-terms)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -26,11 +26,18 @@ For a local Docker endpoint, the design additionally assumes:
   by the same person;
 - a browser origin allowlist is not being used as a substitute for secret
   storage; and
-- a Codex client is trusted with App Server's broad agent and account surface.
+- a raw Codex client is trusted with App Server's broad agent and account
+  surface, while the Chat Adapter bearer is held only by a trusted local
+  backend or development server.
 
 The raw Codex App Server is not a multi-user boundary. It is for a trusted
 native client owned by the same account holder, not a browser, shared service,
 public app, or untrusted plugin.
+
+The Codex Chat Adapter is a separate, narrower contract. It is for a trusted
+local backend or development server owned by the same account holder. Browser
+JavaScript must not call it directly, and it is not for a remote, hosted,
+shared, or production service.
 
 ## Controls implemented by the wizard
 
@@ -62,11 +69,12 @@ public app, or untrusted plugin.
 
 - Generated Compose files publish only literal
   `127.0.0.1:<selected-port>:<container-port>` mappings.
-- Every OpenAI `/v1` operation that can reach OpenAI and every Codex WebSocket
-  upgrade requires a random Relmio capability displayed once by the wizard;
-  only its SHA-256 verifier is persisted. Exact-origin CORS `OPTIONS` is a
-  non-forwarding metadata exception. The bearer remains valid until an
-  endpoint update rotates it.
+- Every OpenAI `/v1` operation that can reach OpenAI, every raw Codex WebSocket
+  upgrade, and every Codex Chat Adapter route except `GET /health` requires a
+  random Relmio capability displayed once by the wizard; only its SHA-256
+  verifier is persisted. Exact-origin CORS `OPTIONS` is a non-forwarding
+  exception only for the Platform-backed `/v1` gateway. The bearer remains
+  valid until an endpoint update rotates it.
 - The Platform API key is accepted only for the OpenAI gateway. A transient,
   network-disabled helper receives it over stdin and atomically seeds a private,
   labeled Docker volume that the gateway mounts read-only. No host key file or
@@ -77,9 +85,16 @@ public app, or untrusted plugin.
 - Browser requests to the OpenAI gateway require an exact configured `http`
   or `https` origin. Wildcards and `null` are rejected; requests without an
   `Origin` remain available to authenticated native clients and backends.
-- Codex receives private named credential and workspace volumes. No host
-  directory, Docker socket, SSH key, browser profile, or home directory is
-  mounted into either local service.
+- The Chat Adapter rejects every request carrying an `Origin` header, emits no
+  CORS permission, and exposes only its authenticated Relmio-specific
+  `POST /chat` contract plus readiness and credential-verification probes.
+- Each Codex target receives its own private named credential and workspace
+  volumes. No long-running local endpoint service mounts a host directory,
+  Docker socket, SSH key, browser profile, or host home directory.
+- Chat Adapter turns use a named read-only permission profile with network
+  disabled. Its model-visible filesystem policy denies root by default, allows
+  only Codex's minimal runtime paths and the empty private workspace, and
+  explicitly denies the persisted Codex credential store.
 - Local managed paths use mode `0700`, generated files use owner-only modes,
   symlinks are rejected, and existing unmanaged directories are not
   overwritten.
@@ -89,7 +104,7 @@ public app, or untrusted plugin.
 - Each install uses a random Compose project identity. Containers, networks,
   and volumes must carry matching Relmio ownership labels before update,
   restart, recovery, or sign-in actions are allowed.
-- Both long-running endpoint containers run as a non-root user, drop Linux
+- All three long-running endpoint containers run as a non-root user, drop Linux
   capabilities, set `no-new-privileges`, use a read-only root filesystem, and
   have bounded temporary storage and resource limits.
 - The one-shot OpenAI credential seed helper is the narrow exception: it has no
@@ -126,11 +141,16 @@ The local capabilities have separate consequences:
 
 - The OpenAI gateway capability can spend through the protected Platform API
   key, subject to that Platform project's permissions and limits.
-- The Codex capability can invoke broad App Server methods inside the isolated
-  container and use its signed-in ChatGPT/Codex session.
+- The raw Codex App Server capability can invoke broad App Server methods
+  inside its isolated container and use its signed-in ChatGPT/Codex session.
+- The separate Chat Adapter bearer can submit chat turns and resume its bounded
+  conversation threads through the signed-in Codex container. Its narrower
+  HTTP surface and model permission profile reduce access, but do not make the
+  bearer safe to expose or share.
 - An origin allowlist does not make a bearer embedded in browser JavaScript
-  private. Use browser access only for private same-owner local development.
-- Do not expose either endpoint on a LAN, public IP, domain, reverse proxy, or
+  private. The Chat Adapter rejects browser origins entirely; keep its bearer
+  in a trusted local backend or development server.
+- Do not expose any local endpoint on a LAN, public IP, domain, reverse proxy, or
   hosted service. Loopback binding and the bearer capability are both required.
 - If a capability is disclosed, update the endpoint to rotate it. If an
   upstream credential may be exposed, revoke or sign out through the provider
@@ -152,12 +172,17 @@ The local capabilities have separate consequences:
   is billed or credited to the associated Platform project; a ChatGPT
   subscription or Codex for Open Source benefit is not substituted for API
   billing.
-- The local Codex option preserves the official App Server JSON-RPC protocol.
+- The raw local Codex option preserves the official App Server JSON-RPC protocol.
   It does not provide `/v1/chat/completions`, `/v1/responses`, or any other
   OpenAI API compatibility route.
 - OpenAI documents App Server WebSocket transport as experimental and
   unsupported for production. It rejects browser-origin requests and is
   limited here to trusted native same-owner clients.
+- The Codex Chat Adapter uses the official App Server lifecycle internally but
+  exposes only Relmio's experimental `POST /chat` contract. It is not
+  `/v1/chat/completions`, `/v1/responses`, or an OpenAI SDK replacement; it
+  rejects browser origins and is limited to trusted local backends or
+  development servers.
 - Acceptance into Codex for Open Source is not treated by Relmio as permission
   to repurpose credentials, share an account, bypass controls, or broaden the
   scope of another agreement. Review the current

--- a/npm/README.md
+++ b/npm/README.md
@@ -47,8 +47,9 @@ Relmio is a local browser wizard with separate setup paths. Its existing
 VPS/n8n path installs a private
 [openai-oauth](https://github.com/EvanZhouDev/openai-oauth) Docker sidecar
 beside an existing self-hosted n8n instance. Its local Docker path can install
-either an OpenAI-compatible gateway backed by a Platform API key or the
-official Codex App Server backed by ChatGPT sign-in.
+an OpenAI-compatible gateway backed by a Platform API key, the official Codex
+App Server, or a small server-side Codex chat adapter backed by ChatGPT
+sign-in.
 
 The existing n8n image, Compose file, container, and workflows stay untouched.
 
@@ -118,6 +119,14 @@ The existing VPS/n8n wizard remains available from native Windows.
 |---|---|---|---|
 | **OpenAI API: compatible clients** | `http://127.0.0.1:12435/v1` by default | Server-side OpenAI Platform API key only | Private local app, SDK, or same-owner development web app |
 | **Codex with ChatGPT: agent clients** | `ws://127.0.0.1:14500` by default | ChatGPT sign-in through Codex | Trusted native Codex/App Server client |
+| **Codex Chat Adapter: development backends** | `http://127.0.0.1:14501/chat` by default | ChatGPT sign-in through Codex | Trusted local backend or development server |
+
+The Chat Adapter starts each model turn with network access disabled and an
+explicit filesystem policy that permits only Codex's minimal runtime files and
+the empty private workspace. The model-accessible sandbox denies
+`/home/node/.codex`, where the official Codex client keeps its ChatGPT session.
+The adapter bearer must stay in your server-side development environment,
+never browser code.
 
 The OpenAI-compatible `/v1` endpoint is powered only by a Platform API key,
 which the wizard seeds over stdin into a private, labeled Docker volume; it
@@ -137,18 +146,24 @@ and the capability must never be embedded in a public frontend bundle. Platform
 requests use that API project's billing, credits, limits, and permissions, not
 a ChatGPT subscription.
 
-ChatGPT sign-in powers only the official experimental Codex App Server JSON-RPC
-protocol. It does not expose `/v1`, and Relmio never translates a ChatGPT
-OAuth/session token into a general API credential. OpenAI documents the WebSocket transport as
-experimental and unsupported for production, and it rejects browser-origin
-connections. Use it only with a trusted native client owned by the same person.
-Its capability is high-trust because it can operate the signed-in
-Codex session and files inside the isolated container workspace.
+ChatGPT sign-in powers Codex, not the OpenAI Platform API. The native target
+keeps the official experimental App Server JSON-RPC protocol. The separate
+adapter offers only Relmio's `POST /chat` request and returns a conversation ID
+plus final text; it is not `/v1/chat/completions`, `/v1/responses`, or an
+OpenAI SDK replacement. A local backend can keep its Relmio bearer secret while
+a browser calls that backend. Direct browser-origin requests to both Codex
+targets are rejected.
 
-Both services bind exactly to `127.0.0.1`, require the generated capability,
-and mount no host directory or Docker socket. The Codex service gets private
-named credential and workspace volumes. This local path does not connect to a
-VPS or modify n8n.
+OpenAI documents the underlying App Server WebSocket transport as experimental
+and unsupported for production. The raw App Server capability is especially
+high-trust because it can operate the signed-in Codex session and files inside
+the isolated container workspace. Keep either target loopback-only, same-owner,
+and limited to local development.
+
+All three services bind exactly to `127.0.0.1`, require the generated capability,
+and mount no host directory or Docker socket. Each Codex target gets its own
+private named credential and workspace volumes. This local path does not
+connect to a VPS or modify n8n.
 
 Read the complete [Local Docker endpoints
 guide](https://github.com/Demonbane18/relmio/blob/main/docs/local-endpoints.md)

--- a/src/domain/local-endpoints.js
+++ b/src/domain/local-endpoints.js
@@ -1,6 +1,8 @@
 import { validatePort } from "./validation.js";
+import packageManifest from "../../package.json" with { type: "json" };
 
 export const CODEX_CLI_VERSION = "0.147.0";
+const PACKAGE_VERSION = packageManifest.version;
 
 export const LOCAL_TARGETS = Object.freeze({
   "openai-api": Object.freeze({
@@ -18,6 +20,14 @@ export const LOCAL_TARGETS = Object.freeze({
     browserClients: false,
     experimental: true,
     containerPort: 4_500,
+  }),
+  "codex-chat": Object.freeze({
+    label: "Codex Chat Adapter",
+    protocol: "relmio-codex-chat-http",
+    upstreamAuth: "chatgpt-via-codex",
+    browserClients: false,
+    experimental: true,
+    containerPort: 14_501,
   }),
 });
 
@@ -114,7 +124,9 @@ export function createLocalDeploymentPlan({
   const endpoint =
     safeTarget === "openai-api"
       ? `http://127.0.0.1:${safePort}/v1`
-      : `ws://127.0.0.1:${safePort}`;
+      : safeTarget === "codex-chatgpt"
+        ? `ws://127.0.0.1:${safePort}`
+        : `http://127.0.0.1:${safePort}`;
 
   return {
     target: safeTarget,
@@ -145,8 +157,11 @@ ENTRYPOINT ["node", "/app/gateway.mjs"]
 
 export function createLocalDockerignore(target) {
   const safeTarget = validateLocalTarget(target);
-  return safeTarget === "openai-api"
-    ? "**\n!Dockerfile\n!gateway.mjs\n"
+  if (safeTarget === "openai-api") {
+    return "**\n!Dockerfile\n!gateway.mjs\n";
+  }
+  return safeTarget === "codex-chat"
+    ? "**\n!Dockerfile\n!gateway.mjs\n!config.toml\n!requirements.toml\n"
     : "**\n!Dockerfile\n!config.toml\n!requirements.toml\n";
 }
 
@@ -265,13 +280,29 @@ volumes:
 `;
 }
 
-export function createCodexConfig() {
-  return `approval_policy = "on-request"
+function renderCodexConfig({
+  approvalPolicy,
+  permissionProfile,
+  permissionProfileBase,
+  protectCredentialStore = false,
+}) {
+  const filesystemPermissions = protectCredentialStore
+    ? `
+[permissions.${permissionProfile}.filesystem]
+":root" = "deny"
+":minimal" = "read"
+":tmpdir" = "deny"
+":slash_tmp" = "deny"
+"/workspace" = "read"
+"/home/node/.codex" = "deny"
+`
+    : "";
+  return `approval_policy = "${approvalPolicy}"
 approvals_reviewer = "user"
 allow_login_shell = false
 check_for_update_on_startup = false
 cli_auth_credentials_store = "file"
-default_permissions = "relmio-workspace"
+default_permissions = "${permissionProfile}"
 forced_login_method = "chatgpt"
 web_search = "disabled"
 
@@ -281,10 +312,11 @@ enabled = false
 [feedback]
 enabled = false
 
-[permissions.relmio-workspace]
-extends = ":workspace"
+[permissions.${permissionProfile}]
+extends = "${permissionProfileBase}"
+${filesystemPermissions}
 
-[permissions.relmio-workspace.network]
+[permissions.${permissionProfile}.network]
 enabled = false
 
 [shell_environment_policy]
@@ -315,8 +347,25 @@ tool_suggest = false
 `;
 }
 
-export function createCodexRequirements() {
-  return `allowed_approval_policies = ["on-request"]
+export function createCodexConfig() {
+  return renderCodexConfig({
+    approvalPolicy: "on-request",
+    permissionProfile: "relmio-workspace",
+    permissionProfileBase: ":workspace",
+  });
+}
+
+export function createCodexChatConfig() {
+  return renderCodexConfig({
+    approvalPolicy: "never",
+    permissionProfile: "relmio-chat-readonly",
+    permissionProfileBase: ":read-only",
+    protectCredentialStore: true,
+  });
+}
+
+function renderCodexRequirements({ approvalPolicy, permissionProfile }) {
+  return `allowed_approval_policies = ["${approvalPolicy}"]
 allowed_approvals_reviewers = ["user"]
 allowed_login_methods = ["chatgpt"]
 allowed_web_search_modes = ["disabled"]
@@ -324,10 +373,10 @@ allow_managed_hooks_only = true
 allow_remote_control = false
 check_for_update_on_startup = false
 allow_login_shell = false
-default_permissions = "relmio-workspace"
+default_permissions = "${permissionProfile}"
 
 [allowed_permission_profiles]
-"relmio-workspace" = true
+"${permissionProfile}" = true
 
 [feedback]
 enabled = false
@@ -356,6 +405,20 @@ tool_suggest = false
 `;
 }
 
+export function createCodexRequirements() {
+  return renderCodexRequirements({
+    approvalPolicy: "on-request",
+    permissionProfile: "relmio-workspace",
+  });
+}
+
+export function createCodexChatRequirements() {
+  return renderCodexRequirements({
+    approvalPolicy: "never",
+    permissionProfile: "relmio-chat-readonly",
+  });
+}
+
 export function createCodexDockerfile() {
   return `FROM node:22-bookworm-slim
 
@@ -375,6 +438,113 @@ WORKDIR /workspace
 USER node
 
 ENTRYPOINT ["codex"]
+`;
+}
+
+export function createCodexChatDockerfile() {
+  return `FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update \\
+    && apt-get install --no-install-recommends -y ca-certificates \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && npm install --global --ignore-scripts @openai/codex@${CODEX_CLI_VERSION} \\
+    && npm cache clean --force \\
+    && mkdir -p /etc/codex /home/node/.codex /workspace \\
+    && chown -R node:node /home/node/.codex /workspace
+
+COPY --chmod=0444 requirements.toml /etc/codex/requirements.toml
+COPY --chown=node:node config.toml /home/node/.codex/config.toml
+COPY --chown=node:node gateway.mjs /app/gateway.mjs
+
+ENV CODEX_HOME=/home/node/.codex
+WORKDIR /workspace
+USER node
+
+ENTRYPOINT ["node", "/app/gateway.mjs"]
+`;
+}
+
+export function createCodexChatComposeFile({ port, tokenSha256, installId }) {
+  const safePort = validateLocalPort(port);
+  const safeVerifier = validateSha256Verifier(tokenSha256);
+  const safeInstallId = validateInstallId(installId);
+  const gatewayImage = `relmio-codex-chat-${safeInstallId}:local`;
+
+  return `services:
+  codex-chat:
+    image: ${gatewayImage}
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    init: true
+    environment:
+      RELMIO_GATEWAY_TOKEN_SHA256: ${safeVerifier}
+      RELMIO_GATEWAY_HOST: 0.0.0.0
+      RELMIO_GATEWAY_PORT: "14501"
+      RELMIO_PACKAGE_VERSION: "${PACKAGE_VERSION}"
+    ports:
+      - "127.0.0.1:${safePort}:14501"
+    volumes:
+      - codex-home:/home/node/.codex
+      - codex-workspace:/workspace
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m,mode=1777,nodev,nosuid
+      - /run:size=16m,mode=0755,nodev,nosuid
+      - /home/node/.cache:uid=1000,gid=1000,mode=0700,nodev,nosuid
+    pids_limit: 128
+    mem_limit: 2g
+    cpus: 2.0
+    ulimits:
+      nofile:
+        soft: 1024
+        hard: 1024
+      core: 0
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - 'fetch("http://127.0.0.1:14501/health").then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))'
+      interval: 10s
+      timeout: 5s
+      retries: 9
+      start_period: 20s
+    labels:
+      io.relmio.managed: "true"
+      io.relmio.target: "codex-chat"
+      io.relmio.install: "${safeInstallId}"
+
+networks:
+  default:
+    labels:
+      io.relmio.managed: "true"
+      io.relmio.target: "codex-chat"
+      io.relmio.install: "${safeInstallId}"
+
+volumes:
+  codex-home:
+    labels:
+      io.relmio.managed: "true"
+      io.relmio.target: "codex-chat"
+      io.relmio.install: "${safeInstallId}"
+  codex-workspace:
+    labels:
+      io.relmio.managed: "true"
+      io.relmio.target: "codex-chat"
+      io.relmio.install: "${safeInstallId}"
 `;
 }
 

--- a/src/gateway/codex-chat.js
+++ b/src/gateway/codex-chat.js
@@ -1,0 +1,754 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { pathToFileURL } from "node:url";
+
+const MAX_HEADER_BYTES = 16 * 1024;
+const MAX_BODY_BYTES = 16 * 1024;
+const MAX_INPUT_BYTES = 12 * 1024;
+const MAX_OUTPUT_BYTES = 128 * 1024;
+const MAX_PROTOCOL_LINE_BYTES = 64 * 1024;
+const MAX_PROTOCOL_STDOUT_BYTES = 256 * 1024;
+const MAX_PROTOCOL_STDERR_BYTES = 64 * 1024;
+const TURN_TIMEOUT_MS = 120_000;
+const TERMINATION_GRACE_MS = 2_000;
+const CONVERSATIONAL_INSTRUCTION =
+  "Provide a conversational answer only. Do not inspect or edit files, run commands, call tools, or access external resources.";
+
+function isLoopbackListenHost(value) {
+  return value === "127.0.0.1" || value === "0.0.0.0" || value === "::1";
+}
+
+function validateTokenVerifier(value) {
+  if (!Buffer.isBuffer(value) || value.length !== 32) {
+    throw new TypeError("A SHA-256 local client credential verifier is required.");
+  }
+  return Buffer.from(value);
+}
+
+function headerOccurrences(request, expectedName) {
+  let count = 0;
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    if (request.rawHeaders[index].toLowerCase() === expectedName) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function validLoopbackHost(value) {
+  if (typeof value !== "string" || value.length === 0 || value.length > 261) {
+    return false;
+  }
+  const match = /^(\[[^\]]+\]|[^:[\]]+)(?::([0-9]{1,5}))?$/u.exec(value);
+  if (!match || /[\s,@/?#\\]/u.test(value)) {
+    return false;
+  }
+  if (match[2] !== undefined && (Number(match[2]) < 1 || Number(match[2]) > 65535)) {
+    return false;
+  }
+  return ["127.0.0.1", "localhost", "[::1]"].includes(match[1].toLowerCase());
+}
+
+function sendJson(response, status, body) {
+  const contents = JSON.stringify(body);
+  response.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": Buffer.byteLength(contents),
+    "Cache-Control": "no-store",
+    "X-Content-Type-Options": "nosniff",
+  });
+  response.end(contents);
+}
+
+function sendError(response, status, code) {
+  sendJson(response, status, { error: { code } });
+}
+
+function hasValidBearer(request, verifier) {
+  if (headerOccurrences(request, "authorization") !== 1) {
+    return false;
+  }
+  const value = request.headers.authorization;
+  if (typeof value !== "string" || value.length > 512) {
+    return false;
+  }
+  const match = /^Bearer ([A-Za-z0-9_-]{1,256})$/u.exec(value);
+  if (!match) {
+    return false;
+  }
+  const candidate = createHash("sha256").update(match[1], "utf8").digest();
+  return timingSafeEqual(candidate, verifier);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isSafeIdentifier(value) {
+  return (
+    typeof value === "string" &&
+    /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/u.test(value)
+  );
+}
+
+function validatePackageVersion(value) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9.+-]{1,64}$/u.test(value)) {
+    throw new TypeError("The Relmio package version is invalid.");
+  }
+  return value;
+}
+
+function parseContentType(request) {
+  if (headerOccurrences(request, "content-type") !== 1) {
+    return false;
+  }
+  const value = request.headers["content-type"];
+  return (
+    typeof value === "string" &&
+    /^application\/json(?:\s*;\s*charset=utf-8)?$/iu.test(value)
+  );
+}
+
+function readChatRequest(request) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const chunks = [];
+    let bytes = 0;
+    let rejected = false;
+    const reject = (code, status = 400) => {
+      if (!rejected) {
+        rejected = true;
+        rejectPromise(Object.assign(new Error(code), { code, status }));
+      }
+    };
+    request.on("data", (chunk) => {
+      if (rejected) {
+        return;
+      }
+      const value = Buffer.from(chunk);
+      bytes += value.length;
+      if (bytes > MAX_BODY_BYTES) {
+        reject("body_too_large", 413);
+        return;
+      }
+      chunks.push(value);
+    });
+    request.once("aborted", () => reject("client_disconnected", 499));
+    request.once("error", () => reject("invalid_request"));
+    request.once("end", () => {
+      if (rejected) {
+        return;
+      }
+      let body;
+      try {
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      } catch {
+        reject("invalid_json");
+        return;
+      }
+      if (!isPlainObject(body)) {
+        reject("invalid_request");
+        return;
+      }
+      const keys = Object.keys(body).sort();
+      if (
+        !keys.includes("input") ||
+        keys.some((key) => key !== "input" && key !== "conversationId")
+      ) {
+        reject("invalid_request");
+        return;
+      }
+      if (
+        typeof body.input !== "string" ||
+        body.input.trim() === "" ||
+        body.input.includes("\0") ||
+        Buffer.byteLength(body.input, "utf8") > MAX_INPUT_BYTES
+      ) {
+        reject("invalid_request");
+        return;
+      }
+      if (
+        body.conversationId !== undefined &&
+        !isSafeIdentifier(body.conversationId)
+      ) {
+        reject("invalid_request");
+        return;
+      }
+      resolvePromise({
+        input: body.input,
+        conversationId: body.conversationId,
+      });
+    });
+  });
+}
+
+function normalizeFinalMessage(value) {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    Buffer.byteLength(value, "utf8") <= MAX_OUTPUT_BYTES
+      ? value
+      : null
+  );
+}
+
+function createAppServerOperation({
+  input,
+  conversationId,
+  packageVersion,
+  signal,
+  spawnProcess,
+  terminationGraceMs,
+  turnTimeoutMs,
+}) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    let child;
+    try {
+      child = spawnProcess(
+        "codex",
+        ["app-server", "--strict-config", "--stdio"],
+        {
+          cwd: "/workspace",
+          shell: false,
+          stdio: ["pipe", "pipe", "pipe"],
+          windowsHide: true,
+        },
+      );
+    } catch {
+      rejectPromise(new Error("unavailable"));
+      return;
+    }
+    if (
+      !child ||
+      typeof child.kill !== "function" ||
+      typeof child.once !== "function" ||
+      typeof child.stdout?.on !== "function" ||
+      typeof child.stderr?.on !== "function" ||
+      typeof child.stdin?.on !== "function" ||
+      typeof child.stdin?.write !== "function"
+    ) {
+      rejectPromise(new Error("unavailable"));
+      return;
+    }
+
+    let settled = false;
+    let closing = false;
+    let stdout = Buffer.alloc(0);
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let threadId = null;
+    let turnId = null;
+    let finalOutput = null;
+    let latestDeltaItemId = null;
+    let deltaBytes = 0;
+    const deltaOutputs = new Map();
+    let phase = "initializing";
+    let outcome = null;
+    let timeout;
+    let killTimeout;
+    let reapTimeout;
+
+    const clearTimers = () => {
+      clearTimeout(timeout);
+      clearTimeout(killTimeout);
+      clearTimeout(reapTimeout);
+      timeout = undefined;
+      killTimeout = undefined;
+      reapTimeout = undefined;
+    };
+    const complete = () => {
+      if (settled || !outcome) {
+        return;
+      }
+      settled = true;
+      signal?.removeEventListener?.("abort", abortOperation);
+      clearTimers();
+      if (outcome.error) {
+        rejectPromise(new Error("unavailable"));
+      } else {
+        resolvePromise(outcome.result);
+      }
+    };
+    const terminate = () => {
+      if (closing) {
+        return;
+      }
+      closing = true;
+      try {
+        child.stdin.end?.();
+      } catch {
+        // The child is already being terminated.
+      }
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // A failed termination still receives a redacted result.
+      }
+      killTimeout = setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // There is no useful process detail to expose to the client.
+        }
+        reapTimeout = setTimeout(complete, terminationGraceMs);
+      }, terminationGraceMs);
+    };
+    const settle = (error, result) => {
+      if (settled || outcome) {
+        return;
+      }
+      outcome = { error, result };
+      signal?.removeEventListener?.("abort", abortOperation);
+      clearTimeout(timeout);
+      timeout = undefined;
+      terminate();
+    };
+    const failProtocol = () => settle(new Error("protocol"));
+    function abortOperation() {
+      settle(new Error("disconnected"));
+    }
+    const write = (message) => {
+      try {
+        child.stdin.write(`${JSON.stringify(message)}\n`);
+      } catch {
+        failProtocol();
+      }
+    };
+    const startThread = () => {
+      phase = "thread";
+      write({
+        id: 1,
+        method: conversationId ? "thread/resume" : "thread/start",
+        params: conversationId
+          ? {
+              approvalPolicy: "never",
+              cwd: "/workspace",
+              developerInstructions: CONVERSATIONAL_INSTRUCTION,
+              permissions: "relmio-chat-readonly",
+              threadId: conversationId,
+            }
+          : {
+              approvalPolicy: "never",
+              cwd: "/workspace",
+              developerInstructions: CONVERSATIONAL_INSTRUCTION,
+              permissions: "relmio-chat-readonly",
+            },
+      });
+    };
+    const startTurn = () => {
+      phase = "turn";
+      write({
+        id: 2,
+        method: "turn/start",
+        params: {
+          approvalPolicy: "never",
+          cwd: "/workspace",
+          input: [{ text: input, type: "text" }],
+          permissions: "relmio-chat-readonly",
+          threadId,
+        },
+      });
+    };
+    const processMessage = (message) => {
+      if (!isPlainObject(message) || settled || outcome) {
+        failProtocol();
+        return;
+      }
+      if (message.id === 0) {
+        if (phase !== "initializing" || message.error !== undefined || !isPlainObject(message.result)) {
+          failProtocol();
+          return;
+        }
+        write({ method: "initialized", params: {} });
+        startThread();
+        return;
+      }
+      if (message.id === 1) {
+        const candidate = message.result?.thread?.id;
+        const activeProfile = message.result?.activePermissionProfile;
+        if (
+          phase !== "thread" ||
+          message.error !== undefined ||
+          !isSafeIdentifier(candidate) ||
+          !isPlainObject(activeProfile) ||
+          activeProfile.id !== "relmio-chat-readonly" ||
+          activeProfile.extends !== ":read-only"
+        ) {
+          failProtocol();
+          return;
+        }
+        threadId = candidate;
+        startTurn();
+        return;
+      }
+      if (message.id === 2) {
+        const candidate = message.result?.turn?.id;
+        if (phase !== "turn" || message.error !== undefined || !isSafeIdentifier(candidate)) {
+          failProtocol();
+          return;
+        }
+        turnId = candidate;
+        phase = "waiting";
+        return;
+      }
+      if (message.id !== undefined) {
+        failProtocol();
+        return;
+      }
+      if (typeof message.method !== "string" || !isPlainObject(message.params)) {
+        failProtocol();
+        return;
+      }
+      const params = message.params;
+      if (message.method === "item/agentMessage/delta") {
+        if (
+          phase !== "waiting" ||
+          params.threadId !== threadId ||
+          params.turnId !== turnId ||
+          !isSafeIdentifier(params.itemId) ||
+          typeof params.delta !== "string" ||
+          Buffer.byteLength(params.delta, "utf8") > MAX_OUTPUT_BYTES
+        ) {
+          failProtocol();
+          return;
+        }
+        const partBytes = Buffer.byteLength(params.delta, "utf8");
+        if (deltaBytes + partBytes > MAX_OUTPUT_BYTES) {
+          failProtocol();
+          return;
+        }
+        deltaBytes += partBytes;
+        latestDeltaItemId = params.itemId;
+        deltaOutputs.set(
+          params.itemId,
+          `${deltaOutputs.get(params.itemId) ?? ""}${params.delta}`,
+        );
+        return;
+      }
+      if (message.method === "item/completed") {
+        if (phase !== "waiting" || params.threadId !== threadId || params.turnId !== turnId || !isPlainObject(params.item)) {
+          failProtocol();
+          return;
+        }
+        if (params.item.type === "agentMessage") {
+          if (!isSafeIdentifier(params.item.id)) {
+            failProtocol();
+            return;
+          }
+          const output = normalizeFinalMessage(params.item.text);
+          if (!output) {
+            failProtocol();
+            return;
+          }
+          finalOutput = output;
+        }
+        return;
+      }
+      if (message.method === "turn/completed") {
+        if (
+          phase !== "waiting" ||
+          params.threadId !== threadId ||
+          !isPlainObject(params.turn) ||
+          params.turn.id !== turnId ||
+          params.turn.status !== "completed"
+        ) {
+          failProtocol();
+          return;
+        }
+        const completedItem = Array.isArray(params.turn.items)
+          ? [...params.turn.items]
+              .reverse()
+              .find((item) => isPlainObject(item) && item.type === "agentMessage")
+          : null;
+        const output =
+          finalOutput ??
+          normalizeFinalMessage(completedItem?.text) ??
+          normalizeFinalMessage(deltaOutputs.get(latestDeltaItemId));
+        if (!output) {
+          failProtocol();
+          return;
+        }
+        settle(null, { conversationId: threadId, output });
+        return;
+      }
+      // App Server emits normal thread, turn, item, warning, and usage
+      // notifications around the response. They are informational for this
+      // deliberately narrow adapter and must not break a valid chat turn.
+    };
+    const processLine = (line) => {
+      if (line.length > MAX_PROTOCOL_LINE_BYTES) {
+        failProtocol();
+        return;
+      }
+      const trimmed = line.at(-1) === 0x0d ? line.subarray(0, -1) : line;
+      if (trimmed.length === 0) {
+        return;
+      }
+      try {
+        processMessage(JSON.parse(trimmed.toString("utf8")));
+      } catch {
+        failProtocol();
+      }
+    };
+
+    child.stdout.on("data", (chunk) => {
+      if (settled || outcome) {
+        return;
+      }
+      const bytes = Buffer.from(chunk);
+      stdoutBytes += bytes.length;
+      if (stdoutBytes > MAX_PROTOCOL_STDOUT_BYTES) {
+        failProtocol();
+        return;
+      }
+      stdout = Buffer.concat([stdout, bytes]);
+      let newline = stdout.indexOf(0x0a);
+      while (newline >= 0 && !settled && !outcome) {
+        const line = stdout.subarray(0, newline);
+        stdout = stdout.subarray(newline + 1);
+        processLine(line);
+        newline = stdout.indexOf(0x0a);
+      }
+      if (!settled && !outcome && stdout.length > MAX_PROTOCOL_LINE_BYTES) {
+        failProtocol();
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      if (!settled && !outcome) {
+        stderrBytes += Buffer.byteLength(chunk);
+        if (stderrBytes > MAX_PROTOCOL_STDERR_BYTES) {
+          failProtocol();
+        }
+      }
+    });
+    const handleStreamError = () => settle(new Error("stream"));
+    child.stdin.on("error", handleStreamError);
+    child.stdout.on("error", handleStreamError);
+    child.stderr.on("error", handleStreamError);
+    child.once("error", () => settle(new Error("process")));
+    child.once("close", () => {
+      if (!outcome) {
+        outcome = { error: new Error("closed"), result: undefined };
+      }
+      complete();
+    });
+    timeout = setTimeout(() => settle(new Error("timeout")), turnTimeoutMs);
+    if (signal?.aborted) {
+      abortOperation();
+      return;
+    }
+    signal?.addEventListener?.("abort", abortOperation, { once: true });
+    write({
+      id: 0,
+      method: "initialize",
+      params: {
+        capabilities: {
+          experimentalApi: true,
+        },
+        clientInfo: {
+          name: "relmio",
+          title: "Relmio",
+          version: packageVersion,
+        },
+      },
+    });
+  });
+}
+
+export function hashCodexChatCredential(value) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 256 ||
+    !/^[A-Za-z0-9_-]+$/u.test(value)
+  ) {
+    throw new TypeError("The local client credential is invalid.");
+  }
+  return createHash("sha256").update(value, "utf8").digest();
+}
+
+export function loadCodexChatGatewayConfig(environment = process.env) {
+  const host = environment?.RELMIO_GATEWAY_HOST;
+  const portText = environment?.RELMIO_GATEWAY_PORT;
+  const verifier = environment?.RELMIO_GATEWAY_TOKEN_SHA256;
+  const packageVersion = environment?.RELMIO_PACKAGE_VERSION;
+  if (
+    !isLoopbackListenHost(host) ||
+    typeof portText !== "string" ||
+    !/^[1-9][0-9]{0,4}$/u.test(portText) ||
+    Number(portText) < 1024 ||
+    Number(portText) > 65_535 ||
+    typeof verifier !== "string" ||
+    !/^[a-f0-9]{64}$/u.test(verifier)
+  ) {
+    throw new TypeError("Codex Chat gateway configuration is invalid.");
+  }
+  try {
+    return {
+      host,
+      packageVersion: validatePackageVersion(packageVersion),
+      port: Number(portText),
+      tokenVerifier: Buffer.from(verifier, "hex"),
+    };
+  } catch {
+    throw new TypeError("Codex Chat gateway configuration is invalid.");
+  }
+}
+
+export async function startCodexChatGateway({
+  host = "127.0.0.1",
+  port = 14_501,
+  tokenVerifier,
+  packageVersion = "unknown",
+  spawnProcess = spawn,
+  terminationGraceMs = TERMINATION_GRACE_MS,
+  turnTimeoutMs = TURN_TIMEOUT_MS,
+} = {}) {
+  if (!isLoopbackListenHost(host)) {
+    throw new TypeError("Codex Chat must listen on a literal loopback-safe host.");
+  }
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw new TypeError("The Codex Chat port is invalid.");
+  }
+  if (typeof spawnProcess !== "function") {
+    throw new TypeError("A Codex App Server process boundary is required.");
+  }
+  if (
+    !Number.isSafeInteger(terminationGraceMs) ||
+    terminationGraceMs < 1 ||
+    terminationGraceMs > 10_000
+  ) {
+    throw new TypeError("The Codex Chat termination grace period is invalid.");
+  }
+  if (
+    !Number.isSafeInteger(turnTimeoutMs) ||
+    turnTimeoutMs < 1 ||
+    turnTimeoutMs > 600_000
+  ) {
+    throw new TypeError("The Codex Chat turn timeout is invalid.");
+  }
+  const verifier = validateTokenVerifier(tokenVerifier);
+  const safePackageVersion = validatePackageVersion(packageVersion);
+  let activeOperation = false;
+  const server = createServer({ maxHeaderSize: MAX_HEADER_BYTES }, (request, response) => {
+    if (headerOccurrences(request, "host") !== 1 || !validLoopbackHost(request.headers.host)) {
+      sendError(response, 421, "host_rejected");
+      return;
+    }
+    if (headerOccurrences(request, "origin") > 0) {
+      sendError(response, 403, "origin_rejected");
+      return;
+    }
+    if (
+      headerOccurrences(request, "authorization") > 1 ||
+      headerOccurrences(request, "content-type") > 1
+    ) {
+      sendError(response, 400, "invalid_request");
+      return;
+    }
+    if (request.method === "GET" && request.url === "/health") {
+      sendJson(response, 200, { status: "ok" });
+      return;
+    }
+    if (!hasValidBearer(request, verifier)) {
+      sendError(response, 401, "unauthorized");
+      return;
+    }
+    if (request.method === "GET" && request.url === "/auth/verify") {
+      sendJson(response, 200, { status: "ok" });
+      return;
+    }
+    if (request.method !== "POST" || request.url !== "/chat") {
+      sendError(response, 404, "not_found");
+      return;
+    }
+    if (!parseContentType(request)) {
+      sendError(response, 415, "content_type_required");
+      return;
+    }
+    if (activeOperation) {
+      sendError(response, 429, "busy");
+      return;
+    }
+    activeOperation = true;
+    const controller = new AbortController();
+    let disconnected = false;
+    const onDisconnect = () => {
+      if (request.aborted || !response.writableEnded) {
+        disconnected = true;
+        controller.abort();
+      }
+    };
+    request.once("aborted", onDisconnect);
+    response.once("close", onDisconnect);
+    void readChatRequest(request)
+      .then((chat) => {
+        if (disconnected) {
+          throw new Error("unavailable");
+        }
+        return createAppServerOperation({
+          ...chat,
+          packageVersion: safePackageVersion,
+          signal: controller.signal,
+          spawnProcess,
+          terminationGraceMs,
+          turnTimeoutMs,
+        });
+      })
+      .then((result) => {
+        if (!disconnected && !response.writableEnded) {
+          sendJson(response, 200, result);
+        }
+      })
+      .catch((error) => {
+        if (disconnected || response.writableEnded) {
+          return;
+        }
+        const status = error?.status;
+        const code = error?.code;
+        if (status === 413 || status === 499 || code === "invalid_json" || code === "invalid_request") {
+          sendError(response, status === 499 ? 400 : status ?? 400, code === "invalid_json" ? "invalid_json" : "invalid_request");
+          return;
+        }
+        sendError(response, 503, "unavailable");
+      })
+      .finally(() => {
+        activeOperation = false;
+      });
+  });
+  server.headersTimeout = 10_000;
+  server.requestTimeout = 30_000;
+  server.keepAliveTimeout = 5_000;
+  server.maxHeadersCount = 32;
+
+  await new Promise((resolvePromise, rejectPromise) => {
+    server.once("error", rejectPromise);
+    server.listen(port, host, () => {
+      server.off("error", rejectPromise);
+      resolvePromise();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Codex Chat could not determine its listener address.");
+  }
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    async close() {
+      await new Promise((resolvePromise, rejectPromise) => {
+        server.close((error) => (error ? rejectPromise(error) : resolvePromise()));
+      });
+    },
+  };
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  startCodexChatGateway(loadCodexChatGatewayConfig()).catch(() => {
+    process.stderr.write("Relmio Codex Chat could not start.\n");
+    process.exitCode = 1;
+  });
+}

--- a/src/services/codex-login.js
+++ b/src/services/codex-login.js
@@ -9,7 +9,7 @@ import {
 
 const COMPOSE_FILE_NAME = "docker-compose.yml";
 const PROJECT_NAME_PATTERN =
-  /^relmio-codex-chatgpt-[a-f0-9]{32}$/u;
+  /^relmio-codex-(chatgpt|chat)-[a-f0-9]{32}$/u;
 const DEFAULT_RESPONSE_TIMEOUT_MS = 15_000;
 const DEFAULT_COMPLETION_TIMEOUT_MS = 300_000;
 const DEFAULT_TERMINATION_GRACE_MS = 2_000;
@@ -88,7 +88,12 @@ function validateOptions({
   if (maxLineBytes > maxStdoutBytes) {
     throw new TypeError("maxLineBytes cannot exceed maxStdoutBytes.");
   }
-  return { dockerHost: validatedDockerHost, projectName };
+  const projectKind = PROJECT_NAME_PATTERN.exec(projectName)?.[1];
+  return {
+    dockerHost: validatedDockerHost,
+    projectName,
+    serviceName: projectKind === "chat" ? "codex-chat" : "codex",
+  };
 }
 
 function validateVerificationUrl(value) {
@@ -205,7 +210,10 @@ export async function startCodexDeviceLogin({
         "run",
         "--rm",
         "--no-deps",
-        "codex",
+        ...(validated.serviceName === "codex-chat"
+          ? ["--entrypoint", "codex"]
+          : []),
+        validated.serviceName,
         "app-server",
         "--strict-config",
         "--stdio",

--- a/src/services/local-installer.js
+++ b/src/services/local-installer.js
@@ -6,6 +6,10 @@ import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 
 import {
   createCodexComposeFile,
+  createCodexChatComposeFile,
+  createCodexChatConfig,
+  createCodexChatDockerfile,
+  createCodexChatRequirements,
   createCodexConfig,
   createCodexDockerfile,
   createCodexRequirements,
@@ -38,6 +42,11 @@ const PROJECTS = Object.freeze({
     projectPrefix: "relmio-codex-chatgpt",
     serviceName: "codex",
     containerPort: 4_500,
+  }),
+  "codex-chat": Object.freeze({
+    projectPrefix: "relmio-codex-chat",
+    serviceName: "codex-chat",
+    containerPort: 14_501,
   }),
 });
 const DOCKER_SELECTION_VARIABLES = Object.freeze([
@@ -613,10 +622,9 @@ function replaceClientCredentialVerifier({ target, composeFile, tokenSha256 }) {
     throw new Error("The managed local endpoint configuration is invalid.");
   }
 
-  const pattern =
-    target === "openai-api"
-      ? /^([ \t]*RELMIO_GATEWAY_TOKEN_SHA256:[ \t]*)[a-f0-9]{64}([ \t]*)$/gmu
-      : /^([ \t]*-[ \t]+--ws-token-sha256[ \t]*\n[ \t]*-[ \t]+)[a-f0-9]{64}([ \t]*)$/gmu;
+  const pattern = target === "openai-api" || target === "codex-chat"
+    ? /^([ \t]*RELMIO_GATEWAY_TOKEN_SHA256:[ \t]*)[a-f0-9]{64}([ \t]*)$/gmu
+    : /^([ \t]*-[ \t]+--ws-token-sha256[ \t]*\n[ \t]*-[ \t]+)[a-f0-9]{64}([ \t]*)$/gmu;
   const matches = [...composeFile.matchAll(pattern)];
   if (matches.length !== 1) {
     throw new Error("The managed local endpoint configuration is invalid.");
@@ -745,30 +753,34 @@ export async function getLocalDockerStatus({
 }
 
 export async function restartLocalCodex(
-  { installDirectory },
+  { installDirectory, target = "codex-chatgpt" },
   dependencies = {},
 ) {
+  const safeTarget = validateLocalTarget(target);
+  if (safeTarget !== "codex-chatgpt" && safeTarget !== "codex-chat") {
+    throw new TypeError("The Codex login target is invalid.");
+  }
   const runProcess = dependencies.runProcess ?? runLocalProcess;
   const releaseLock = dependencies.changeLockHeld === true
     ? async () => {}
     : await acquireLocalProjectLock(
-        { installRoot: installDirectory, target: "codex-chatgpt" },
+        { installRoot: installDirectory, target: safeTarget },
         dependencies,
       );
   try {
   const attested = await attestLocalCodexInstallation(
-    { installDirectory },
+    { installDirectory, target: safeTarget },
     dependencies,
   );
 
   await runOrThrow(runProcess, {
     label: "Codex credential reload",
     file: "docker",
-    args: createComposeArgs("codex-chatgpt", attested.projectName, [
+    args: createComposeArgs(safeTarget, attested.projectName, [
       "restart",
       "--timeout",
       "10",
-      "codex",
+      PROJECTS[safeTarget].serviceName,
     ]),
     cwd: installDirectory,
     dockerHost: attested.dockerHost,
@@ -776,14 +788,14 @@ export async function restartLocalCodex(
   await runOrThrow(runProcess, {
     label: "Codex readiness wait",
     file: "docker",
-    args: createComposeArgs("codex-chatgpt", attested.projectName, [
+    args: createComposeArgs(safeTarget, attested.projectName, [
       "up",
       "-d",
       "--wait",
       "--wait-timeout",
       "90",
       "--no-deps",
-      "codex",
+      PROJECTS[safeTarget].serviceName,
     ]),
     cwd: installDirectory,
     dockerHost: attested.dockerHost,
@@ -1111,7 +1123,7 @@ function parseModelIds(value) {
 }
 
 async function verifyHttpEndpoint({ plan, clientCredential, fetchImpl }) {
-  const healthPath = plan.target === "openai-api" ? "/health" : "/readyz";
+  const healthPath = plan.target === "codex-chatgpt" ? "/readyz" : "/health";
   const httpEndpoint = `http://127.0.0.1:${plan.port}${healthPath}`;
   let health;
   try {
@@ -1124,6 +1136,29 @@ async function verifyHttpEndpoint({ plan, clientCredential, fetchImpl }) {
   }
   if (!health.ok) {
     throw new Error("The local endpoint did not pass its readiness check.");
+  }
+
+  if (plan.target === "codex-chat" && clientCredential !== undefined) {
+    let verification;
+    try {
+      verification = await fetchImpl(
+        `http://127.0.0.1:${plan.port}/auth/verify`,
+        {
+          method: "GET",
+          headers: { Authorization: `Bearer ${clientCredential}` },
+          signal: AbortSignal.timeout(10_000),
+        },
+      );
+    } catch {
+      throw new Error(
+        "The Codex Chat client credential could not be verified.",
+      );
+    }
+    if (!verification.ok) {
+      throw new Error(
+        "The Codex Chat client credential could not be verified.",
+      );
+    }
   }
 
   if (plan.target !== "openai-api" || clientCredential === undefined) {
@@ -1275,6 +1310,13 @@ async function defaultReadGatewaySource() {
   );
 }
 
+async function defaultReadCodexChatSource() {
+  return defaultFileSystem.readFile(
+    new URL("../gateway/codex-chat.js", import.meta.url),
+    "utf8",
+  );
+}
+
 async function attestManagedLocalEndpoint(
   { target, installDirectory, missingMessage, notRunningMessage },
   {
@@ -1334,12 +1376,16 @@ async function attestManagedLocalEndpoint(
 }
 
 export async function attestLocalCodexInstallation(
-  { installDirectory },
+  { installDirectory, target = "codex-chatgpt" },
   dependencies = {},
 ) {
+  const safeTarget = validateLocalTarget(target);
+  if (safeTarget !== "codex-chatgpt" && safeTarget !== "codex-chat") {
+    throw new TypeError("The Codex login target is invalid.");
+  }
   const attested = await attestManagedLocalEndpoint(
     {
-      target: "codex-chatgpt",
+      target: safeTarget,
       installDirectory,
       missingMessage: "Install the local Codex endpoint before signing in.",
       notRunningMessage: "The managed local Codex endpoint is not running.",
@@ -1611,6 +1657,7 @@ export async function installLocalEndpoint(
     randomBytes = createRandomBytes,
     isPortAvailable = isLoopbackPortAvailable,
     readGatewaySource = defaultReadGatewaySource,
+    readCodexChatSource = defaultReadCodexChatSource,
     fetchImpl = fetch,
     verifyCodexCapability = verifyCodexWebSocketCapability,
     platform = process.platform,
@@ -1725,6 +1772,39 @@ export async function installLocalEndpoint(
       fileSystem,
       join(installRoot, "gateway.mjs"),
       gatewaySource,
+      0o600,
+    );
+  } else if (normalizedPlan.target === "codex-chat") {
+    const gatewaySource = await readCodexChatSource();
+    if (
+      typeof gatewaySource !== "string" ||
+      gatewaySource.length === 0 ||
+      gatewaySource.length > 512 * 1024
+    ) {
+      throw new Error("The packaged Codex Chat runtime is invalid.");
+    }
+    dockerfile = createCodexChatDockerfile();
+    composeFile = createCodexChatComposeFile({
+      port: normalizedPlan.port,
+      tokenSha256,
+      installId,
+    });
+    await writeManagedFile(
+      fileSystem,
+      join(installRoot, "gateway.mjs"),
+      gatewaySource,
+      0o600,
+    );
+    await writeManagedFile(
+      fileSystem,
+      join(installRoot, "config.toml"),
+      createCodexChatConfig(),
+      0o600,
+    );
+    await writeManagedFile(
+      fileSystem,
+      join(installRoot, "requirements.toml"),
+      createCodexChatRequirements(),
       0o600,
     );
   } else {

--- a/src/ui/local.html
+++ b/src/ui/local.html
@@ -92,8 +92,8 @@
         <section class="intro" aria-labelledby="page-title">
           <h1 id="page-title">Run Relmio on localhost</h1>
           <p class="lede">
-            Choose the official credential path that matches your client. Both
-            options run in a hardened Docker container and bind only to
+            Choose the official credential path that matches your client. All
+            three options run in hardened Docker containers and bind only to
             <code>127.0.0.1</code>.
           </p>
         </section>
@@ -197,6 +197,20 @@
                   Official Codex JSON-RPC over WebSocket, using ChatGPT sign-in.
                   This is not an OpenAI-compatible <code>/v1</code> endpoint and
                   browsers cannot connect directly. Codex App Server WebSocket is experimental and unsupported for production workloads.
+                </span>
+              </span>
+            </label>
+
+            <label class="target-card warning-card">
+              <input type="radio" name="target" value="codex-chat" />
+              <span class="target-card-copy">
+                <strong>Codex Chat Adapter</strong>
+                <span class="target-meta">Experimental · trusted local backends or development servers only</span>
+                <span>
+                  Relmio-specific authenticated <code>POST /chat</code>, backed by
+                  official Codex App Server and ChatGPT sign-in. This is not an
+                  OpenAI-compatible <code>/v1</code> endpoint and browser bundles
+                  must never connect to it.
                 </span>
               </span>
             </label>
@@ -358,8 +372,8 @@
         </div>
 
         <aside id="codex-install-warning" class="high-trust-warning" hidden>
-          <strong>High-trust capability</strong>
-          <p>
+          <strong id="codex-install-warning-title">High-trust capability</strong>
+          <p id="codex-install-warning-detail">
             Anyone holding the generated client credential can control Codex
             inside its isolated container, act through your signed-in ChatGPT
             session, and may be able to recover that container's ChatGPT session
@@ -445,10 +459,8 @@
         </dl>
 
         <aside id="codex-production-warning" class="high-trust-warning" hidden>
-          <strong>Experimental WebSocket transport</strong>
-          <p>
-            Codex App Server WebSocket is experimental and unsupported for production workloads.
-          </p>
+          <strong id="codex-production-warning-title">Experimental Codex integration</strong>
+          <p id="codex-production-warning-detail"></p>
         </aside>
 
         <section id="codex-login" class="codex-login" aria-labelledby="codex-login-title" hidden>

--- a/src/ui/local.js
+++ b/src/ui/local.js
@@ -129,6 +129,14 @@ function readAllowedOrigins() {
     .filter((value) => value !== "");
 }
 
+function isCodexChat(target) {
+  return target === "codex-chat";
+}
+
+function isOpenAiApi(target) {
+  return target === "openai-api";
+}
+
 function invalidatePlan() {
   state.planId = null;
   state.plan = null;
@@ -140,15 +148,24 @@ function renderTarget() {
   state.target = selectedTarget();
   invalidatePlan();
 
-  const isOpenAiApi = state.target === "openai-api";
-  element("local-port").value = isOpenAiApi ? "12435" : "14500";
-  element("origins-field").hidden = !isOpenAiApi;
-  element("target-guidance-title").textContent = isOpenAiApi
+  const openAiApi = isOpenAiApi(state.target);
+  const codexChat = isCodexChat(state.target);
+  element("local-port").value = openAiApi
+    ? "12435"
+    : codexChat
+      ? "14501"
+      : "14500";
+  element("origins-field").hidden = !openAiApi;
+  element("target-guidance-title").textContent = openAiApi
     ? "Uses an OpenAI Platform API key"
-    : "Uses the official Codex ChatGPT sign-in";
-  element("target-guidance-detail").textContent = isOpenAiApi
+    : codexChat
+      ? "Uses official Codex ChatGPT sign-in through the experimental Relmio-specific Chat Adapter"
+      : "Uses the official Codex ChatGPT sign-in";
+  element("target-guidance-detail").textContent = openAiApi
     ? "Your Platform key is seeded over stdin into a private Docker volume and is never returned to the browser. A separate local client credential is generated for your apps."
-    : "This runs Codex App Server as its own experimental protocol. It does not translate the ChatGPT session into a generic OpenAI /v1 API and it does not accept direct browser connections.";
+    : codexChat
+      ? "This exposes Relmio-specific HTTP POST /chat for a trusted local backend or development server. It is not OpenAI /v1, has no CORS, and browser bundles must never connect directly."
+      : "This runs Codex App Server as its own experimental protocol. It does not translate the ChatGPT session into a generic OpenAI /v1 API and it does not accept direct browser connections.";
 }
 
 function appendPolicyNotice(container, heading, detail) {
@@ -160,32 +177,43 @@ function appendPolicyNotice(container, heading, detail) {
 }
 
 function renderPlan(plan) {
-  const isOpenAiApi = plan.target === "openai-api";
+  const openAiApi = isOpenAiApi(plan.target);
+  const codexChat = isCodexChat(plan.target);
   element("review-endpoint").textContent = plan.endpoint;
-  element("review-protocol").textContent = isOpenAiApi
+  element("review-protocol").textContent = openAiApi
     ? "OpenAI-compatible HTTP /v1"
-    : "Codex App Server JSON-RPC over WebSocket";
-  element("review-auth").textContent = isOpenAiApi
+    : codexChat
+      ? "Relmio Codex Chat HTTP: POST /chat"
+      : "Codex App Server JSON-RPC over WebSocket";
+  element("review-auth").textContent = openAiApi
     ? "OpenAI Platform API key"
     : "ChatGPT sign-in through official Codex";
-  element("review-browser").textContent = isOpenAiApi
+  element("review-browser").textContent = openAiApi
     ? plan.allowedOrigins.length > 0
       ? `Only ${plan.allowedOrigins.length} exact allowed origin(s)`
       : "Native clients only until exact origins are added"
-    : "No — trusted native local clients only";
-  element("review-origins-row").hidden = !isOpenAiApi;
-  element("review-origins").textContent = isOpenAiApi
+    : codexChat
+      ? "No — trusted local backends and development servers only"
+      : "No — trusted native local clients only";
+  element("review-origins-row").hidden = !openAiApi;
+  element("review-origins").textContent = openAiApi
     ? plan.allowedOrigins.length > 0
       ? plan.allowedOrigins.join(", ")
       : "None"
     : "";
   element("review-path").textContent = plan.managedPath;
 
-  if (isOpenAiApi) {
+  if (openAiApi) {
     appendPolicyNotice(
       element("review-policy"),
       "OpenAI Platform terms and billing apply",
       "This option sends requests to the OpenAI API with your developer Platform key. ChatGPT subscriptions and open-source program benefits do not turn a ChatGPT credential into an API key.",
+    );
+  } else if (codexChat) {
+    appendPolicyNotice(
+      element("review-policy"),
+      "Experimental Codex Chat Adapter — trusted local backends or development servers only",
+      "This option runs a small authenticated Relmio HTTP adapter on loopback. It accepts only POST /chat from a trusted local backend or development server. It has no CORS and is not OpenAI /v1. ChatGPT credentials stay in the isolated Codex Docker volume and never become Platform API keys.",
     );
   } else {
     appendPolicyNotice(
@@ -197,18 +225,31 @@ function renderPlan(plan) {
 }
 
 function prepareInstallPanel() {
-  const isOpenAiApi = state.plan.target === "openai-api";
+  const openAiApi = isOpenAiApi(state.plan.target);
+  const codexChat = isCodexChat(state.plan.target);
   const apiKey = element("platform-api-key");
-  element("api-key-field").hidden = !isOpenAiApi;
-  element("codex-install-warning").hidden = isOpenAiApi;
-  apiKey.required = isOpenAiApi;
+  element("api-key-field").hidden = !openAiApi;
+  element("codex-install-warning").hidden = openAiApi;
+  element("codex-install-warning-title").textContent = codexChat
+    ? "Credential for trusted local backends or development servers only"
+    : "High-trust capability";
+  element("codex-install-warning-detail").textContent = codexChat
+    ? "The generated bearer authorizes chat turns through your signed-in Codex container. Keep it only in a trusted local backend or development server; never put it in browser code."
+    : "Anyone holding the generated client credential can control Codex inside its isolated container, act through your signed-in ChatGPT session, and may be able to recover that container's ChatGPT session credential. Treat this capability like your ChatGPT password and give it only to a trusted native local app.";
+  apiKey.required = openAiApi;
   apiKey.value = "";
-  element("install-intro").textContent = isOpenAiApi
+  element("install-intro").textContent = openAiApi
     ? "Enter the OpenAI Platform API key this endpoint will use upstream. It is sent only to this local Relmio process."
-    : "Relmio will install the official Codex App Server first. You will complete ChatGPT device sign-in after the container is ready.";
+    : codexChat
+      ? "Relmio will install the experimental Codex Chat Adapter and official Codex App Server first. You will complete ChatGPT device sign-in after the container is ready."
+      : "Relmio will install the official Codex App Server first. You will complete ChatGPT device sign-in after the container is ready.";
   setButtonLabel(
     element("install-button"),
-    isOpenAiApi ? "Install OpenAI API endpoint" : "Install Codex App Server",
+    openAiApi
+      ? "Install OpenAI API endpoint"
+      : codexChat
+        ? "Install Codex Chat Adapter"
+        : "Install Codex App Server",
   );
 }
 
@@ -216,29 +257,46 @@ function renderInstallResult(result) {
   if (
     typeof result.endpoint !== "string" ||
     typeof result.clientCredential !== "string" ||
-    !["openai-api", "codex-chatgpt"].includes(result.target)
+    !["openai-api", "codex-chatgpt", "codex-chat"].includes(result.target)
   ) {
     throw new Error("The local installer returned an unexpected response.");
   }
 
-  const isOpenAiApi = result.target === "openai-api";
+  const openAiApi = isOpenAiApi(result.target);
+  const codexChat = isCodexChat(result.target);
   state.installedTarget = result.target;
   element("result-endpoint").textContent = result.endpoint;
   element("result-credential").textContent = result.clientCredential;
-  element("codex-production-warning").hidden = isOpenAiApi;
-  element("codex-login").hidden = isOpenAiApi;
-  element("done-title").textContent = isOpenAiApi
+  element("codex-production-warning").hidden = openAiApi;
+  element("codex-login").hidden = openAiApi;
+  element("codex-production-warning-title").textContent = codexChat
+    ? "Experimental Chat Adapter — trusted local backends or development servers only"
+    : "Experimental WebSocket transport";
+  element("codex-production-warning-detail").textContent = codexChat
+    ? "The adapter is for trusted local backends or development servers only. It has a Relmio-specific POST /chat contract, no CORS, and is not OpenAI /v1."
+    : "Codex App Server WebSocket is experimental and unsupported for production workloads.";
+  element("done-title").textContent = openAiApi
     ? "OpenAI API endpoint is ready"
-    : "Codex App Server is installed";
-  element("done-detail").textContent = isOpenAiApi
+    : codexChat
+      ? "Codex Chat Adapter is installed"
+      : "Codex App Server is installed";
+  element("done-detail").textContent = openAiApi
     ? "Copy the endpoint and generated bearer credential into your local app."
-    : "Copy the endpoint and capability, then sign the isolated Codex container in to ChatGPT.";
+    : codexChat
+      ? "Copy the endpoint and generated bearer credential into your trusted local backend or development server, then sign the isolated Codex container in to ChatGPT."
+      : "Copy the endpoint and capability, then sign the isolated Codex container in to ChatGPT.";
   appendPolicyNotice(
     element("client-warning"),
-    isOpenAiApi ? "For local OpenAI-compatible clients" : "For trusted native Codex clients only",
-    isOpenAiApi
+    openAiApi
+      ? "For local OpenAI-compatible clients"
+      : codexChat
+        ? "For trusted local backends or development servers only"
+        : "For trusted native Codex clients only",
+    openAiApi
       ? "Use the generated client credential as the bearer API key. Your upstream Platform key remains private in the managed Docker volume."
-      : "This capability is not an OpenAI API key. Treat it like your ChatGPT password: the client is trusted to control the isolated container and may recover its ChatGPT session credential. It must speak official Codex App Server JSON-RPC over WebSocket.",
+      : codexChat
+        ? "Use this one-time credential only as a Bearer token for the Relmio-specific POST /chat endpoint. It is not an OpenAI API key, has no browser CORS support, and must remain in a trusted local backend or development server."
+        : "This capability is not an OpenAI API key. Treat it like your ChatGPT password: the client is trusted to control the isolated container and may recover its ChatGPT session credential. It must speak official Codex App Server JSON-RPC over WebSocket.",
   );
 }
 
@@ -432,7 +490,9 @@ element("install-button").addEventListener("click", async (event) => {
     setMessage(
       result.target === "openai-api"
         ? "Local OpenAI API endpoint verified. Copy its one-time client credential now."
-        : "Codex App Server verified. Copy its one-time capability and complete ChatGPT sign-in.",
+        : result.target === "codex-chat"
+          ? "Codex Chat Adapter for trusted local backends or development servers verified. Copy its one-time bearer and complete ChatGPT sign-in."
+          : "Codex App Server verified. Copy its one-time capability and complete ChatGPT sign-in.",
     );
   } catch (error) {
     invalidatePlan();
@@ -494,7 +554,7 @@ element("codex-login-button").addEventListener("click", async (event) => {
   try {
     const result = await api("/api/local/codex/login", {
       method: "POST",
-      body: {},
+      body: { target: state.installedTarget },
     });
     const verificationUrl = validateVerificationUrl(result.verificationUrl);
     const userCode = validateDeviceCode(result.userCode);
@@ -504,7 +564,9 @@ element("codex-login-button").addEventListener("click", async (event) => {
     resultBox.hidden = false;
     setMessage("Open the official OpenAI page and enter the displayed device code.");
     await waitForCodexLogin();
-    status.textContent = "ChatGPT sign-in completed. Codex is ready for your trusted native client.";
+    status.textContent = isCodexChat(state.installedTarget)
+      ? "ChatGPT sign-in completed. Codex Chat Adapter is ready for your trusted local backend or development server."
+      : "ChatGPT sign-in completed. Codex is ready for your trusted native client.";
     setMessage("Codex ChatGPT sign-in completed successfully.");
   } catch (error) {
     status.textContent = "ChatGPT sign-in did not complete.";

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -776,6 +776,10 @@ async function handleApi(request, response, path, state) {
       );
     }
 
+    const target = validateLocalTarget(body?.target ?? "codex-chatgpt");
+    if (target !== "codex-chatgpt" && target !== "codex-chat") {
+      throw new Error("Choose a Codex local endpoint before signing in.");
+    }
     state.codexLoginStartInFlight = true;
     let finishStart;
     const startPromise = new Promise((resolvePromise) => {
@@ -802,7 +806,7 @@ async function handleApi(request, response, path, state) {
       }
 
       releaseChangeLock = await state.services.acquireLocalEndpointChangeLock({
-        target: "codex-chatgpt",
+        target,
       });
       if (state.closing) {
         throw Object.assign(new Error("The local wizard is closing."), {
@@ -810,11 +814,12 @@ async function handleApi(request, response, path, state) {
         });
       }
       const installDirectory = await state.services.resolveLocalInstallRoot({
-        target: "codex-chatgpt",
+        target,
       });
       const { dockerHost, projectName } =
         await state.services.attestLocalCodexInstallation({
           installDirectory,
+          ...(target === "codex-chat" ? { target } : {}),
         });
 
       const attempt = await state.services.startCodexDeviceLogin({
@@ -847,7 +852,10 @@ async function handleApi(request, response, path, state) {
             return;
           }
           await state.services.restartLocalCodex(
-            { installDirectory },
+            {
+              installDirectory,
+              ...(target === "codex-chat" ? { target } : {}),
+            },
             { changeLockHeld: true },
           );
           if (state.codexLogin === login && !state.closing) {

--- a/test/codex-chat.test.js
+++ b/test/codex-chat.test.js
@@ -1,0 +1,713 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { request } from "node:http";
+import test from "node:test";
+
+import {
+  hashCodexChatCredential,
+  loadCodexChatGatewayConfig,
+  startCodexChatGateway,
+} from "../src/gateway/codex-chat.js";
+
+const clientCredential = "TEST_REL_MIO_CODEX_CHAT_CLIENT_CREDENTIAL_0123456789";
+
+test("Codex Chat entrypoint accepts only an explicit verifier and literal listener settings", () => {
+  assert.deepEqual(
+    loadCodexChatGatewayConfig({
+      RELMIO_GATEWAY_HOST: "0.0.0.0",
+      RELMIO_GATEWAY_PORT: "14501",
+      RELMIO_GATEWAY_TOKEN_SHA256: hashCodexChatCredential(clientCredential).toString("hex"),
+      RELMIO_PACKAGE_VERSION: "0.5.0",
+    }),
+    {
+      host: "0.0.0.0",
+      packageVersion: "0.5.0",
+      port: 14501,
+      tokenVerifier: hashCodexChatCredential(clientCredential),
+    },
+  );
+  for (const environment of [
+    {},
+    {
+      RELMIO_GATEWAY_HOST: "example.test",
+      RELMIO_GATEWAY_PORT: "14501",
+      RELMIO_GATEWAY_TOKEN_SHA256: "a".repeat(64),
+      RELMIO_PACKAGE_VERSION: "0.5.0",
+    },
+    {
+      RELMIO_GATEWAY_HOST: "0.0.0.0",
+      RELMIO_GATEWAY_PORT: "14501;id",
+      RELMIO_GATEWAY_TOKEN_SHA256: "a".repeat(64),
+      RELMIO_PACKAGE_VERSION: "0.5.0",
+    },
+  ]) {
+    assert.throws(() => loadCodexChatGatewayConfig(environment), /Codex Chat/i);
+  }
+});
+
+function createCompletingAppServer({
+  activePermissionProfile = {
+    extends: ":read-only",
+    id: "relmio-chat-readonly",
+  },
+  delta = "draft output",
+  finalText = "Final answer",
+  includeCompletedItem = true,
+  turnItems = [],
+  turnStatus = "completed",
+} = {}) {
+  const messages = [];
+  const signals = [];
+  const child = new EventEmitter();
+  child.stdin = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin.end = () => {};
+  child.kill = (signal) => {
+    signals.push(signal);
+    queueMicrotask(() => child.emit("close", 0, signal));
+    return true;
+  };
+  child.stdin.write = (wire) => {
+    const message = JSON.parse(wire);
+    messages.push(message);
+    queueMicrotask(() => {
+      if (message.method === "initialize") {
+        child.stdout.emit("data", Buffer.from('{"id":0,"result":{}}\n'));
+      } else if (
+        message.method === "thread/start" ||
+        message.method === "thread/resume"
+      ) {
+        child.stdout.emit(
+          "data",
+          Buffer.from(
+            `${JSON.stringify({
+              id: message.id,
+              result: {
+                activePermissionProfile,
+                thread: { id: "thread_123" },
+              },
+            })}\n`,
+          ),
+        );
+        child.stdout.emit(
+          "data",
+          Buffer.from(
+            '{"method":"thread/started","params":{"thread":{"id":"thread_123"}}}\n',
+          ),
+        );
+      } else if (message.method === "turn/start") {
+        child.stdout.emit(
+          "data",
+          Buffer.from(`{\"id\":${message.id},\"result\":{\"turn\":{\"id\":\"turn_123\"}}}\n`),
+        );
+        child.stdout.emit(
+          "data",
+          Buffer.from(
+            '{"method":"turn/started","params":{"threadId":"thread_123","turn":{"id":"turn_123","status":"inProgress","items":[]}}}\n',
+          ),
+        );
+        for (const deltaEntry of Array.isArray(delta) ? delta : [delta]) {
+          const deltaPart = typeof deltaEntry === "object"
+            ? deltaEntry.text
+            : deltaEntry;
+          const itemId = typeof deltaEntry === "object"
+            ? deltaEntry.itemId
+            : "item_123";
+          if (deltaPart === null) {
+            continue;
+          }
+          child.stdout.emit(
+            "data",
+            Buffer.from(`${JSON.stringify({
+              method: "item/agentMessage/delta",
+              params: {
+                threadId: "thread_123",
+                turnId: "turn_123",
+                itemId,
+                delta: deltaPart,
+              },
+            })}\n`),
+          );
+        }
+        if (includeCompletedItem) {
+          child.stdout.emit(
+            "data",
+            Buffer.from(`${JSON.stringify({
+              method: "item/completed",
+              params: {
+                threadId: "thread_123",
+                turnId: "turn_123",
+                completedAtMs: 1,
+                item: { id: "item_123", type: "agentMessage", text: finalText },
+              },
+            })}\n`),
+          );
+        }
+        child.stdout.emit(
+          "data",
+          Buffer.from(`${JSON.stringify({
+            method: "turn/completed",
+            params: {
+              threadId: "thread_123",
+              turn: { id: "turn_123", status: turnStatus, items: turnItems },
+            },
+          })}\n`),
+        );
+      }
+    });
+    return true;
+  };
+  return { child, messages, signals };
+}
+
+function rawRequest(origin, { body, headers = {}, method = "GET", path = "/health" }) {
+  const url = new URL(origin);
+  return new Promise((resolvePromise, rejectPromise) => {
+    const pending = request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path,
+        method,
+        headers,
+      },
+      (response) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        response.on("end", () => {
+          resolvePromise({
+            body: JSON.parse(Buffer.concat(chunks).toString("utf8")),
+            status: response.statusCode,
+          });
+        });
+      },
+    );
+    pending.once("error", rejectPromise);
+    if (body !== undefined) {
+      pending.write(body);
+    }
+    pending.end();
+  });
+}
+
+function authenticatedHeaders() {
+  return {
+    Authorization: `Bearer ${clientCredential}`,
+    "Content-Type": "application/json",
+  };
+}
+
+function createStallingAppServer() {
+  const child = new EventEmitter();
+  child.stdin = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin.write = () => true;
+  child.stdin.end = () => {};
+  child.signals = [];
+  child.kill = (signal) => {
+    child.signals.push(signal);
+    queueMicrotask(() => child.emit("close", 0, signal));
+    return true;
+  };
+  return child;
+}
+
+test("Codex Chat health is public while chat requires its dedicated bearer credential", async (t) => {
+  let spawnCalls = 0;
+  const gateway = await startCodexChatGateway({
+    host: "127.0.0.1",
+    port: 0,
+    tokenVerifier: hashCodexChatCredential(clientCredential),
+    spawnProcess() {
+      spawnCalls += 1;
+      throw new Error("chat must not start for health or rejected requests");
+    },
+  });
+  t.after(() => gateway.close());
+
+  const health = await fetch(`${gateway.origin}/health`);
+  assert.equal(health.status, 200);
+  assert.deepEqual(await health.json(), { status: "ok" });
+  assert.equal(health.headers.get("cache-control"), "no-store");
+  assert.equal(health.headers.get("x-content-type-options"), "nosniff");
+
+  const unauthenticatedProbe = await fetch(
+    `${gateway.origin}/auth/verify`,
+  );
+  assert.equal(unauthenticatedProbe.status, 401);
+  const authenticatedProbe = await fetch(`${gateway.origin}/auth/verify`, {
+    headers: { Authorization: `Bearer ${clientCredential}` },
+  });
+  assert.equal(authenticatedProbe.status, 200);
+  assert.deepEqual(await authenticatedProbe.json(), { status: "ok" });
+
+  const rejected = await fetch(`${gateway.origin}/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ input: "Hello" }),
+  });
+  assert.equal(rejected.status, 401);
+  assert.deepEqual(await rejected.json(), { error: { code: "unauthorized" } });
+
+  const browser = await fetch(`${gateway.origin}/chat`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${clientCredential}`,
+      "Content-Type": "application/json",
+      Origin: "https://example.test",
+    },
+    body: JSON.stringify({ input: "Hello" }),
+  });
+  assert.equal(browser.status, 403);
+  assert.deepEqual(await browser.json(), { error: { code: "origin_rejected" } });
+
+  const badHost = await rawRequest(gateway.origin, {
+    headers: { Host: "example.test" },
+  });
+  assert.deepEqual(badHost, {
+    body: { error: { code: "host_rejected" } },
+    status: 421,
+  });
+  const unknownWithoutCredential = await fetch(`${gateway.origin}/unknown`);
+  assert.equal(unknownWithoutCredential.status, 401);
+  const unknownWithCredential = await fetch(`${gateway.origin}/unknown`, {
+    headers: { Authorization: `Bearer ${clientCredential}` },
+  });
+  assert.equal(unknownWithCredential.status, 404);
+  assert.equal(spawnCalls, 0);
+});
+
+test("Codex Chat rejects malformed, unexpected, and oversized request bodies before spawning", async (t) => {
+  let spawnCalls = 0;
+  const gateway = await startCodexChatGateway({
+    host: "127.0.0.1",
+    port: 0,
+    tokenVerifier: hashCodexChatCredential(clientCredential),
+    spawnProcess() {
+      spawnCalls += 1;
+      throw new Error("invalid requests must not spawn");
+    },
+  });
+  t.after(() => gateway.close());
+
+  for (const [body, expectedCode] of [
+    ["{", "invalid_json"],
+    [JSON.stringify({ input: "Hello", extra: true }), "invalid_request"],
+    [JSON.stringify({ input: "x".repeat(17 * 1024) }), "invalid_request"],
+  ]) {
+    const response = await fetch(`${gateway.origin}/chat`, {
+      method: "POST",
+      headers: authenticatedHeaders(),
+      body,
+    });
+    assert.equal(response.status, body.length > 16 * 1024 ? 413 : 400);
+    assert.deepEqual(await response.json(), { error: { code: expectedCode } });
+  }
+  assert.equal(spawnCalls, 0);
+});
+
+test("Codex Chat starts a read-only conversation and returns the completed agent message", async (t) => {
+  const appServer = createCompletingAppServer();
+  const spawnCalls = [];
+  const gateway = await startCodexChatGateway({
+    host: "127.0.0.1",
+    port: 0,
+    packageVersion: "0.5.0",
+    tokenVerifier: hashCodexChatCredential(clientCredential),
+    spawnProcess(...args) {
+      spawnCalls.push(args);
+      return appServer.child;
+    },
+  });
+  t.after(() => gateway.close());
+
+  const response = await fetch(`${gateway.origin}/chat`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${clientCredential}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ input: "What is a semaphore?" }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    conversationId: "thread_123",
+    output: "Final answer",
+  });
+  assert.deepEqual(spawnCalls[0].slice(0, 2), [
+    "codex",
+    ["app-server", "--strict-config", "--stdio"],
+  ]);
+  assert.deepEqual(appServer.messages.map((message) => message.method), [
+    "initialize",
+    "initialized",
+    "thread/start",
+    "turn/start",
+  ]);
+  assert.deepEqual(appServer.messages[0].params.clientInfo, {
+    name: "relmio",
+    title: "Relmio",
+    version: "0.5.0",
+  });
+  assert.deepEqual(appServer.messages[0].params.capabilities, {
+    experimentalApi: true,
+  });
+  assert.deepEqual(appServer.messages[2].params, {
+    approvalPolicy: "never",
+    cwd: "/workspace",
+    developerInstructions:
+      "Provide a conversational answer only. Do not inspect or edit files, run commands, call tools, or access external resources.",
+    permissions: "relmio-chat-readonly",
+  });
+  assert.deepEqual(appServer.messages[3].params, {
+    approvalPolicy: "never",
+    cwd: "/workspace",
+    input: [{ text: "What is a semaphore?", type: "text" }],
+    permissions: "relmio-chat-readonly",
+    threadId: "thread_123",
+  });
+  assert.deepEqual(appServer.signals, ["SIGTERM"]);
+});
+
+test("Codex Chat resumes only the requested bounded conversation", async (t) => {
+  const appServer = createCompletingAppServer();
+  const gateway = await startCodexChatGateway({
+    host: "127.0.0.1",
+    port: 0,
+    packageVersion: "0.5.0",
+    tokenVerifier: hashCodexChatCredential(clientCredential),
+    spawnProcess() {
+      return appServer.child;
+    },
+  });
+  t.after(() => gateway.close());
+
+  const response = await fetch(`${gateway.origin}/chat`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${clientCredential}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      conversationId: "thread_123",
+      input: "Continue.",
+    }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(appServer.messages[2].method, "thread/resume");
+  assert.deepEqual(appServer.messages[2].params, {
+    approvalPolicy: "never",
+    cwd: "/workspace",
+    developerInstructions:
+      "Provide a conversational answer only. Do not inspect or edit files, run commands, call tools, or access external resources.",
+    permissions: "relmio-chat-readonly",
+    threadId: "thread_123",
+  });
+});
+
+test("Codex Chat prefers item completion, keeps delta item IDs separate, and bounds output", async (t) => {
+  const fixtures = [
+    {
+      appServer: createCompletingAppServer({
+        delta: "draft",
+        finalText: "intermediate",
+        turnItems: [{ type: "agentMessage", text: "authoritative" }],
+      }),
+      expected: { status: 200, output: "intermediate" },
+    },
+    {
+      appServer: createCompletingAppServer({
+        delta: ["bounded ", "fallback"],
+        includeCompletedItem: false,
+      }),
+      expected: { status: 200, output: "bounded fallback" },
+    },
+    {
+      appServer: createCompletingAppServer({
+        delta: [
+          { itemId: "old_item", text: "old" },
+          { itemId: "new_item", text: "new" },
+        ],
+        includeCompletedItem: false,
+      }),
+      expected: { status: 200, output: "new" },
+    },
+    {
+      appServer: createCompletingAppServer({
+        delta: [
+          { itemId: "first_item", text: "one" },
+          { itemId: "second_item", text: "two" },
+          { itemId: "first_item", text: "three" },
+        ],
+        includeCompletedItem: false,
+      }),
+      expected: { status: 200, output: "onethree" },
+    },
+    {
+      appServer: createCompletingAppServer({ turnStatus: "failed" }),
+      expected: { status: 503 },
+    },
+    {
+      appServer: createCompletingAppServer({
+        activePermissionProfile: {
+          extends: ":read-only",
+          id: ":read-only",
+        },
+      }),
+      expected: { status: 503 },
+    },
+    {
+      appServer: createCompletingAppServer({
+        delta: Array.from({ length: 3 }, () => "x".repeat(50 * 1024)),
+        includeCompletedItem: false,
+      }),
+      expected: { status: 503 },
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const gateway = await startCodexChatGateway({
+      host: "127.0.0.1",
+      port: 0,
+      tokenVerifier: hashCodexChatCredential(clientCredential),
+      spawnProcess() {
+        return fixture.appServer.child;
+      },
+    });
+    const response = await fetch(`${gateway.origin}/chat`, {
+      method: "POST",
+      headers: authenticatedHeaders(),
+      body: JSON.stringify({ input: "Hello" }),
+    });
+    assert.equal(response.status, fixture.expected.status);
+    const payload = await response.json();
+    if (fixture.expected.output) {
+      assert.equal(payload.output, fixture.expected.output);
+    } else {
+      assert.deepEqual(payload, { error: { code: "unavailable" } });
+    }
+    await gateway.close();
+  }
+});
+
+test("Codex Chat contains child stdio errors behind a generic failure", async () => {
+  for (const streamName of ["stdin", "stdout", "stderr"]) {
+    const child = createStallingAppServer();
+    const gateway = await startCodexChatGateway({
+      host: "127.0.0.1",
+      port: 0,
+      tokenVerifier: hashCodexChatCredential(clientCredential),
+      spawnProcess() {
+        queueMicrotask(() => {
+          child[streamName].emit("error", new Error("sensitive pipe detail"));
+        });
+        return child;
+      },
+    });
+    const response = await fetch(`${gateway.origin}/chat`, {
+      method: "POST",
+      headers: authenticatedHeaders(),
+      body: JSON.stringify({ input: "Hello" }),
+    });
+    assert.equal(response.status, 503);
+    const text = await response.text();
+    assert.equal(text.includes("sensitive"), false);
+    assert.deepEqual(JSON.parse(text), { error: { code: "unavailable" } });
+    await gateway.close();
+  }
+});
+
+test("Codex Chat rejects an overlong App Server protocol line without exposing it", async (t) => {
+  const child = createStallingAppServer();
+  child.stdin.write = () => {
+    queueMicrotask(() => child.stdout.emit("data", Buffer.alloc(65 * 1024, 0x78)));
+    return true;
+  };
+  const gateway = await startCodexChatGateway({
+    host: "127.0.0.1",
+    port: 0,
+    tokenVerifier: hashCodexChatCredential(clientCredential),
+    spawnProcess() {
+      return child;
+    },
+  });
+  t.after(() => gateway.close());
+
+  const response = await fetch(`${gateway.origin}/chat`, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+    body: JSON.stringify({ input: "Hello" }),
+  });
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), { error: { code: "unavailable" } });
+});
+
+test("Codex Chat permits only one active turn and cleans up a disconnected client", async (t) => {
+  const child = createStallingAppServer();
+  let markSpawned;
+  const spawned = new Promise((resolvePromise) => {
+    markSpawned = resolvePromise;
+  });
+  const gateway = await startCodexChatGateway({
+    host: "127.0.0.1",
+    port: 0,
+    tokenVerifier: hashCodexChatCredential(clientCredential),
+    spawnProcess() {
+      markSpawned();
+      return child;
+    },
+  });
+  t.after(() => gateway.close());
+
+  const controller = new AbortController();
+  const first = fetch(`${gateway.origin}/chat`, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+    body: JSON.stringify({ input: "First" }),
+    signal: controller.signal,
+  }).catch((error) => error);
+  await spawned;
+  const second = await fetch(`${gateway.origin}/chat`, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+    body: JSON.stringify({ input: "Second" }),
+  });
+  assert.equal(second.status, 429);
+  assert.deepEqual(await second.json(), { error: { code: "busy" } });
+
+  controller.abort();
+  await first;
+  for (let attempt = 0; attempt < 10 && child.signals.length === 0; attempt += 1) {
+    await new Promise((resolvePromise) => setImmediate(resolvePromise));
+  }
+  assert.deepEqual(child.signals, ["SIGTERM"]);
+});
+
+test("Codex Chat bounds a stalled App Server turn and returns only a generic failure", async (t) => {
+  const child = createStallingAppServer();
+  const gateway = await startCodexChatGateway({
+    host: "127.0.0.1",
+    port: 0,
+    packageVersion: "0.5.0",
+    tokenVerifier: hashCodexChatCredential(clientCredential),
+    turnTimeoutMs: 5,
+    spawnProcess() {
+      return child;
+    },
+  });
+  t.after(() => gateway.close());
+
+  const response = await fetch(`${gateway.origin}/chat`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${clientCredential}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ input: "Hello" }),
+  });
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), { error: { code: "unavailable" } });
+  assert.deepEqual(child.signals, ["SIGTERM"]);
+});
+
+test("Codex Chat holds its concurrency slot until the terminated child closes", async (t) => {
+  const child = createStallingAppServer();
+  child.kill = (signal) => {
+    child.signals.push(signal);
+    if (signal === "SIGKILL") {
+      queueMicrotask(() => child.emit("close", 0, signal));
+    }
+    return true;
+  };
+  const gateway = await startCodexChatGateway({
+    host: "127.0.0.1",
+    port: 0,
+    tokenVerifier: hashCodexChatCredential(clientCredential),
+    terminationGraceMs: 30,
+    turnTimeoutMs: 5,
+    spawnProcess() {
+      return child;
+    },
+  });
+  t.after(() => gateway.close());
+
+  const first = fetch(`${gateway.origin}/chat`, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+    body: JSON.stringify({ input: "First" }),
+  });
+  for (let attempt = 0; attempt < 20 && child.signals.length === 0; attempt += 1) {
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 1));
+  }
+  assert.deepEqual(child.signals, ["SIGTERM"]);
+  const second = await fetch(`${gateway.origin}/chat`, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+    body: JSON.stringify({ input: "Second" }),
+  });
+  assert.equal(second.status, 429);
+  assert.equal((await first).status, 503);
+  assert.deepEqual(child.signals, ["SIGTERM", "SIGKILL"]);
+});
+
+test("Codex Chat escalates an unresponsive App Server from SIGTERM to SIGKILL", async (t) => {
+  const child = createStallingAppServer();
+  child.kill = (signal) => {
+    child.signals.push(signal);
+    if (signal === "SIGKILL") {
+      queueMicrotask(() => child.emit("close", 0, signal));
+    }
+    return true;
+  };
+  const gateway = await startCodexChatGateway({
+    host: "127.0.0.1",
+    port: 0,
+    tokenVerifier: hashCodexChatCredential(clientCredential),
+    terminationGraceMs: 5,
+    turnTimeoutMs: 5,
+    spawnProcess() {
+      return child;
+    },
+  });
+  t.after(() => gateway.close());
+
+  const response = await fetch(`${gateway.origin}/chat`, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+    body: JSON.stringify({ input: "Hello" }),
+  });
+  assert.equal(response.status, 503);
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, 15));
+  assert.deepEqual(child.signals, ["SIGTERM", "SIGKILL"]);
+});
+
+test("Codex Chat returns after a bounded wait when SIGKILL cannot be reaped", async (t) => {
+  const child = createStallingAppServer();
+  child.kill = (signal) => {
+    child.signals.push(signal);
+    return true;
+  };
+  const gateway = await startCodexChatGateway({
+    host: "127.0.0.1",
+    port: 0,
+    tokenVerifier: hashCodexChatCredential(clientCredential),
+    terminationGraceMs: 5,
+    turnTimeoutMs: 5,
+    spawnProcess() {
+      return child;
+    },
+  });
+  t.after(() => gateway.close());
+
+  const response = await fetch(`${gateway.origin}/chat`, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+    body: JSON.stringify({ input: "Hello" }),
+  });
+  assert.equal(response.status, 503);
+  assert.deepEqual(child.signals, ["SIGTERM", "SIGKILL"]);
+});

--- a/test/codex-login.test.js
+++ b/test/codex-login.test.js
@@ -13,6 +13,8 @@ const VERIFICATION_URL = "https://auth.openai.com/codex/device";
 const LOCAL_DOCKER_HOST = "unix:///var/run/docker.sock";
 const PROJECT_NAME =
   "relmio-codex-chatgpt-0123456789abcdef0123456789abcdef";
+const ADAPTER_PROJECT_NAME =
+  "relmio-codex-chat-0123456789abcdef0123456789abcdef";
 const CHILD_ENVIRONMENT = Object.freeze({
   PATH: "/usr/bin",
   LANG: "C",
@@ -251,6 +253,25 @@ test("startCodexDeviceLogin pins Docker and waits for initialize before starting
   await assertPromisePending(login.completion);
   closeChild(fixture.child, 0);
   assert.deepEqual(await login.completion, { success: true });
+});
+
+test("Codex Chat login overrides the adapter entrypoint without accepting foreign projects", async () => {
+  const fixture = createSpawnFixture();
+  const login = startLogin(fixture, { projectName: ADAPTER_PROJECT_NAME });
+
+  assert.deepEqual(fixture.calls[0].args.slice(-7), [
+    "--no-deps",
+    "--entrypoint",
+    "codex",
+    "codex-chat",
+    "app-server",
+    "--strict-config",
+    "--stdio",
+  ]);
+  emitDeviceResponse(fixture.child);
+  const attempt = await login;
+  attempt.cancel();
+  await assert.rejects(attempt.completion, /cancelled/i);
 });
 
 test("startCodexDeviceLogin rejects unpinned Docker hosts and foreign project identities", async () => {

--- a/test/documentation.test.js
+++ b/test/documentation.test.js
@@ -103,6 +103,20 @@ test("local endpoint guides document safe standalone client credential rotation"
   );
 });
 
+test("security guidance distinguishes all three local endpoint trust contracts", async () => {
+  const security = await readFile("docs/security.md", "utf8");
+
+  assert.match(security, /every raw Codex WebSocket[\s\S]*every Codex Chat Adapter route except `GET \/health`/u);
+  assert.match(security, /Chat Adapter rejects every request carrying an `Origin` header/u);
+  assert.match(security, /All three long-running endpoint containers/u);
+  assert.match(security, /Each Codex target receives its own private named/u);
+  assert.match(security, /named read-only permission profile with network[\s\S]*disabled/u);
+  assert.match(security, /trusted local backend or development server/u);
+  assert.match(security, /not[\s\S]*`\/v1\/chat\/completions`[\s\S]*`\/v1\/responses`/u);
+  assert.doesNotMatch(security, /Both long-running endpoint containers/u);
+  assert.doesNotMatch(security, /Do not expose either endpoint/u);
+});
+
 test("beginner documentation states the critical safety and product limits", async () => {
   const files = await Promise.all(
     [

--- a/test/local-endpoints.test.js
+++ b/test/local-endpoints.test.js
@@ -4,6 +4,10 @@ import test from "node:test";
 import {
   CODEX_CLI_VERSION,
   LOCAL_TARGETS,
+  createCodexChatComposeFile,
+  createCodexChatConfig,
+  createCodexChatDockerfile,
+  createCodexChatRequirements,
   createCodexComposeFile,
   createCodexConfig,
   createCodexDockerfile,
@@ -23,9 +27,10 @@ import {
 const verifier = "a".repeat(64);
 const installId = "b".repeat(32);
 
-test("local endpoint validation accepts the two explicit provider contracts", () => {
+test("local endpoint validation accepts the explicit provider contracts", () => {
   assert.equal(validateLocalTarget("openai-api"), "openai-api");
   assert.equal(validateLocalTarget("codex-chatgpt"), "codex-chatgpt");
+  assert.equal(validateLocalTarget("codex-chat"), "codex-chat");
   assert.equal(validateLocalPort("12435"), 12435);
   assert.equal(
     validatePlatformApiKey(`sk-${"a".repeat(48)}`),
@@ -143,6 +148,65 @@ test("Codex deployment plan preserves official App Server semantics", () => {
   });
 });
 
+test("Codex Chat has its own loopback HTTP contract and hardened adapter image", () => {
+  const plan = createLocalDeploymentPlan({ target: "codex-chat", port: 14501 });
+  assert.deepEqual(plan, {
+    target: "codex-chat",
+    label: "Codex Chat Adapter",
+    bindHost: "127.0.0.1",
+    port: 14501,
+    endpoint: "http://127.0.0.1:14501",
+    protocol: "relmio-codex-chat-http",
+    upstreamAuth: "chatgpt-via-codex",
+    allowedOrigins: [],
+    browserClients: false,
+    experimental: true,
+    managedPath: "~/.relmio/local/codex-chat",
+  });
+
+  const dockerfile = createCodexChatDockerfile();
+  const config = createCodexChatConfig();
+  const requirements = createCodexChatRequirements();
+  const compose = createCodexChatComposeFile({
+    port: 14501,
+    tokenSha256: verifier,
+    installId,
+  });
+  assert.match(dockerfile, /@openai\/codex@0\.147\.0/);
+  assert.match(dockerfile, /COPY --chown=node:node gateway\.mjs/);
+  assert.match(dockerfile, /ENTRYPOINT \["node", "\/app\/gateway\.mjs"\]/);
+  assert.match(config, /^approval_policy = "never"$/mu);
+  assert.match(config, /^default_permissions = "relmio-chat-readonly"$/mu);
+  assert.match(
+    config,
+    /^\[permissions\.relmio-chat-readonly\]\nextends = ":read-only"$/mu,
+  );
+  assert.match(config, /^\[permissions\.relmio-chat-readonly\.filesystem\]$/mu);
+  assert.match(config, /^":root" = "deny"$/mu);
+  assert.match(config, /^":minimal" = "read"$/mu);
+  assert.match(config, /^":tmpdir" = "deny"$/mu);
+  assert.match(config, /^":slash_tmp" = "deny"$/mu);
+  assert.match(config, /^"\/workspace" = "read"$/mu);
+  assert.match(config, /^"\/home\/node\/\.codex" = "deny"$/mu);
+  assert.match(requirements, /^allowed_approval_policies = \["never"\]$/mu);
+  assert.match(
+    requirements,
+    /^\[allowed_permission_profiles\]\n"relmio-chat-readonly" = true$/mu,
+  );
+  assert.doesNotMatch(requirements, /allowed_approval_policies = \["on-request"\]/u);
+  assert.match(compose, /127\.0\.0\.1:14501:14501/);
+  assert.match(compose, /RELMIO_GATEWAY_TOKEN_SHA256: a{64}/);
+  assert.match(compose, /RELMIO_GATEWAY_HOST: 0\.0\.0\.0/);
+  assert.match(compose, /RELMIO_GATEWAY_PORT: "14501"/);
+  assert.match(compose, /codex-home:\/home\/node\/\.codex/);
+  assert.match(compose, /codex-workspace:\/workspace/);
+  assert.match(compose, /127\.0\.0\.1:14501\/health/);
+  assert.match(compose, /no-new-privileges:true/);
+  assert.match(compose, /cap_drop:\n\s+- ALL/);
+  assert.match(compose, /read_only: true/);
+  assert.doesNotMatch(compose, /0\.0\.0\.0:14501|:::14501|\/var\/run\/docker\.sock|n8n/i);
+});
+
 test("OpenAI gateway Compose uses a private seeded volume without weakening runtime isolation", () => {
   const compose = createOpenAiGatewayComposeFile({
     port: 12435,
@@ -255,6 +319,8 @@ test("Codex image and config pin the official App Server and ChatGPT login", () 
   assert.match(config, /cli_auth_credentials_store = "file"/);
   assert.match(config, /forced_login_method = "chatgpt"/);
   assert.match(config, /^default_permissions = "relmio-workspace"$/m);
+  assert.doesNotMatch(config, /^":root" = "deny"$/mu);
+  assert.doesNotMatch(config, /\/home\/node\/\.codex/u);
   assert.match(config, /\[permissions\.relmio-workspace\]/);
   assert.match(config, /extends = ":workspace"/);
   assert.match(
@@ -306,6 +372,7 @@ test("Codex Compose isolates the official server behind one loopback binding", (
 
 test("local target metadata remains closed and immutable", () => {
   assert.deepEqual(Object.keys(LOCAL_TARGETS).sort(), [
+    "codex-chat",
     "codex-chatgpt",
     "openai-api",
   ]);

--- a/test/local-installer.test.js
+++ b/test/local-installer.test.js
@@ -72,13 +72,21 @@ function createRunner({
     }
     if (args.includes("ps --status running --services")) {
       return {
-        stdout: args.includes("relmio-openai-api") ? "gateway\n" : "codex\n",
+        stdout: args.includes("relmio-openai-api")
+          ? "gateway\n"
+          : args.includes("relmio-codex-chat-")
+            ? "codex-chat\n"
+            : "codex\n",
         stderr: "",
         code: 0,
       };
     }
     if (args.includes("ps --format json")) {
-      const targetPort = args.includes("relmio-openai-api") ? 10_531 : 4_500;
+      const targetPort = args.includes("relmio-openai-api")
+        ? 10_531
+        : args.includes("relmio-codex-chat-")
+          ? 14_501
+          : 4_500;
       return {
         stdout: JSON.stringify({
           Publishers: [
@@ -446,6 +454,67 @@ test("credential rotation recreates and verifies the managed Codex service befor
   assert.deepEqual(verifyCodexCapability.calls, [
     { port: 14500, clientCredential: rotated.clientCredential },
   ]);
+});
+
+test("Codex Chat rotation authenticates the fresh bearer without starting a model turn", async (t) => {
+  const home = await createTestHome(t);
+  const runProcess = createRunner({ publishedPort: 14501 });
+  const fetchImpl = createFetch();
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const randomValues = [
+    Buffer.alloc(32, 4),
+    Buffer.alloc(32, 7),
+    Buffer.alloc(32, 9),
+  ];
+  const randomBytes = () => randomValues.shift();
+  const plan = createLocalDeploymentPlan({
+    target: "codex-chat",
+    port: 14501,
+  });
+  await installLocalEndpoint(
+    { plan, confirmed: true },
+    {
+      env,
+      runProcess,
+      randomBytes,
+      isPortAvailable: async () => true,
+      readCodexChatSource: async () => "export const fixture = true;\n",
+      fetchImpl,
+    },
+  );
+  fetchImpl.calls.length = 0;
+
+  const staged = await prepareLocalClientCredentialRotation(
+    { target: "codex-chat" },
+    { env, runProcess, randomBytes },
+  );
+  const activated = await activateLocalClientCredentialRotation(staged, {
+    env,
+    runProcess,
+    fetchImpl,
+  });
+
+  assert.equal(activated.target, "codex-chat");
+  assert.deepEqual(
+    fetchImpl.calls.map(({ url }) => url),
+    [
+      "http://127.0.0.1:14501/health",
+      "http://127.0.0.1:14501/auth/verify",
+    ],
+  );
+  assert.equal(
+    fetchImpl.calls[1].options.headers.Authorization,
+    `Bearer ${staged.clientCredential}`,
+  );
+  assert.ok(
+    runProcess.calls.some(({ args }) =>
+      args
+        .join(" ")
+        .includes(
+          "up -d --wait --wait-timeout 90 --force-recreate --no-deps codex-chat",
+        ),
+    ),
+  );
 });
 
 test("Codex credential rotation rolls back when the fresh WebSocket capability is rejected", async (t) => {
@@ -1651,6 +1720,68 @@ test("Codex install has no Platform secret and returns native App Server details
   assert.match(requirements, /"relmio-workspace" = true/);
   assert.doesNotMatch(requirements, /allowed_sandbox_modes/);
   assert.equal((await stat(join(installRoot, "requirements.toml"))).mode & 0o777, 0o600);
+});
+
+test("Codex Chat install packages the adapter and verifies only its non-billing readiness route", async (t) => {
+  const home = await createTestHome(t);
+  const runProcess = createRunner({ publishedPort: 14501 });
+  const fetchImpl = createFetch();
+  const env = { RELMIO_HOME: join(home, ".relmio") };
+  const plan = createLocalDeploymentPlan({ target: "codex-chat", port: 14501 });
+
+  const result = await installLocalEndpoint(
+    { plan, confirmed: true },
+    {
+      env,
+      runProcess,
+      randomBytes: () => Buffer.alloc(32, 7),
+      isPortAvailable: async () => true,
+      readCodexChatSource: async () => "export const adapterFixture = true;\n",
+      fetchImpl,
+    },
+  );
+
+  assert.deepEqual(result, {
+    target: "codex-chat",
+    endpoint: "http://127.0.0.1:14501",
+    protocol: "relmio-codex-chat-http",
+    clientCredential: capability,
+    credentialShownOnce: true,
+    models: [],
+    deploymentMode: "installed",
+    experimental: true,
+    browserClients: false,
+  });
+  assert.deepEqual(fetchImpl.calls, [
+    {
+      url: "http://127.0.0.1:14501/health",
+      options: { method: "GET", signal: fetchImpl.calls[0].options.signal },
+    },
+    {
+      url: "http://127.0.0.1:14501/auth/verify",
+      options: {
+        method: "GET",
+        headers: { Authorization: `Bearer ${capability}` },
+        signal: fetchImpl.calls[1].options.signal,
+      },
+    },
+  ]);
+  const installRoot = await resolveLocalInstallRoot({ target: "codex-chat", env });
+  assert.equal(
+    await readFile(join(installRoot, "gateway.mjs"), "utf8"),
+    "export const adapterFixture = true;\n",
+  );
+  const compose = await readFile(join(installRoot, "docker-compose.yml"), "utf8");
+  assert.match(compose, /127\.0\.0\.1:14501:14501/);
+  assert.doesNotMatch(compose, new RegExp(capability));
+  assert.ok(
+    runProcess.calls.some(({ args }) =>
+      args.join(" ").includes("build codex-chat"),
+    ),
+  );
+  assert.ok(
+    fetchImpl.calls.every(({ url }) => !String(url).includes("/v1/models")),
+  );
 });
 
 test("Codex install removes only its exact service when capability authentication fails", async (t) => {

--- a/test/local-server.test.js
+++ b/test/local-server.test.js
@@ -794,6 +794,80 @@ test("a fresh wizard server can sign in an attested existing Codex installation"
   ]);
 });
 
+test("Codex Chat sign-in attests and restarts only the adapter project", async (t) => {
+  const installDirectory = "/Users/fixture/.relmio/local/codex-chat";
+  const projectName = `relmio-codex-chat-${"02".repeat(16)}`;
+  const calls = [];
+  const wizard = await startLocalWizard(t, {
+    async acquireLocalEndpointChangeLock(input) {
+      calls.push(["lock", input]);
+      return async () => calls.push(["unlock"]);
+    },
+    resolveLocalInstallRoot(input) {
+      calls.push(["resolve", input]);
+      return installDirectory;
+    },
+    async attestLocalCodexInstallation(input) {
+      calls.push(["attest", input]);
+      return {
+        dockerHost: "unix:///Users/fixture/.docker/run/docker.sock",
+        projectName,
+      };
+    },
+    async startCodexDeviceLogin(input) {
+      calls.push(["login", input]);
+      return {
+        verificationUrl: "https://auth.openai.com/codex/device",
+        userCode: "CHAT-CODE",
+        completion: Promise.resolve({ success: true }),
+        cancel() {},
+      };
+    },
+    async restartLocalCodex(input, dependencies) {
+      calls.push(["restart", input, dependencies]);
+    },
+  });
+
+  const response = await postJson(wizard, "/api/local/codex/login", {
+    target: "codex-chat",
+  });
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    verificationUrl: "https://auth.openai.com/codex/device",
+    userCode: "CHAT-CODE",
+  });
+  for (
+    let attempt = 0;
+    attempt < 10 && !calls.some(([name]) => name === "unlock");
+    attempt += 1
+  ) {
+    await new Promise((resolvePromise) => setImmediate(resolvePromise));
+  }
+  assert.deepEqual(calls, [
+    ["lock", { target: "codex-chat" }],
+    ["resolve", { target: "codex-chat" }],
+    ["attest", { installDirectory, target: "codex-chat" }],
+    [
+      "login",
+      {
+        installDirectory,
+        dockerHost: "unix:///Users/fixture/.docker/run/docker.sock",
+        projectName,
+      },
+    ],
+    [
+      "restart",
+      { installDirectory, target: "codex-chat" },
+      { changeLockHeld: true },
+    ],
+    ["unlock"],
+  ]);
+  assert.deepEqual(
+    await (await api(wizard, "/api/local/codex/login/status")).json(),
+    { status: "success" },
+  );
+});
+
 test("Codex sign-in rejects a concurrent start and releases its start lock", async (t) => {
   const installDirectory = "/Users/fixture/.relmio/local/codex-chatgpt";
   let releaseFirstAttestation;

--- a/test/local-ui.test.js
+++ b/test/local-ui.test.js
@@ -130,12 +130,63 @@ test("local wizard shows Codex WebSocket production limits before and after inst
   );
   assert.match(
     html,
-    /data-step="4"[\s\S]*id="codex-production-warning"[\s\S]*Codex App Server WebSocket is experimental and unsupported for production workloads/u,
+    /data-step="4"[\s\S]*id="codex-production-warning"[\s\S]*id="codex-production-warning-detail"/u,
   );
   assert.match(
     script,
-    /element\("codex-production-warning"\)\.hidden = isOpenAiApi/u,
+    /Codex App Server WebSocket is experimental and unsupported for production workloads/u,
   );
+});
+
+test("local wizard presents Codex Chat as an experimental server-side HTTP adapter", async () => {
+  const [html, script] = await Promise.all([
+    readFile("src/ui/local.html", "utf8"),
+    readFile("src/ui/local.js", "utf8"),
+  ]);
+
+  assert.match(html, /name="target" value="codex-chat"/u);
+  assert.match(html, /Codex Chat Adapter/u);
+  assert.match(html, /Relmio-specific authenticated <code>POST \/chat<\/code>/u);
+  assert.match(html, /browser bundles[\s\S]*must never connect/u);
+  assert.match(
+    html,
+    /trusted local backends or development servers only/u,
+  );
+  assert.match(script, /return target === "codex-chat"/u);
+  assert.match(script, /\? "14501"/u);
+  assert.match(script, /Relmio Codex Chat HTTP: POST \/chat/u);
+  assert.match(script, /no CORS/u);
+  assert.match(
+    script,
+    /Credential for trusted local backends or development servers only/u,
+  );
+  assert.match(
+    script,
+    /Experimental Codex Chat Adapter — trusted local backends or development servers only/u,
+  );
+  assert.match(
+    script,
+    /Experimental Chat Adapter — trusted local backends or development servers only/u,
+  );
+  assert.match(
+    script,
+    /Codex Chat Adapter for trusted local backends or development servers verified/u,
+  );
+  assert.match(
+    script,
+    /Keep it only in a trusted local backend or development server; never put it in browser code/u,
+  );
+  assert.match(
+    script,
+    /ready for your trusted local backend or development server/u,
+  );
+  assert.doesNotMatch(script, /trusted server-side (?:app|client)/iu);
+  assert.doesNotMatch(
+    script,
+    /Codex Chat[^\n]*(?:native process)|adapter is for[^\n]*native process/iu,
+  );
+  assert.match(script, /body: \{ target: state\.installedTarget \}/u);
+  assert.match(script, /\["openai-api", "codex-chatgpt", "codex-chat"\]/u);
 });
 
 test("local wizard clearly excludes native Windows", async () => {
@@ -221,6 +272,11 @@ test("local wizard calls only the dedicated local API contract", async () => {
   assert.match(script, /result\.userCode/u);
   assert.match(script, /recover that container's ChatGPT session credential/u);
   assert.match(script, /Treat it like your ChatGPT password/u);
+  assert.match(script, /trusted local backends and development servers only/u);
+  assert.match(
+    script,
+    /Codex Chat Adapter for trusted local backends or development servers verified/u,
+  );
   assert.doesNotMatch(script, /\/api\/oauth\/login/u);
   assert.doesNotMatch(script, /\/api\/install["']/u);
 });

--- a/test/package-contents.test.js
+++ b/test/package-contents.test.js
@@ -63,6 +63,7 @@ const expectedPackedFiles = new Set([
   "src/domain/templates.js",
   "src/domain/validation.js",
   "src/domain/local-endpoints.js",
+  "src/gateway/codex-chat.js",
   "src/gateway/openai.js",
   "src/infrastructure/local-process.js",
   "src/infrastructure/ssh.js",


### PR DESCRIPTION
## Outcome

Adds an experimental loopback-only HTTP chat adapter for trusted local backends and development servers. It uses the official pinned Codex App Server with ChatGPT device-code sign-in while keeping the raw Codex WebSocket and Platform-key `/v1` paths separate.

Also restores persistent theme/support controls in the local wizard, fixes notification wrapping, and adds client credential rotation.

## Baseline and scope

- Base: `origin/main` at `3f395cbaf6eacd5dcf3358f5258ebb2d1e8ceb2c`
- Candidate: `b63a94642cd77a872153f1d0a2a008f42cd78551`
- Version remains `0.5.0`; this is a merge-only change with no publication.

## Delivery-surface applicability

- `README.md`, `npm/README.md`, `CHANGELOG.md`, local endpoint guides/security/architecture: updated.
- npm package contents: applicable; package preview includes `src/gateway/codex-chat.js` and 69 allowed files.
- `web/**` and Vercel: not applicable; no web paths changed.
- `web/public/install.*` and installers: not applicable; no bootstrap/runtime/entrypoint changes.
- Homebrew/distribution metadata: not applicable; no version, artifact layout, or package-manager changes.
- Screenshots: not required; the existing local-wizard structure is retained and browser QA covered dark/light and narrow layouts.

## Verification

- Astral Sol review: `VERDICT: SHIP`, no findings.
- Opera GX UI QA: dark/light theme, notification wrapping, support controls, and Codex Chat card checked.
- `npm run check`: 312 tests, 306 passed, 6 expected Windows-only skips, 0 failed; lint and release metadata passed.
- `npm audit --audit-level=high`: 0 vulnerabilities.
- `npm pack --dry-run`: passed, 69 files.
- `git diff --check`: passed.
- staged secret scan: passed.
- published 0.5.0 distribution audit: all required checks passed; WinGet is `NOT-PUBLIC`.

## Security boundary

The adapter binds through Docker only to `127.0.0.1`, requires its own bearer credential, rejects browser `Origin` requests, sends no CORS headers, verifies the exact read-only permission profile, disables model network access, protects the Codex credential store, and returns redacted bounded errors. It is not an OpenAI API key and is not an OpenAI-compatible `/v1` endpoint.

## Known limit

The adapter and underlying Codex App Server transport remain experimental and are not intended for production workloads.