### PR TITLE
Release Relmio 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ checks the registry separately after publication.
 
 ## Unreleased
 
+## [0.6.0] - 2026-08-15
+
 ### Added
 
 - Add an experimental loopback-only Codex Chat Adapter for trusted local
@@ -16,15 +18,18 @@ checks the registry separately after publication.
 
 ### Changed
 
-- Make Codex device sign-in target-aware so both the native App Server and the
-  chat adapter retain isolated, persistent ChatGPT credentials.
+- Make Codex device sign-in target-aware so the experimental Relmio `/chat`
+  adapter and native App Server retain isolated, persistent ChatGPT credentials;
+  a Platform API key powers neither target and remains reserved for the generic
+  OpenAI-compatible `/v1` endpoint.
 
 ### Security
 
 - Reject browser-origin adapter requests, keep the adapter separate from
-  OpenAI-compatible `/v1` semantics, explicitly deny model turns access to the
-  private Codex credential store, run chat turns read-only without network
-  access, and preserve loopback-only publication plus credential rotation.
+  Platform-key-backed generic OpenAI-compatible `/v1` semantics, explicitly deny
+  model turns access to the private Codex credential store, run chat turns
+  read-only without network access, and preserve loopback-only publication plus
+  credential rotation.
 
 ## [0.5.0] - 2026-08-15
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relmio",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relmio",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ssh2": "1.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relmio",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Install private local OpenAI API and Codex endpoints with explicit provider credential boundaries, plus the existing isolated n8n sidecar.",
   "keywords": [
     "relmio",


### PR DESCRIPTION
## Release

Prepares Relmio 0.6.0 for the experimental loopback-only Codex Chat Adapter added in PR #39. This is a pre-1.0 minor release because it adds a meaningful new local development capability.

## Exact range

- Published baseline: `v0.5.0` at `3f395cbaf6eacd5dcf3358f5258ebb2d1e8ceb2c`
- Feature merge: `0e16d0db3cebb08d7fba041a95005de91d322c8c`
- Reviewed release head: `4417e0c7ceaa2957e50036f2d7752b01d61899d9`
- Intended version/tag: `0.6.0` / `v0.6.0`

## Provider boundary

ChatGPT sign-in powers the official native Codex App Server and the experimental Relmio-specific `POST /chat` adapter. It is not an OpenAI Platform API key and does not provide a generic OpenAI-compatible `/v1` endpoint. The separate `/v1` gateway continues to require a user-supplied Platform API key.

## Applicability

- npm package/runtime/docs: applicable; adapter and synchronized READMEs were merged in PR #39, and this PR updates release metadata only.
- `README.md` and `npm/README.md`: already synchronized in PR #39; no additional release-only edit needed.
- Installers and hosted wrappers: no source change; live bytes and TTY behavior verified against the baseline.
- Vercel web app: no `web/**` change; CI and production commit verification still required.
- Homebrew: package version changes, so the post-publish formula must be generated from the immutable npm 0.6.0 tarball and applied to the tap.
- Windows assets: package version changes, so x64 and ARM64 release assets must be built and attached by protected automation.
- WinGet: remains `NOT-PUBLIC`; no catalog mutation.

## Verification

- Astral Terra XHigh prepared the three-file metadata candidate.
- Fresh Astral Sol High read-only review: `ship`, no findings.
- `npm run check`: 312 tests, 306 passed, 6 expected platform skips, 0 failed.
- `npm audit --audit-level=high`: 0 vulnerabilities.
- `npm run package:build`: passed.
- `npm pack --dry-run`: passed, 69 files.
- `git diff --check`: passed.
- Staged scope/secret scan: passed.
- Published 0.5.0 distribution audit: every required check passed; WinGet `NOT-PUBLIC`.
- 0.6.0 pre-publication audit: all local/installer/install-page checks passed; only expected unpublished npm, GitHub release/assets, and Homebrew checks are red.

## Publication plan

After protected merge and exact-commit verification: create immutable annotated `v0.6.0`, publish a curated GitHub release, let the protected OIDC workflow publish npm and attach Windows assets, update Homebrew from the exact registry tarball, verify Vercel production, then require a fully green 0.6.0 distribution audit.