### PR TITLE
Redesign Vercel web app with Editorial Console

### DIFF
--- a/web/app/components/ChatConsole.tsx
+++ b/web/app/components/ChatConsole.tsx
@@ -5,9 +5,12 @@ import {
   SignInWithChatGPT,
   type SignInWithChatGPTState,
 } from "@openai-oauth/react";
-import { StatusDot } from "@astryxdesign/core/StatusDot";
-import { Token } from "@astryxdesign/core/Token";
 import { HStack } from "@astryxdesign/core/HStack";
+import { StatusDot } from "@astryxdesign/core/StatusDot";
+import { Text } from "@astryxdesign/core/Text";
+import { Token } from "@astryxdesign/core/Token";
+import { VStack } from "@astryxdesign/core/VStack";
+import { LoaderCircle, SendHorizontal, Square } from "lucide-react";
 import {
   useEffect,
   useRef,
@@ -42,7 +45,7 @@ export function ChatConsole() {
   const [localError, setLocalError] = useState("");
   const [streamPhase, setStreamPhase] = useState("Ready");
   const abortRef = useRef<AbortController | null>(null);
-  const conversationRef = useRef<HTMLDivElement>(null);
+  const conversationRef = useRef<HTMLElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -188,33 +191,34 @@ export function ChatConsole() {
           : "teal";
 
   return (
-    <div className="chat-console">
-      <div className="chat-console-header">
-        <div>
-          <span className="console-kicker">Relmio chat</span>
-          <strong>gpt-5.4-mini</strong>
-        </div>
-        <HStack className="console-statuses" aria-live="polite">
-          <Token
-            label={streamPhase}
-            size="sm"
-            color={phaseColor}
-            endContent={
-              <StatusDot
-                variant={phaseVariant}
-                label={`Response state: ${streamPhase}`}
-                isPulsing={isLoading}
-              />
-            }
-          />
-          <span className={`auth-pill auth-${authStatus}`} aria-live="polite">
-            <i aria-hidden="true" />
-            {statusLabel}
-          </span>
+    <section className="chat-console" aria-label="Hosted chat console">
+      <header className="chat-console-header">
+        <HStack justify="between" align="center" gap={3} wrap="wrap">
+          <VStack gap={0.5}>
+            <Text as="p" className="console-kicker" type="code" color="accent">Relmio chat</Text>
+            <Text as="p" type="label" weight="bold">gpt-5.4-mini</Text>
+          </VStack>
+          <HStack className="console-statuses" aria-live="polite" gap={2} wrap="wrap">
+            <Token
+              label={streamPhase}
+              size="sm"
+              color={phaseColor}
+              endContent={
+                <StatusDot
+                  variant={phaseVariant}
+                  label={`Response state: ${streamPhase}`}
+                  isPulsing={isLoading}
+                />
+              }
+            />
+            <Text className={`auth-pill auth-${authStatus}`} type="supporting" aria-live="polite">
+              {statusLabel}
+            </Text>
+          </HStack>
         </HStack>
-      </div>
+      </header>
 
-      <div className="auth-row">
+      <HStack className="auth-row" gap={3} align="center" wrap="wrap">
         <SignInWithChatGPT
           className="chatgpt-connect"
           loadingLabel="Checking ChatGPT…"
@@ -226,54 +230,49 @@ export function ChatConsole() {
             if (state.status === "error") setLocalError(state.error.message);
           }}
         />
-        <p>Encrypted locally. Sent only with requests you make here.</p>
-      </div>
+        <Text as="p" type="supporting">Encrypted locally. Sent only with requests you make here.</Text>
+      </HStack>
 
-      <div
+      <section
         className="conversation"
         ref={conversationRef}
         aria-live="polite"
         aria-busy={isLoading}
       >
         {!lastPrompt && !completion ? (
-          <div className="conversation-empty">
-            <span aria-hidden="true">⌁</span>
-            <strong>Your private test lane is ready.</strong>
-            <p>Connect ChatGPT, choose a starter, or ask your own question.</p>
-          </div>
+          <VStack className="conversation-empty" gap={2}>
+            <Text as="p" type="label" weight="bold">Your private test lane is ready.</Text>
+            <Text as="p" type="supporting">Connect ChatGPT, choose a starter, or ask your own question.</Text>
+          </VStack>
         ) : (
-          <>
+          <VStack gap={3}>
             {lastPrompt ? (
-              <div className="message message-user">
-                <span>You</span>
-                <p>{lastPrompt}</p>
-              </div>
+              <article className="message message-user">
+                <Text as="span" type="code" color="secondary">You</Text>
+                <Text as="p" type="body">{lastPrompt}</Text>
+              </article>
             ) : null}
             {completion || isLoading ? (
-              <div className={`message message-assistant${isIncomplete ? " message-incomplete" : ""}`}>
-                <span>{isIncomplete ? "Relmio · incomplete" : "Relmio"}</span>
-                <p>
+              <article className={`message message-assistant${isIncomplete ? " message-incomplete" : ""}`}>
+                <Text as="span" type="code" color="accent">{isIncomplete ? "Relmio · incomplete" : "Relmio"}</Text>
+                <Text as="p" type="body">
                   {completion || (
-                    <span
-                      className="typing-dots"
+                    <LoaderCircle
+                      className="typing-indicator"
                       role="status"
                       aria-label={`Relmio is ${streamPhase.toLowerCase()}`}
-                    >
-                      <i />
-                      <i />
-                      <i />
-                    </span>
+                    />
                   )}
-                </p>
-              </div>
+                </Text>
+              </article>
             ) : null}
-          </>
+          </VStack>
         )}
-      </div>
+      </section>
 
-      {localError ? <p className="chat-error" role="alert">{localError}</p> : null}
+      {localError ? <Text as="p" className="chat-error" type="supporting" role="alert">{localError}</Text> : null}
 
-      <div className="suggestion-row" aria-label="Suggested prompts">
+      <section className="suggestion-row" aria-label="Suggested prompts">
         {suggestions.map((suggestion) => (
           <button
             key={suggestion}
@@ -284,42 +283,40 @@ export function ChatConsole() {
             {suggestion}
           </button>
         ))}
-      </div>
+      </section>
 
       <form className="chat-form" onSubmit={handleSubmit}>
-        <div className="form-label-row">
-          <label htmlFor="chat-prompt">Ask anything</label>
-          <span className="input-hint" aria-hidden="true">
-            Enter to send · Shift+Enter for a new line
-          </span>
-        </div>
-        <div>
-          <textarea
-            id="chat-prompt"
-            name="prompt"
-            ref={textareaRef}
-            value={input}
-            onChange={(event) => setInput(event.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Ask Relmio to help with a workflow…"
-            maxLength={3000}
-            rows={1}
-          />
-          {isLoading ? (
-            <button className="send-button stop-button" type="button" onClick={stop} aria-label="Stop response">
-              <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-                <rect x="4" y="4" width="8" height="8" rx="1.5" fill="currentColor" />
-              </svg>
-            </button>
-          ) : (
-            <button className="send-button" type="submit" disabled={!input.trim()} aria-label="Send message">
-              <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-                <path d="M8 12.75v-9.5M3.75 7.5 8 3.25 12.25 7.5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            </button>
-          )}
-        </div>
+        <VStack gap={2}>
+          <HStack className="form-label-row" justify="between" gap={2} wrap="wrap">
+            <label htmlFor="chat-prompt">Ask anything</label>
+            <Text className="input-hint" type="supporting" aria-hidden="true">
+              Enter to send. Shift+Enter for a new line.
+            </Text>
+          </HStack>
+          <HStack className="chat-compose-row" gap={2} align="end">
+            <textarea
+              id="chat-prompt"
+              name="prompt"
+              ref={textareaRef}
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Ask Relmio to help with a workflow…"
+              maxLength={3000}
+              rows={1}
+            />
+            {isLoading ? (
+              <button className="send-button stop-button" type="button" onClick={stop} aria-label="Stop response">
+                <Square aria-hidden="true" />
+              </button>
+            ) : (
+              <button className="send-button" type="submit" disabled={!input.trim()} aria-label="Send message">
+                <SendHorizontal aria-hidden="true" />
+              </button>
+            )}
+          </HStack>
+        </VStack>
       </form>
-    </div>
+    </section>
   );
 }

--- a/web/app/components/CopyCommand.tsx
+++ b/web/app/components/CopyCommand.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import { HStack } from "@astryxdesign/core/HStack";
+import { Text } from "@astryxdesign/core/Text";
+import { VStack } from "@astryxdesign/core/VStack";
+import { Check, Copy } from "lucide-react";
 import {
   type KeyboardEvent,
   useEffect,
@@ -90,9 +94,7 @@ export function CopyCommand() {
       nextIndex = installMethods.length - 1;
     }
 
-    if (nextIndex === null) {
-      return;
-    }
+    if (nextIndex === null) return;
 
     event.preventDefault();
     selectMethod(installMethods[nextIndex]);
@@ -115,21 +117,18 @@ export function CopyCommand() {
     }
 
     setCopiedMethod(method.id);
-    if (revertTimer.current !== null) {
-      window.clearTimeout(revertTimer.current);
-    }
-    revertTimer.current = window.setTimeout(
-      () => setCopiedMethod(null),
-      1800,
-    );
+    if (revertTimer.current !== null) window.clearTimeout(revertTimer.current);
+    revertTimer.current = window.setTimeout(() => setCopiedMethod(null), 1800);
   }
 
   return (
-    <div className="install-method-picker">
-      <div
+    <section className="install-method-picker" aria-label="Installation command selector">
+      <HStack
         className="install-method-tabs"
         role="tablist"
         aria-label="Installation method"
+        aria-orientation="horizontal"
+        gap={0}
       >
         {installMethods.map((method, index) => {
           const selected = selectedMethod === method.id;
@@ -154,14 +153,14 @@ export function CopyCommand() {
             </button>
           );
         })}
-      </div>
+      </HStack>
 
       {installMethods.map((method) => {
         const selected = selectedMethod === method.id;
         const copied = copiedMethod === method.id;
 
         return (
-          <div
+          <section
             key={method.id}
             className="install-method-panel"
             id={`install-method-${method.id}-panel`}
@@ -169,30 +168,28 @@ export function CopyCommand() {
             aria-labelledby={`install-method-${method.id}-tab`}
             hidden={!selected}
           >
-            <button
-              type="button"
-              className={`install-command${copied ? " copied" : ""}`}
-              onClick={() => copy(method)}
-              aria-label={`Copy installation command (${method.label}): ${method.command}`}
-              aria-describedby={`install-method-${method.id}-note`}
-            >
-              <span className="terminal-mark" aria-hidden="true">
-                {method.prompt}
-              </span>
-              <code>{method.command}</code>
-              <span className="copy-hint" role="status" aria-live="polite">
-                {copied ? "Copied" : "Copy"}
-              </span>
-            </button>
-            <p
-              className="install-method-note"
-              id={`install-method-${method.id}-note`}
-            >
-              {method.note}
-            </p>
-          </div>
+            <VStack gap={3}>
+              <button
+                type="button"
+                className={`install-command${copied ? " copied" : ""}`}
+                onClick={() => copy(method)}
+                aria-label={`Copy installation command (${method.label}): ${method.command}`}
+                aria-describedby={`install-method-${method.id}-note`}
+              >
+                <Text type="code" color="accent">{method.prompt}</Text>
+                <code>{method.command}</code>
+                {copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+                <Text type="supporting" role="status" aria-live="polite">
+                  {copied ? "Copied" : "Copy"}
+                </Text>
+              </button>
+              <Text as="p" className="install-method-note" id={`install-method-${method.id}-note`} type="supporting">
+                {method.note}
+              </Text>
+            </VStack>
+          </section>
         );
       })}
-    </div>
+    </section>
   );
 }

--- a/web/app/docs/DocumentPage.tsx
+++ b/web/app/docs/DocumentPage.tsx
@@ -71,7 +71,7 @@ export function DocumentationPage({ page }: { page?: DocumentationEntry }) {
   }));
 
   return (
-    <main className={styles.page} id="main-content">
+    <main className={`${styles.page} ${styles.editorialPage}`} id="main-content">
       <a className="skip-link" href="#docs-content">
         Skip to documentation
       </a>
@@ -99,7 +99,7 @@ export function DocumentationPage({ page }: { page?: DocumentationEntry }) {
       </header>
 
       <section
-        className={`${styles.layout} ${page ? styles.layoutDetail : styles.layoutIndex}`}
+        className={`${styles.layout} ${styles.editorialLayout} ${page ? styles.layoutDetail : styles.layoutIndex}`}
         aria-label="Documentation"
       >
         <details className={styles.mobileNavigation}>

--- a/web/app/docs/docs.module.css
+++ b/web/app/docs/docs.module.css
@@ -389,3 +389,67 @@
     text-align: left;
   }
 }
+
+.editorialPage {
+  min-height: 100dvh;
+  background: var(--color-background-body);
+}
+
+.editorialPage .header {
+  border-bottom: var(--border-width) solid var(--color-border);
+  background: var(--color-background-body);
+}
+
+.editorialPage .brand strong {
+  letter-spacing: -0.02em;
+}
+
+.editorialPage .primaryNav a,
+.editorialPage .footer a {
+  color: var(--color-text-secondary);
+}
+
+.editorialPage .primaryNav a:hover,
+.editorialPage .footer a:hover,
+.editorialPage .article a {
+  color: var(--color-text-accent);
+}
+
+.editorialLayout {
+  max-width: 84rem;
+  padding-top: var(--spacing-8);
+  padding-bottom: var(--spacing-8);
+}
+
+.editorialPage .sidebar {
+  border-right: var(--border-width) solid var(--color-border);
+}
+
+.editorialPage .sidebar > p,
+.editorialPage .sourceNote {
+  color: var(--color-text-accent);
+  font-family: var(--font-family-code);
+}
+
+.editorialPage .article {
+  max-width: 76ch;
+}
+
+.editorialPage .article h1,
+.editorialPage .article h2,
+.editorialPage .article h3 {
+  letter-spacing: -0.02em;
+}
+
+.editorialPage .pageList li {
+  border-top: var(--border-width) solid var(--color-border);
+}
+
+.editorialPage .pageList li:last-child {
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.editorialPage :focus-visible {
+  outline: var(--border-width) solid var(--color-accent);
+  outline-offset: var(--spacing-1);
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2503,3 +2503,619 @@ footer > div {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Editorial Console: compact, token-led surfaces for the hosted app. */
+.editorial-home,
+.editorial-install {
+  min-height: 100dvh;
+  background: var(--color-background-body);
+  color: var(--color-text-primary);
+}
+
+.editorial-header {
+  border-bottom: var(--border-width) solid var(--color-border);
+  background: var(--color-background-body);
+}
+
+.editorial-header-inner,
+.editorial-footer-inner {
+  max-width: 84rem;
+  margin-inline: auto;
+  padding: var(--spacing-4) var(--spacing-6);
+}
+
+.editorial-brand,
+.editorial-nav a,
+.editorial-footer a {
+  color: var(--color-text-primary);
+  text-decoration: none;
+}
+
+.editorial-brand .astryx-text {
+  letter-spacing: -0.02em;
+}
+
+.editorial-nav {
+  display: flex;
+  gap: var(--spacing-4);
+  min-width: 0;
+}
+
+.editorial-nav a,
+.editorial-footer a {
+  color: var(--color-text-secondary);
+  font-size: var(--text-supporting-size);
+  line-height: var(--text-supporting-leading);
+}
+
+.editorial-nav a:hover,
+.editorial-footer a:hover,
+.editorial-note a,
+.install-disclosure a {
+  color: var(--color-text-accent);
+}
+
+.editorial-hero,
+.editorial-process,
+.editorial-chat,
+.editorial-security,
+.install-lead,
+.install-toolbox,
+.install-reference {
+  max-width: 84rem;
+  margin-inline: auto;
+  padding: var(--spacing-8) var(--spacing-6);
+}
+
+.editorial-hero {
+  padding-top: var(--spacing-8);
+}
+
+.editorial-hero-grid,
+.editorial-chat-grid,
+.editorial-security-grid {
+  grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
+}
+
+.editorial-title {
+  max-width: 13ch;
+  letter-spacing: -0.04em;
+}
+
+.editorial-lede,
+.editorial-boundary,
+.editorial-section-heading .astryx-text,
+.editorial-chat-copy > .astryx-text {
+  max-width: 62ch;
+}
+
+.editorial-boundary,
+.editorial-device-note {
+  padding-left: var(--spacing-3);
+  border-left: var(--border-width) solid var(--color-border-emphasized);
+}
+
+.editorial-actions .astryx-button,
+.install-wizard-link,
+.install-footer .astryx-button,
+.send-button,
+.suggestion-row button {
+  min-height: var(--spacing-11);
+}
+
+.install-wizard-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--spacing-11);
+  padding: var(--spacing-2) var(--spacing-3);
+  border: var(--border-width) solid var(--color-border-emphasized);
+  border-radius: var(--radius-element);
+  color: var(--color-text-primary);
+  text-decoration: none;
+}
+
+.request-route,
+.editorial-note,
+.install-toolbox {
+  padding: var(--spacing-6);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-container);
+  background: var(--color-background-surface);
+}
+
+.request-route-list,
+.editorial-capabilities,
+.editorial-boundaries,
+.install-steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.request-route-list {
+  display: grid;
+  gap: var(--spacing-3);
+}
+
+.request-route-list li {
+  padding-block: var(--spacing-3);
+  border-top: var(--border-width) solid var(--color-border);
+}
+
+.request-route-list li:last-child {
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.editorial-process {
+  display: grid;
+  grid-template-columns: minmax(0, 0.7fr) minmax(0, 1.3fr);
+  gap: var(--spacing-8);
+  align-items: start;
+}
+
+.editorial-capabilities {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--spacing-3);
+}
+
+.editorial-capabilities li,
+.install-steps li {
+  padding: var(--spacing-5);
+  border-top: var(--border-width) solid var(--color-border);
+  background: var(--color-background-surface);
+}
+
+.editorial-capabilities li:last-child {
+  grid-column: 1 / -1;
+}
+
+.editorial-chat {
+  border-block: var(--border-width) solid var(--color-border);
+  background: var(--color-background-muted);
+}
+
+.editorial-note {
+  background: var(--color-background-card);
+}
+
+.editorial-security-grid {
+  padding-top: var(--spacing-8);
+  border-top: var(--border-width) solid var(--color-border);
+}
+
+.editorial-boundaries {
+  display: grid;
+  gap: var(--spacing-2);
+}
+
+.editorial-boundaries li {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  min-height: var(--spacing-11);
+  padding-inline: var(--spacing-3);
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.editorial-boundaries svg,
+.install-command svg,
+.send-button svg {
+  flex: 0 0 auto;
+  color: var(--color-icon-accent);
+}
+
+.editorial-footer {
+  grid-template-columns: minmax(0, 1fr);
+  border-top: var(--border-width) solid var(--color-border);
+}
+
+.editorial-footer > .editorial-footer-inner {
+  grid-column: 1 / -1;
+  justify-self: stretch;
+}
+
+.install-lead {
+  padding-bottom: var(--spacing-5);
+}
+
+.install-lead-copy {
+  max-width: 72ch;
+}
+
+.install-toolbox {
+  margin-top: var(--spacing-2);
+}
+
+.install-reference {
+  display: grid;
+  gap: var(--spacing-6);
+  padding-top: var(--spacing-5);
+}
+
+.install-reference details {
+  padding: var(--spacing-4);
+  border-top: var(--border-width) solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.install-reference summary {
+  min-height: var(--spacing-11);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  font-weight: var(--font-weight-semibold);
+}
+
+.install-disclosure {
+  margin-top: var(--spacing-4);
+  max-width: 76ch;
+}
+
+.install-steps {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--spacing-3);
+}
+
+.install-method-picker {
+  display: grid;
+  gap: var(--spacing-4);
+}
+
+.install-method-tabs {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border: var(--border-width) solid var(--color-border-emphasized);
+  border-radius: var(--radius-element);
+  overflow: hidden;
+}
+
+.install-method-tab {
+  min-height: var(--spacing-11);
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 0;
+  border-right: var(--border-width) solid var(--color-border);
+  background: var(--color-background-card);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--text-supporting-size);
+  font-weight: var(--font-weight-medium);
+}
+
+.install-method-tab:last-child {
+  border-right: 0;
+}
+
+.install-method-tab[aria-selected="true"] {
+  background: var(--color-accent-muted);
+  color: var(--color-text-accent);
+}
+
+.install-method-panel {
+  min-width: 0;
+}
+
+.install-command {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: var(--spacing-3);
+  width: 100%;
+  min-height: calc(var(--spacing-11) * 2);
+  padding: var(--spacing-4);
+  border: var(--border-width) solid var(--color-border-emphasized);
+  border-radius: var(--radius-element);
+  --terminal-background: var(--color-on-light);
+  --terminal-foreground: var(--color-on-dark);
+  --terminal-accent: var(--color-on-dark);
+  --terminal-muted: var(--color-on-dark);
+  background: var(--terminal-background);
+  color: var(--terminal-foreground);
+  cursor: pointer;
+  text-align: left;
+}
+
+.install-command code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--terminal-foreground);
+  font-family: var(--font-family-code);
+  font-size: var(--text-supporting-size);
+}
+
+.install-command .astryx-text:first-child,
+.install-command svg {
+  color: var(--terminal-accent);
+}
+
+.install-command .astryx-text:last-child {
+  color: var(--terminal-muted);
+}
+
+.install-command.copied {
+  border-color: var(--color-border-teal);
+}
+
+.install-method-note {
+  max-width: 76ch;
+}
+
+.chat-console {
+  display: grid;
+  gap: var(--spacing-4);
+  padding: var(--spacing-5);
+  border: var(--border-width) solid var(--color-border-emphasized);
+  border-radius: var(--radius-container);
+  background: var(--color-background-card);
+}
+
+.chat-console-header,
+.auth-row,
+.chat-form {
+  padding-bottom: var(--spacing-4);
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.auth-pill {
+  padding: var(--spacing-1) var(--spacing-2);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-full);
+  color: var(--color-text-secondary);
+}
+
+.auth-signed-in {
+  border-color: var(--color-border-teal);
+  color: var(--color-text-teal);
+}
+
+.conversation {
+  min-height: calc(var(--spacing-12) * 5);
+  max-height: 32rem;
+  overflow: auto;
+  padding-block: var(--spacing-2);
+}
+
+.conversation-empty {
+  min-height: calc(var(--spacing-12) * 4);
+  justify-content: center;
+  padding: var(--spacing-4);
+  border-left: var(--border-width) solid var(--color-border-emphasized);
+}
+
+.message {
+  max-width: 88%;
+  padding: var(--spacing-3) var(--spacing-4);
+  border-left: var(--border-width) solid var(--color-border-emphasized);
+  background: var(--color-background-muted);
+}
+
+.message-user {
+  margin-left: auto;
+  border-left: 0;
+  border-right: var(--border-width) solid var(--color-border-teal);
+}
+
+.message-incomplete p {
+  color: var(--color-text-orange);
+}
+
+.message-incomplete > span {
+  color: var(--color-text-orange);
+}
+
+.typing-indicator {
+  color: var(--color-icon-accent);
+}
+
+.chat-error {
+  padding: var(--spacing-3);
+  border-left: var(--border-width) solid var(--color-border-red);
+  background: var(--color-background-red);
+  color: var(--color-text-red);
+}
+
+.suggestion-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+}
+
+.suggestion-row button {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-element);
+  background: transparent;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--text-supporting-size);
+  text-align: left;
+}
+
+.suggestion-row button:disabled,
+.send-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.chat-compose-row {
+  align-items: flex-end;
+}
+
+.chat-compose-row textarea {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: var(--spacing-11);
+  max-height: 10rem;
+  padding: var(--spacing-3);
+  border: var(--border-width) solid var(--color-border-emphasized);
+  border-radius: var(--radius-element);
+  background: var(--color-background-card);
+  color: var(--color-text-primary);
+  font: inherit;
+  resize: vertical;
+}
+
+.send-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--spacing-11);
+  padding: var(--spacing-2);
+  border: var(--border-width) solid var(--color-accent);
+  border-radius: var(--radius-element);
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  cursor: pointer;
+}
+
+.send-button svg {
+  color: currentColor;
+}
+
+.stop-button {
+  background: var(--color-background-card);
+  color: var(--color-text-accent);
+}
+
+/* Focus Mode overrides for legacy chat control styles. */
+.editorial-home .send-button {
+  position: static;
+  inset: auto;
+  right: auto;
+  bottom: auto;
+  flex: 0 0 auto;
+}
+
+.editorial-home .send-button:hover:not(:disabled) {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-on-accent);
+}
+
+.editorial-home .stop-button:hover:not(:disabled) {
+  background: var(--color-background-card);
+  border-color: var(--color-accent);
+  color: var(--color-text-accent);
+}
+
+.editorial-home .suggestion-row button:hover:not(:disabled) {
+  background: var(--color-background-card);
+  border-color: var(--color-accent);
+  color: var(--color-text-primary);
+}
+
+:where(.editorial-home, .editorial-install) :focus-visible {
+  outline: var(--border-width) solid var(--color-accent);
+  outline-offset: var(--spacing-1);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .typing-indicator {
+    animation: editorial-spin var(--duration-slow) linear infinite;
+  }
+}
+
+@keyframes editorial-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@media (max-width: 48rem) {
+  .editorial-header-inner,
+  .editorial-footer-inner,
+  .editorial-hero,
+  .editorial-process,
+  .editorial-chat,
+  .editorial-security,
+  .install-lead,
+  .install-toolbox,
+  .install-reference {
+    padding-inline: var(--spacing-4);
+  }
+
+  .editorial-header-inner {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .editorial-nav {
+    width: 100%;
+    overflow-x: auto;
+    padding-bottom: var(--spacing-1);
+  }
+
+  .editorial-header-actions {
+    margin-left: auto;
+  }
+
+  .editorial-hero-grid,
+  .editorial-chat-grid,
+  .editorial-security-grid,
+  .editorial-process,
+  .install-steps {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .install-steps li {
+    display: block;
+    grid-template-columns: none;
+    gap: 0;
+  }
+
+  .editorial-capabilities {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .editorial-capabilities li:last-child {
+    grid-column: auto;
+  }
+
+  .install-method-tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .install-method-tab {
+    min-width: 0;
+    border-right: var(--border-width) solid var(--color-border);
+    border-bottom: var(--border-width) solid var(--color-border);
+  }
+
+  .install-method-tab:nth-child(even),
+  .install-method-tab:last-child {
+    border-right: 0;
+  }
+
+  .install-method-tab:last-child {
+    border-bottom: 0;
+  }
+
+  .install-method-tab:last-child:nth-child(odd) {
+    grid-column: 1 / -1;
+  }
+
+  .install-command {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .install-command .astryx-text:last-child {
+    grid-column: 2 / -1;
+  }
+
+  .conversation {
+    min-height: calc(var(--spacing-12) * 4);
+  }
+
+  .message {
+    max-width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .typing-indicator {
+    animation: none;
+  }
+}

--- a/web/app/install/page.tsx
+++ b/web/app/install/page.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import { Button } from "@astryxdesign/core/Button";
+import { Heading } from "@astryxdesign/core/Heading";
+import { HStack } from "@astryxdesign/core/HStack";
+import { Text } from "@astryxdesign/core/Text";
+import { VStack } from "@astryxdesign/core/VStack";
 import { CopyCommand } from "../components/CopyCommand";
 import { RepositoryButton } from "../components/RepositoryButton";
 import { SupportButton } from "../components/SupportButton";
@@ -13,137 +18,102 @@ export const metadata: Metadata = {
 };
 
 const steps = [
-  {
-    index: "01",
-    title: "Choose an install method",
-    copy: "Use Homebrew, your local shell, or NPX. Windows does not need Git Bash.",
-  },
-  {
-    index: "02",
-    title: "Start locally",
-    copy: "Paste the command on your own computer and keep that terminal open.",
-  },
-  {
-    index: "03",
-    title: "Verify, then approve",
-    copy: "Confirm the SSH fingerprint and sidecar plan before any VPS write.",
-  },
-];
+  ["Choose an install method", "Use Homebrew, your local shell, or NPX. Windows does not need Git Bash."],
+  ["Start locally", "Paste the command on your own computer and keep that terminal open."],
+  ["Verify, then approve", "Confirm the target identity and sidecar plan before any deployment write."],
+] as const;
 
 export default function InstallPage() {
   return (
-    <main className="install-shell" id="main-content">
+    <main className="editorial-install" id="main-content">
       <a className="skip-link" href="#install-command">
         Skip to installation command
       </a>
-      <header className="site-header install-header">
-        <div className="site-header-inner">
-          <Link className="brand" href="/" aria-label="Relmio home">
-            <Image
-              src="/relmio-icon.png"
-              alt=""
-              width={38}
-              height={38}
-              priority
-            />
-            <span>Relmio</span>
+      <header className="editorial-header editorial-install-header">
+        <HStack className="editorial-header-inner" gap={4} justify="between" align="center">
+          <Link className="editorial-brand" href="/" aria-label="Relmio home">
+            <HStack gap={2} align="center">
+              <Image src="/relmio-icon.png" alt="" width={38} height={38} priority />
+              <Text type="label" weight="bold">Relmio</Text>
+            </HStack>
           </Link>
-          <nav className="install-nav" aria-label="Primary navigation">
+          <nav className="editorial-nav" aria-label="Primary navigation">
             <Link href="/">Hosted chat</Link>
             <Link href="/docs">Documentation</Link>
           </nav>
-          <div className="header-actions">
+          <HStack className="editorial-header-actions" gap={2} align="center">
             <ThemeModeControl />
             <SupportButton />
             <RepositoryButton />
-          </div>
-        </div>
+          </HStack>
+        </HStack>
       </header>
 
-      <section className="install-page">
-        <div className="install-panel">
-          <p className="eyebrow install-eyebrow">
-            <span className="status-dot" aria-hidden="true" />
-            n8n + Hostinger VPS
-          </p>
-          <h1>Install Relmio for n8n</h1>
-          <p className="install-lede">
-            Run one local wizard to sign in with ChatGPT, verify your VPS, and
-            install a private OpenAI-compatible sidecar beside n8n. Choose
-            Homebrew or the terminal already on your computer. Native Windows
-            works without Git Bash or a preinstalled Node.js runtime.
-          </p>
-
-          <p className="install-boundary">
-            <strong>Local endpoint choice:</strong> The OpenAI-compatible /v1
-            option uses a Platform API key. ChatGPT sign-in is only for the
-            experimental Codex App Server and Chat Adapter paths.
-          </p>
-
-          <p className="install-boundary">
-            <strong>ChatGPT token lifetime:</strong> ChatGPT/Codex sign-in
-            tokens expire, but the official Codex client refreshes them
-            automatically during active use before they expire, so active
-            sessions usually continue without another browser login. The{" "}
-            <a
-              href="https://learn.chatgpt.com/docs/auth"
-              target="_blank"
-              rel="noreferrer"
-            >
-              official OpenAI authentication documentation
-            </a>{" "}
-            does not publish a fixed 10-day lifetime; do not plan around one.
-            That upstream provider credential is separate from Relmio&apos;s
-            local client capability, which remains valid until you rotate it.
-          </p>
-
-          <div className="install-command-stage" id="install-command">
-            <p>Choose an installation method</p>
-            <CopyCommand />
-          </div>
-
-          <p className="install-boundary">
-            <strong>Package-manager status:</strong> Homebrew is available from
-            the public <code>Demonbane18/relmio</code> tap. The WinGet command
-            stays hidden until Microsoft accepts its catalog pull request and
-            the catalog updates.
-          </p>
-
-          <p className="install-boundary">
-            <strong>Run this on your own computer, not on the VPS.</strong>{" "}
-            The direct macOS/Linux and native Windows options reuse Node.js 22+
-            when available, or download and verify a temporary official
-            runtime. NPX is for computers that already have Node.js 22 or
-            newer. Relmio does not edit, rebuild, or restart your existing n8n
-            container.
-          </p>
-
-          <ol className="install-steps">
-            {steps.map((step) => (
-              <li key={step.index}>
-                <span>{step.index}</span>
-                <div>
-                  <strong>{step.title}</strong>
-                  <p>{step.copy}</p>
-                </div>
-              </li>
-            ))}
-          </ol>
-
-          <div className="install-page-actions">
-            <Link className="button button-primary" href="/">
-              Back to Relmio
-              <span aria-hidden="true">↖</span>
-            </Link>
-            <Link className="button button-secondary" href="/#security">
-              Review the safety boundary
-            </Link>
-            <Link className="button button-secondary" href="/docs/ai-assistant">
-              Follow the setup guide
-            </Link>
-          </div>
-        </div>
+      <section className="install-lead">
+        <VStack className="install-lead-copy" gap={3}>
+          <Text as="p" type="code" color="accent">Self-hosted n8n</Text>
+          <Heading level={1} type="display-2">Install Relmio for n8n</Heading>
+          <Text as="p" type="large" color="secondary">
+            Run one local wizard to sign in with ChatGPT, verify your target host, and install a private OpenAI-compatible sidecar beside n8n.
+          </Text>
+        </VStack>
       </section>
+
+      <section className="install-toolbox" id="install-command" data-install-toolbox>
+        <VStack gap={3}>
+          <VStack gap={1}>
+            <Text as="p" type="code" color="accent">Start here</Text>
+            <Heading level={2}>Choose an installation method</Heading>
+          </VStack>
+          <CopyCommand />
+        </VStack>
+      </section>
+
+      <section className="install-reference" aria-label="Installation details">
+        <details>
+          <summary>Read the installation and credential details</summary>
+          <VStack className="install-disclosure" gap={4}>
+            <Text as="p" type="supporting">
+              Choose Homebrew or the terminal already on your computer. Native Windows works without Git Bash or a preinstalled Node.js runtime.
+            </Text>
+            <Text as="p" type="supporting">
+              <strong>Local endpoint choice:</strong> The OpenAI-compatible /v1 option uses a Platform API key. ChatGPT sign-in is only for the experimental Codex App Server and Chat Adapter paths.
+            </Text>
+            <Text as="p" type="supporting">
+              <strong>ChatGPT token lifetime:</strong> ChatGPT/Codex sign-in tokens expire, but the official Codex client refreshes them automatically during active use before they expire, so active sessions usually continue without another browser login. The <a href="https://learn.chatgpt.com/docs/auth" target="_blank" rel="noreferrer">official OpenAI authentication documentation</a> does not publish a fixed 10-day lifetime; do not plan around one. That upstream provider credential is separate from Relmio&apos;s local client capability, which remains valid until you rotate it.
+            </Text>
+            <Text as="p" type="supporting">
+              <strong>Package-manager status:</strong> Homebrew is available from the public <code>Demonbane18/relmio</code> tap. The WinGet command stays hidden until Microsoft accepts its catalog pull request and the catalog updates.
+            </Text>
+            <Text as="p" type="supporting">
+              <strong>Run this on your own computer, not inside the n8n container.</strong> The direct macOS/Linux and native Windows options reuse Node.js 22+ when available, or download and verify a temporary official runtime. NPX is for computers that already have Node.js 22 or newer. Relmio does not edit, rebuild, or restart your existing n8n container.
+            </Text>
+          </VStack>
+        </details>
+
+        <ol className="install-steps">
+          {steps.map(([title, copy]) => (
+            <li key={title}>
+              <VStack gap={1}>
+                <Heading level={3}>{title}</Heading>
+                <Text as="p" type="supporting">{copy}</Text>
+              </VStack>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <footer className="editorial-footer install-footer">
+        <HStack className="editorial-footer-inner" gap={3} justify="between" align="center" wrap="wrap">
+          <Button label="Back to Relmio" href="/" variant="secondary" size="lg">
+            Back to Relmio
+          </Button>
+          <HStack gap={3} wrap="wrap">
+            <Link href="/#security">Review the safety boundary</Link>
+            <Link href="/docs/ai-assistant">Follow the setup guide</Link>
+          </HStack>
+        </HStack>
+      </footer>
     </main>
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,48 +1,34 @@
 import Image from "next/image";
 import Link from "next/link";
-import { Card } from "@astryxdesign/core/Card";
+import { Button } from "@astryxdesign/core/Button";
 import { Grid } from "@astryxdesign/core/Grid";
+import { Heading } from "@astryxdesign/core/Heading";
 import { HStack } from "@astryxdesign/core/HStack";
-import { StatusDot } from "@astryxdesign/core/StatusDot";
 import { Text } from "@astryxdesign/core/Text";
-import { Token } from "@astryxdesign/core/Token";
 import { VStack } from "@astryxdesign/core/VStack";
+import { ArrowUpRight, Check } from "lucide-react";
 import { ChatConsole } from "./components/ChatConsole";
 import { RepositoryButton } from "./components/RepositoryButton";
 import { SupportButton } from "./components/SupportButton";
 import { ThemeModeControl } from "./components/ThemeModeControl";
 
+const routeNotes = [
+  ["Your app", "Trusted local backend"],
+  ["Relmio", "Authenticated relay"],
+  ["AI response", "Streamed back"],
+] as const;
+
 const capabilities = [
-  {
-    index: "01",
-    title: "Sign in once",
-    copy: "Connect a supported ChatGPT account through the browser. Your session stays encrypted on this device.",
-  },
-  {
-    index: "02",
-    title: "Relay the request",
-    copy: "Relmio sends request-bound credentials to the model route without turning them into a reusable API key.",
-  },
-  {
-    index: "03",
-    title: "Use the client you know",
-    copy: "Start with the hosted chat, then move to n8n AI nodes, local apps, and OpenAI-compatible clients.",
-  },
-];
+  ["Sign in once", "Connect a supported ChatGPT account through the browser. Your session stays encrypted on this device."],
+  ["Keep credentials scoped", "Relmio sends request-bound credentials to the model route without turning them into a reusable API key."],
+  ["Use familiar clients", "Start with the hosted chat, then move to n8n AI nodes, local apps, and OpenAI-compatible clients."],
+] as const;
 
 const boundaries = [
   "No shared subscription pool",
   "No OAuth tokens in application logs",
   "No public n8n sidecar port",
   "No OpenAI Platform API key created",
-];
-
-const relayTargets = [
-  "n8n AI Agent",
-  "LLM Chain",
-  "HTTP Request",
-  "Local chat",
-  "OpenAI SDK",
 ];
 
 const chromeExtensionUrl =
@@ -52,274 +38,158 @@ const firefoxExtensionUrl =
 
 export default function Home() {
   return (
-    <main id="main-content">
-      <a className="skip-link" href="#main-content">
+    <main className="editorial-home" id="main-content">
+      <a className="skip-link" href="#content-start">
         Skip to main content
       </a>
-      <header className="site-header">
-        <div className="site-header-inner">
-          <a className="brand" href="#top" aria-label="Relmio home">
-            <Image
-              src="/relmio-icon.png"
-              alt=""
-              width={38}
-              height={38}
-              priority
-            />
-            <span>Relmio</span>
-          </a>
-          <nav aria-label="Primary navigation">
+      <header className="editorial-header" id="top">
+        <HStack className="editorial-header-inner" gap={4} justify="between" align="center">
+          <Link className="editorial-brand" href="/" aria-label="Relmio home">
+            <HStack gap={2} align="center">
+              <Image src="/relmio-icon.png" alt="" width={38} height={38} priority />
+              <Text type="label" weight="bold">Relmio</Text>
+            </HStack>
+          </Link>
+          <nav className="editorial-nav" aria-label="Primary navigation">
             <a href="#how-it-works">How it works</a>
             <Link href="/install">Install</Link>
             <Link href="/docs">Docs</Link>
             <a href="#chat">Chat</a>
           </nav>
-          <div className="header-actions">
+          <HStack className="editorial-header-actions" gap={2} align="center">
             <ThemeModeControl />
             <SupportButton />
             <RepositoryButton />
-          </div>
-        </div>
+          </HStack>
+        </HStack>
       </header>
 
-      <section className="hero" id="top">
-        <div className="hero-copy">
-          <p className="eyebrow">
-            <span className="status-dot" aria-hidden="true" />
-            Private bridge
-          </p>
-          <h1>
-            A private bridge
-            <span>between your plan and your tools.</span>
-          </h1>
-          <p className="hero-lede">
-            Test a supported ChatGPT sign-in in the hosted chat. For n8n,
-            install Relmio&apos;s private sidecar and keep the relay inside
-            your own Docker network.
-          </p>
-          <p className="hero-boundary">
-            A Platform API key powers the OpenAI-compatible /v1 endpoint.
-            ChatGPT sign-in powers only the experimental Codex App Server
-            protocol.
-          </p>
-          <div className="hero-actions">
-            <a className="button button-primary" href="#chat">
-              Try the secure chat
-              <span aria-hidden="true">↘</span>
-            </a>
-            <Link
-              className="button button-secondary"
-              href="/install"
-            >
-              Install wizard
-            </Link>
-          </div>
-        </div>
+      <section className="editorial-hero" id="content-start">
+        <Grid className="editorial-hero-grid" columns={2} gap={8} align="stretch">
+          <VStack className="editorial-hero-copy" gap={5} align="start">
+            <Text as="p" type="code" color="accent">Private bridge</Text>
+            <Heading className="editorial-title" level={1} type="display-1">
+              A private bridge between your plan and your tools.
+            </Heading>
+            <Text as="p" className="editorial-lede" type="large" color="secondary">
+              Test a supported ChatGPT sign-in in the hosted chat. For n8n, install Relmio&apos;s private sidecar and keep the relay inside your own Docker network.
+            </Text>
+            <Text as="p" className="editorial-boundary" type="supporting">
+              A Platform API key powers the OpenAI-compatible /v1 endpoint. ChatGPT sign-in powers only the experimental Codex App Server protocol.
+            </Text>
+            <HStack className="editorial-actions" gap={3} wrap="wrap">
+              <Button label="Try the secure chat" href="#chat" variant="primary" size="lg" endContent={<ArrowUpRight aria-hidden="true" />}>
+                Try the secure chat
+              </Button>
+              <Link className="install-wizard-link" href="/install">Install wizard</Link>
+            </HStack>
+          </VStack>
 
-        <VStack className="private-bridge" gap={0} aria-label="Private request route">
-          <HStack className="visual-heading" gap={4} justify="between" align="center">
-            <VStack gap={0.5}>
-              <Text type="code">Request route</Text>
-              <Text type="label" weight="bold">One boundary at a time</Text>
+          <section className="request-route" aria-label="Private request route">
+            <VStack gap={5}>
+              <VStack gap={1}>
+                <Text as="p" type="code" color="accent">Request route</Text>
+                <Heading level={2}>One boundary at a time</Heading>
+              </VStack>
+              <ol className="request-route-list">
+                {routeNotes.map(([title, detail]) => (
+                  <li key={title}>
+                    <VStack gap={1}>
+                      <Text type="label" weight="bold">{title}</Text>
+                      <Text as="p" type="supporting">{detail}</Text>
+                    </VStack>
+                  </li>
+                ))}
+              </ol>
+              <Text as="p" type="supporting" color="secondary">
+                Credentials stay behind the boundary. Responses stream through.
+              </Text>
             </VStack>
-            <Token
-              label="Ready"
-              size="sm"
-              color="teal"
-              endContent={<StatusDot variant="success" label="Route ready" />}
-            />
-          </HStack>
-          <Grid className="bridge-route" columns={5} gap={2} align="center">
-            <Card className="bridge-node" padding={5} elevation="low">
-              <VStack height="100%" gap={1}>
-                <Text type="code" color="accent">01</Text>
-                <Text type="label" weight="bold">Your app</Text>
-                <Text type="supporting" color="secondary">Trusted local backend</Text>
-              </VStack>
-            </Card>
-            <HStack className="bridge-link bridge-link-in" aria-hidden="true">
-              <StatusDot variant="accent" label="Request moving to Relmio" />
-            </HStack>
-            <Card className="bridge-node bridge-node-relmio" padding={5} variant="teal">
-              <VStack height="100%" gap={1}>
-                <Text type="code" color="inherit">02</Text>
-                <Text type="label" color="inherit" weight="bold">Relmio</Text>
-                <Text type="supporting" color="inherit">Authenticated relay</Text>
-              </VStack>
-            </Card>
-            <HStack className="bridge-link bridge-link-out" aria-hidden="true">
-              <StatusDot variant="accent" label="Response streaming to the app" />
-            </HStack>
-            <Card className="bridge-node" padding={5} elevation="low">
-              <VStack height="100%" gap={1}>
-                <Text type="code" color="accent">03</Text>
-                <Text type="label" weight="bold">AI response</Text>
-                <Text type="supporting" color="secondary">Streamed back</Text>
-              </VStack>
-            </Card>
-          </Grid>
-          <HStack className="bridge-boundary" gap={4} justify="between">
-            <Text type="code" color="secondary">Credential stays behind the boundary</Text>
-            <Text type="code" color="secondary">Response streams through</Text>
-          </HStack>
+          </section>
+        </Grid>
+      </section>
+
+      <section className="editorial-process" id="how-it-works">
+        <VStack className="editorial-section-heading" gap={3}>
+          <Text as="p" type="code" color="accent">How it works</Text>
+          <Heading level={2} type="display-2">A relay, not another account system.</Heading>
+          <Text as="p" type="large" color="secondary">
+            Relmio keeps authentication, transport, and client compatibility separate. That makes each boundary easier to understand and easier to protect.
+          </Text>
         </VStack>
-      </section>
-
-      <section className="signal-strip" aria-label="Supported starting points">
-        <p>Built to relay into</p>
-        <div className="marquee">
-          <div className="marquee-track">
-            {relayTargets.map((target) => (
-              <span key={target}>{target}</span>
-            ))}
-            {relayTargets.map((target) => (
-              <span key={`${target}-duplicate`} aria-hidden="true">
-                {target}
-              </span>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section className="process-section" id="how-it-works">
-        <div className="section-intro reveal">
-          <p className="section-label">How it works</p>
-          <h2>A relay, not another account system.</h2>
-          <p>
-            Relmio keeps authentication, transport, and client compatibility
-            separate. That makes each boundary easier to understand and easier
-            to protect.
-          </p>
-        </div>
-        <ol className="process-grid">
-          {capabilities.map((capability) => (
-            <li className="reveal" key={capability.index}>
-              <span>{capability.index}</span>
-              <h3>{capability.title}</h3>
-              <p>{capability.copy}</p>
+        <ol className="editorial-capabilities">
+          {capabilities.map(([title, copy]) => (
+            <li key={title}>
+              <Heading level={3}>{title}</Heading>
+              <Text as="p" type="supporting">{copy}</Text>
             </li>
           ))}
         </ol>
       </section>
 
-      <section className="chat-section reveal" id="chat">
-        <div className="chat-copy">
-          <p className="section-label">Hosted demo</p>
-          <h2>Connect, then ask.</h2>
-          <p>
-            This chat uses the account you connect in this browser. Relmio
-            forwards credentials only with your request; the server does not
-            keep a reusable session.
-          </p>
-          <aside className="extension-guide" aria-labelledby="extension-guide-title">
-            <span aria-hidden="true">!</span>
-            <div>
-              <strong id="extension-guide-title">
-                Before you connect: install the browser extension
-              </strong>
-              <p>
-                The hosted chat needs the open-source Sign in with ChatGPT
-                extension to complete the secure OAuth handoff. Install it for{" "}
-                <a href={chromeExtensionUrl} target="_blank" rel="noreferrer">
-                  Chrome
-                </a>{" "}
-                or{" "}
-                <a href={firefoxExtensionUrl} target="_blank" rel="noreferrer">
-                  Firefox
-                </a>
-                , reload this page, then connect again.
-              </p>
-              <p className="extension-local-note">
-                Using the local npm wizard? It handles its own localhost
-                callback. If an OAuth extension intercepts that callback,
-                temporarily disable it during local sign-in.
-              </p>
-            </div>
-          </aside>
-          <div className="privacy-note">
-            <span aria-hidden="true">⌁</span>
-            <div>
-              <strong>Device-local by design</strong>
-              <p>
-                Credentials are encrypted in this browser. Disconnect whenever
-                you want to remove the local session.
-              </p>
-            </div>
-          </div>
-        </div>
-        <ChatConsole />
+      <section className="editorial-chat" id="chat" aria-labelledby="chat-title">
+        <Grid className="editorial-chat-grid" columns={2} gap={8} align="start">
+          <VStack className="editorial-chat-copy" gap={4}>
+            <Text as="p" type="code" color="accent">Hosted chat</Text>
+            <Heading id="chat-title" level={2} type="display-2">Connect, then ask.</Heading>
+            <Text as="p" type="large" color="secondary">
+              This chat uses the account you connect in this browser. Relmio forwards credentials only with your request; the server does not keep a reusable session.
+            </Text>
+            <aside className="editorial-note" aria-labelledby="extension-guide-title">
+              <VStack gap={2}>
+                <Text id="extension-guide-title" type="label" weight="bold">Before you connect: install the browser extension</Text>
+                <Text as="p" type="supporting">
+                  The hosted chat needs the open-source Sign in with ChatGPT extension to complete the secure OAuth handoff. Install it for <a href={chromeExtensionUrl} target="_blank" rel="noreferrer">Chrome</a> or <a href={firefoxExtensionUrl} target="_blank" rel="noreferrer">Firefox</a>, reload this page, then connect again.
+                </Text>
+                <Text as="p" type="supporting">
+                  Using the local npm wizard? It handles its own localhost callback. If an OAuth extension intercepts that callback, temporarily disable it during local sign-in.
+                </Text>
+              </VStack>
+            </aside>
+            <Text as="p" className="editorial-device-note" type="supporting">
+              Device-local by design. Credentials are encrypted in this browser. Disconnect whenever you want to remove the local session.
+            </Text>
+          </VStack>
+          <ChatConsole />
+        </Grid>
       </section>
 
-      <section className="security-section" id="security">
-        <div className="security-panel reveal">
-          <div>
-            <p className="section-label section-label-light">Safety boundary</p>
-            <h2>Private where it matters.</h2>
-            <p>
-              The hosted chat is a browser demo. The n8n installer remains a
-              local wizard that deploys a separate sidecar without changing
-              your existing n8n container, image, or workflows.
-            </p>
-          </div>
-          <ul>
+      <section className="editorial-security" id="security">
+        <Grid className="editorial-security-grid" columns={2} gap={8} align="start">
+          <VStack gap={3}>
+            <Text as="p" type="code" color="accent">Safety boundary</Text>
+            <Heading level={2} type="display-2">Private where it matters.</Heading>
+            <Text as="p" type="large" color="secondary">
+              The hosted chat is a browser demo. The n8n installer remains a local wizard that deploys a separate sidecar without changing your existing n8n container, image, or workflows.
+            </Text>
+          </VStack>
+          <ul className="editorial-boundaries">
             {boundaries.map((boundary) => (
               <li key={boundary}>
-                <span aria-hidden="true">✓</span>
-                {boundary}
+                <Check aria-hidden="true" />
+                <Text type="label">{boundary}</Text>
               </li>
             ))}
           </ul>
-        </div>
+        </Grid>
       </section>
 
-      <section className="closing-section reveal">
-        <div>
-          <p className="section-label">Start locally</p>
-          <h2>Bring your own plan. Keep your own boundary.</h2>
-        </div>
-        <Link
-          className="button button-primary"
-          href="/install"
-        >
-          Install the wizard
-          <span aria-hidden="true">↘</span>
-        </Link>
-      </section>
-
-      <footer>
-        <a className="brand footer-brand" href="#top" aria-label="Relmio home">
-          <Image src="/relmio-icon.png" alt="" width={32} height={32} />
-          <span>Relmio</span>
-        </a>
-        <p>
-          Hosted sign-in uses the{" "}
-          <a
-            href="https://github.com/EvanZhouDev/openai-oauth"
-            target="_blank"
-            rel="noreferrer"
-          >
-            openai-oauth method by Evan Zhou Dev
-          </a>
-          .
-        </p>
-        <div>
-          <a
-            href="https://www.npmjs.com/package/relmio"
-            target="_blank"
-            rel="noreferrer"
-          >
-            npm
-          </a>
-          <a
-            href="https://github.com/Demonbane18/relmio"
-            target="_blank"
-            rel="noreferrer"
-          >
-            GitHub
-          </a>
-          <a href="#security">Security</a>
-          <a href="#chat">Chat demo</a>
-        </div>
+      <footer className="editorial-footer">
+        <HStack className="editorial-footer-inner" gap={4} justify="between" align="center" wrap="wrap">
+          <HStack gap={2} align="center">
+            <Image src="/relmio-icon.png" alt="" width={32} height={32} />
+            <Text type="label" weight="bold">Relmio</Text>
+          </HStack>
+          <Text as="p" type="supporting">
+            Hosted sign-in uses the <a href="https://github.com/EvanZhouDev/openai-oauth" target="_blank" rel="noreferrer">openai-oauth method by Evan Zhou Dev</a>.
+          </Text>
+          <HStack gap={3} wrap="wrap">
+            <a href="https://www.npmjs.com/package/relmio" target="_blank" rel="noreferrer">npm</a>
+            <a href="https://github.com/Demonbane18/relmio" target="_blank" rel="noreferrer">GitHub</a>
+            <a href="#security">Security</a>
+            <a href="#chat">Chat demo</a>
+          </HStack>
+        </HStack>
       </footer>
     </main>
   );

--- a/web/tests/editorial-console.test.mjs
+++ b/web/tests/editorial-console.test.mjs
@@ -1,0 +1,379 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const appFile = (path) =>
+  readFile(new URL(`../app/${path}`, import.meta.url), "utf8");
+
+function readThemeTokens(source) {
+  return new Map(
+    [...source.matchAll(/^\s*"(?<name>--color-[^"]+)":\s*"(?<value>[^"]+)"/gmu)].map(
+      ({ groups }) => [groups.name, groups.value],
+    ),
+  );
+}
+
+function themeColor(tokens, name, mode) {
+  const value = tokens.get(name);
+  assert.ok(value, `missing theme token: ${name}`);
+
+  const pair = value.match(
+    /^light-dark\((?<light>#[\da-f]+),\s*(?<dark>#[\da-f]+)\)$/iu,
+  );
+  return pair?.groups?.[mode] ?? value;
+}
+
+function parseHexColor(value) {
+  assert.match(value, /^#[\da-f]{3,8}$/iu, `expected a hex theme color: ${value}`);
+  const hex = value.slice(1);
+  const channels = hex.length <= 4 ? [...hex].map((channel) => channel.repeat(2)) : hex.match(/../gu);
+  const [red, green, blue] = channels.slice(0, 3).map((channel) => parseInt(channel, 16));
+  const alpha = channels[3] ? parseInt(channels[3], 16) / 255 : 1;
+  return { red, green, blue, alpha };
+}
+
+function composite(color, backdrop) {
+  const alpha = color.alpha + backdrop.alpha * (1 - color.alpha);
+  return {
+    red: (color.red * color.alpha + backdrop.red * backdrop.alpha * (1 - color.alpha)) / alpha,
+    green: (color.green * color.alpha + backdrop.green * backdrop.alpha * (1 - color.alpha)) / alpha,
+    blue: (color.blue * color.alpha + backdrop.blue * backdrop.alpha * (1 - color.alpha)) / alpha,
+    alpha,
+  };
+}
+
+function relativeLuminance({ red, green, blue }) {
+  const channel = (value) => {
+    const normalized = value / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+
+  return 0.2126 * channel(red) + 0.7152 * channel(green) + 0.0722 * channel(blue);
+}
+
+function contrastRatio(foreground, background) {
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  );
+}
+
+test("uses an editorial homepage without decorative status or marquee patterns", async () => {
+  const home = await appFile("page.tsx");
+
+  assert.match(home, /className="editorial-home"/u);
+  assert.match(home, /id="chat"/u);
+  assert.match(home, /id="security"/u);
+  assert.match(home, /id="top"/u);
+  assert.match(home, /href="\/install"/u);
+  assert.match(home, /href="\/docs"/u);
+  assert.doesNotMatch(home, /marquee|status-dot|index:\s*"0[123]"/u);
+});
+
+test("makes the real installer command the first interactive toolbox", async () => {
+  const [installPage, copyCommand] = await Promise.all([
+    appFile("install/page.tsx"),
+    appFile("components/CopyCommand.tsx"),
+  ]);
+
+  assert.match(installPage, /data-install-toolbox/u);
+  assert.match(installPage, /Self-hosted n8n/u);
+  assert.doesNotMatch(installPage, /Hostinger VPS/u);
+  assert.ok(
+    installPage.indexOf("<CopyCommand") < installPage.indexOf("<details"),
+    "the command selector must precede progressive disclosure",
+  );
+  assert.match(copyCommand, /role="tablist"/u);
+  assert.match(copyCommand, /aria-orientation="horizontal"/u);
+  assert.match(copyCommand, /selectedMethod.*"posix"/su);
+  assert.match(copyCommand, /ArrowRight|ArrowLeft/u);
+  assert.match(copyCommand, /navigator\.clipboard\.writeText/u);
+  assert.match(copyCommand, /document\.execCommand\("copy"\)/u);
+
+  for (const command of [
+    "curl -fsSL https://relmio.vercel.app/install.sh | sh",
+    "brew tap Demonbane18/relmio && brew install relmio",
+    "irm https://relmio.vercel.app/install.ps1 | iex",
+    "https://relmio.vercel.app/install.cmd",
+    "npx --yes --ignore-scripts relmio@latest",
+  ]) {
+    assert.ok(copyCommand.includes(command), `missing install command: ${command}`);
+  }
+  assert.doesNotMatch(copyCommand, /winget install/u);
+});
+
+test("keeps hosted chat as a focused request-only console", async () => {
+  const chatConsole = await appFile("components/ChatConsole.tsx");
+
+  assert.match(chatConsole, /aria-label="Hosted chat console"/u);
+  assert.match(chatConsole, /aria-live="polite"/u);
+  assert.match(chatConsole, /aria-label="Suggested prompts"/u);
+  assert.match(chatConsole, /fetch\("\/api\/chat"/u);
+  assert.match(chatConsole, /openaiAuthHeaders/u);
+  assert.match(chatConsole, /readRelmioEvents/u);
+  assert.match(chatConsole, /abortRef/u);
+  assert.match(chatConsole, /maxLength=\{3000\}/u);
+  assert.doesNotMatch(chatConsole, /conversation history|persistent history|<svg/iu);
+});
+
+test("keeps mobile installer steps full width with one-child markup", async () => {
+  const styles = await appFile("globals.css");
+  const editorialMobileStyles = styles.slice(
+    styles.lastIndexOf("@media (max-width: 48rem)"),
+  );
+
+  assert.match(
+    editorialMobileStyles,
+    /\.install-steps li\s*\{[^}]*display:\s*block;[^}]*grid-template-columns:\s*none;[^}]*gap:\s*0;[^}]*\}/su,
+  );
+});
+
+test("keeps Focus Mode send and stop icons at accessible hover contrast", async () => {
+  const [styles, themeSource] = await Promise.all([
+    appFile("globals.css"),
+    appFile("relmio.js"),
+  ]);
+  const themeTokens = readThemeTokens(themeSource);
+  const sendHover = styles.match(
+    /\.editorial-home \.send-button:hover:not\(:disabled\)\s*\{(?<declarations>[^}]*)\}/u,
+  )?.groups?.declarations;
+  const stopHover = styles.match(
+    /\.editorial-home \.stop-button:hover:not\(:disabled\)\s*\{(?<declarations>[^}]*)\}/u,
+  )?.groups?.declarations;
+  const suggestionHover = styles.match(
+    /\.editorial-home \.suggestion-row button:hover:not\(:disabled\)\s*\{(?<declarations>[^}]*)\}/u,
+  )?.groups?.declarations;
+
+  assert.ok(sendHover, "missing Focus Mode send hover override");
+  assert.ok(stopHover, "missing Focus Mode stop hover override");
+  assert.ok(suggestionHover, "missing Focus Mode suggestion hover override");
+  assert.doesNotMatch(sendHover, /#[\da-f]{3,8}/iu);
+  assert.doesNotMatch(stopHover, /#[\da-f]{3,8}/iu);
+  assert.doesNotMatch(suggestionHover, /#[\da-f]{3,8}/iu);
+
+  const tokenFor = (declarations, property) =>
+    declarations.match(
+      new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*var\\((--color-[^)]+)\\)`, "u"),
+    )?.[1];
+  const sendBackgroundToken = tokenFor(sendHover, "background");
+  const sendForegroundToken = tokenFor(sendHover, "color");
+  const stopBackgroundToken = tokenFor(stopHover, "background");
+  const stopForegroundToken = tokenFor(stopHover, "color");
+  const suggestionBackgroundToken = tokenFor(suggestionHover, "background");
+  const suggestionForegroundToken = tokenFor(suggestionHover, "color");
+
+  assert.equal(sendBackgroundToken, "--color-accent");
+  assert.equal(sendForegroundToken, "--color-on-accent");
+  assert.equal(stopBackgroundToken, "--color-background-card");
+  assert.equal(stopForegroundToken, "--color-text-accent");
+  assert.equal(suggestionBackgroundToken, "--color-background-card");
+  assert.equal(suggestionForegroundToken, "--color-text-primary");
+
+  for (const mode of ["light", "dark"]) {
+    const sendBackground = parseHexColor(
+      themeColor(themeTokens, sendBackgroundToken, mode),
+    );
+    const sendForeground = parseHexColor(
+      themeColor(themeTokens, sendForegroundToken, mode),
+    );
+    const stopBackground = parseHexColor(
+      themeColor(themeTokens, stopBackgroundToken, mode),
+    );
+    const stopForeground = parseHexColor(
+      themeColor(themeTokens, stopForegroundToken, mode),
+    );
+    const suggestionBackground = parseHexColor(
+      themeColor(themeTokens, suggestionBackgroundToken, mode),
+    );
+    const suggestionForeground = parseHexColor(
+      themeColor(themeTokens, suggestionForegroundToken, mode),
+    );
+
+    assert.ok(
+      contrastRatio(sendForeground, sendBackground) >= 3,
+      `send icon contrast is below 3:1 in ${mode} mode`,
+    );
+    assert.ok(
+      contrastRatio(stopForeground, stopBackground) >= 3,
+      `stop icon contrast is below 3:1 in ${mode} mode`,
+    );
+    assert.ok(
+      contrastRatio(suggestionForeground, suggestionBackground) >= 4.5,
+      `suggestion text contrast is below 4.5:1 in ${mode} mode`,
+    );
+  }
+});
+
+test("keeps Focus Mode compose controls in flow beside long prompts", async () => {
+  const styles = await appFile("globals.css");
+  const composeControl = styles.match(
+    /\.editorial-home \.send-button\s*\{(?<declarations>[^}]*)\}/u,
+  )?.groups?.declarations;
+
+  assert.ok(composeControl, "missing Focus Mode compose control override");
+  assert.match(composeControl, /position:\s*static;/u);
+  assert.match(composeControl, /inset:\s*auto;/u);
+  assert.match(composeControl, /right:\s*auto;/u);
+  assert.match(composeControl, /bottom:\s*auto;/u);
+  assert.match(composeControl, /flex:\s*0\s+0\s+auto;/u);
+  assert.doesNotMatch(composeControl, /position:\s*absolute/u);
+});
+
+test("keeps mobile editorial visual order aligned with DOM focus order", async () => {
+  const [styles, home, install] = await Promise.all([
+    appFile("globals.css"),
+    appFile("page.tsx"),
+    appFile("install/page.tsx"),
+  ]);
+  const editorialMobileStyles = styles.slice(
+    styles.lastIndexOf("@media (max-width: 48rem)"),
+  );
+  const mobileNav = editorialMobileStyles.match(
+    /\.editorial-nav\s*\{(?<declarations>[^}]*)\}/u,
+  )?.groups?.declarations;
+
+  assert.ok(mobileNav, "missing mobile editorial navigation rule");
+  assert.doesNotMatch(mobileNav, /order\s*:/u);
+  assert.match(mobileNav, /width:\s*100%;/u);
+  assert.match(mobileNav, /overflow-x:\s*auto;/u);
+
+  for (const source of [home, install]) {
+    const brandIndex = source.indexOf('className="editorial-brand"');
+    const navIndex = source.indexOf('className="editorial-nav"');
+    const actionsIndex = source.indexOf('className="editorial-header-actions"');
+
+    assert.ok(brandIndex >= 0, "missing editorial brand in header");
+    assert.ok(navIndex >= 0, "missing editorial nav in header");
+    assert.ok(actionsIndex >= 0, "missing editorial actions in header");
+    assert.ok(
+      brandIndex < navIndex && navIndex < actionsIndex,
+      "header DOM order must remain brand, navigation, then actions",
+    );
+  }
+});
+
+test("lets editorial footers span the desktop footer over the legacy grid", async () => {
+  const styles = await appFile("globals.css");
+  const editorialFooter = styles.match(/\.editorial-footer\s*\{[^}]*\}/u)?.[0];
+  const editorialFooterInner = styles.match(
+    /\.editorial-footer\s*>\s*\.editorial-footer-inner\s*\{[^}]*\}/u,
+  )?.[0];
+
+  assert.ok(editorialFooter, "missing editorial footer rule");
+  assert.match(editorialFooter, /grid-template-columns:\s*minmax\(0,\s*1fr\)/u);
+  assert.ok(editorialFooterInner, "missing editorial footer inner reset");
+  assert.match(editorialFooterInner, /grid-column:\s*1\s*\/\s*-1/u);
+  assert.match(editorialFooterInner, /justify-self:\s*stretch/u);
+
+  const editorialMobileStyles = styles.slice(
+    styles.lastIndexOf("@media (max-width: 48rem)"),
+  );
+  assert.match(
+    editorialMobileStyles,
+    /\.editorial-footer-inner[\s\S]*padding-inline:\s*var\(--spacing-4\)/u,
+  );
+});
+
+test("keeps terminal and incomplete response colors accessible in both themes", async () => {
+  const [styles, themeSource] = await Promise.all([
+    appFile("globals.css"),
+    appFile("relmio.js"),
+  ]);
+  const terminalStart = styles.indexOf(".install-command {\n  display: grid;");
+  const terminalEnd = styles.indexOf(".install-command.copied {", terminalStart);
+  const terminalStyles = styles.slice(terminalStart, terminalEnd);
+  const themeTokens = readThemeTokens(themeSource);
+
+  assert.ok(
+    terminalStart >= 0 && terminalEnd > terminalStart,
+    "missing terminal command styles",
+  );
+  assert.match(terminalStyles, /--terminal-background:\s*var\(--color-on-light\)/u);
+  assert.match(terminalStyles, /--terminal-foreground:\s*var\(--color-on-dark\)/u);
+  assert.match(terminalStyles, /--terminal-accent:\s*var\(--color-on-dark\)/u);
+  assert.match(terminalStyles, /--terminal-muted:\s*var\(--color-on-dark\)/u);
+  assert.doesNotMatch(terminalStyles, /#[\da-f]{3,8}/iu);
+
+  for (const mode of ["light", "dark"]) {
+    const terminalBackground = parseHexColor(
+      themeColor(themeTokens, "--color-on-light", mode),
+    );
+    for (const role of ["foreground", "accent", "muted"]) {
+      const terminalColor = parseHexColor(
+        themeColor(
+          themeTokens,
+          terminalStyles.match(
+            new RegExp(`--terminal-${role}:\\s*var\\((--color-[^)]+)\\)`, "u"),
+          )?.[1],
+          mode,
+        ),
+      );
+      assert.ok(
+        contrastRatio(terminalColor, terminalBackground) >= 4.5,
+        `${role} terminal contrast is below 4.5:1 in ${mode} mode`,
+      );
+    }
+  }
+
+  const incompleteRules = [
+    ...styles.matchAll(/\.message-incomplete p\s*\{([^}]*)\}/gu),
+  ];
+  const incompleteDeclarations = incompleteRules.at(-1)?.[1] ?? "";
+  assert.match(incompleteDeclarations, /color:\s*var\(--color-text-orange\)/u);
+  assert.doesNotMatch(incompleteDeclarations, /color:\s*var\(--color-border-orange\)/u);
+
+  for (const mode of ["light", "dark"]) {
+    const orangeBackdrop = parseHexColor(
+      themeColor(themeTokens, "--color-background-muted", mode),
+    );
+    const orangeBackground = composite(
+      parseHexColor(themeColor(themeTokens, "--color-background-orange", mode)),
+      orangeBackdrop,
+    );
+    const orangeText = parseHexColor(
+      themeColor(themeTokens, "--color-text-orange", mode),
+    );
+    assert.ok(
+      contrastRatio(orangeText, orangeBackground) >= 4.5,
+      `incomplete response contrast is below 4.5:1 in ${mode} mode`,
+    );
+  }
+});
+
+test("keeps Focus Mode speaker labels out of legacy message bubbles", async () => {
+  const chatConsole = await appFile("components/ChatConsole.tsx");
+
+  assert.match(
+    chatConsole,
+    /<Text\s+as="span"\s+type="code"\s+color="secondary">\s*You\s*<\/Text>/su,
+  );
+  assert.match(
+    chatConsole,
+    /<Text\s+as="span"\s+type="code"\s+color="accent">\s*\{isIncomplete\s*\?/su,
+  );
+  assert.match(
+    chatConsole,
+    /<Text\s+as="p"\s+type="body">\s*\{lastPrompt\}\s*<\/Text>/su,
+  );
+  assert.match(
+    chatConsole,
+    /<Text\s+as="p"\s+type="body">\s*\{completion\s*\|\|/su,
+  );
+});
+
+test("gives documentation the same editorial console framing", async () => {
+  const [documentPage, docsStyles] = await Promise.all([
+    appFile("docs/DocumentPage.tsx"),
+    appFile("docs/docs.module.css"),
+  ]);
+
+  assert.match(documentPage, /styles\.editorialPage/u);
+  assert.match(documentPage, /aria-label="Documentation navigation"/u);
+  assert.match(documentPage, /DocumentOutline/u);
+  assert.match(docsStyles, /\.editorialPage/u);
+  assert.doesNotMatch(documentPage, /dangerouslySetInnerHTML|rehypeRaw|innerHTML/u);
+});

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -51,7 +51,7 @@ test("server-renders the Relmio product page", async () => {
   assert.match(html, /lucide-sun/);
   assert.match(html, /lucide-moon/);
   assert.doesNotMatch(html, /theme-mode-mobile|<select/u);
-  assert.match(html, /class="[^"]*\bprivate-bridge\b/);
+  assert.match(html, /class="[^"]*\beditorial-home\b/);
   assert.match(html, /aria-label="Private request route"/);
   assert.match(html, /Your app/);
   assert.match(html, /Authenticated relay/);
@@ -116,7 +116,7 @@ test("server-renders canonical generated Markdown documentation routes", async (
   assert.doesNotMatch(troubleshootingHtml, /dangerouslySetInnerHTML|rehype-raw/u);
 });
 
-test("renders a command-first n8n and Hostinger VPS install page", async () => {
+test("renders a command-first self-hosted n8n install page", async () => {
   const response = await requestApp("/install");
   assert.equal(response.status, 200);
 
@@ -143,7 +143,8 @@ test("renders a command-first n8n and Hostinger VPS install page", async () => {
   assert.match(html, /lucide-sun/);
   assert.match(html, /lucide-moon/);
   assert.doesNotMatch(html, /theme-mode-mobile|<select/u);
-  assert.match(html, /Hostinger VPS/);
+  assert.match(html, /Self-hosted n8n/);
+  assert.doesNotMatch(html, /Hostinger VPS/);
   assert.match(html, /class="support-button"/);
   assert.match(html, /https:\/\/ko-fi\.com\/paldogies/);
   assert.match(


### PR DESCRIPTION
## Summary
- Applies the Editorial Utility design system across the hosted web app and documentation.
- Uses Focus Mode for the dedicated chat experience and a Modular Toolbox installer selector.
- Preserves Relmio's muted teal identity, black install terminal, light/dark modes, existing URLs, functionality, and security boundaries.
- Replaces Hostinger-specific framing with provider-neutral self-hosted n8n language.

## Accessibility and responsive validation
- Opera GX evidence at 390×844 in light and dark modes.
- Installer commands remain above the fold, the black terminal treatment is preserved, and mobile content follows a single-column flow.
- Regression coverage includes DOM/focus order, an in-flow compose control, desktop footer reset, mobile installer layout, speaker markup, and computed light/dark contrast guards.
- Measured contrast evidence: terminal 17.93:1 in both themes; incomplete-response orange 6.79:1 light and 6.01:1 dark; send hover 5.04:1 light and 6.11:1 dark; stop hover 7.51:1 light and 9.30:1 dark; suggestion hover 17.69:1 light and 14.08:1 dark.

## Verification
- `npm run lint` — passed.
- `npm run typecheck` — passed.
- `npm test` — 35/35 web tests passed.
- `npm run build:vercel` — passed with 15/15 static pages.
- `git diff --check` — passed.