### PR TITLE
Fix reduced-motion relay hydration

### DIFF
--- a/web/app/components/relay/SignalPlotter.tsx
+++ b/web/app/components/relay/SignalPlotter.tsx
@@ -225,7 +225,7 @@ export function SignalPlotter() {
                         }
                   }
                   className={styles.signalPacket}
-                  initial={false}
+                  initial={{ x: 12, y: activeRoute.sourceY, opacity: 0 }}
                   key={`signal-${activeRoute.id}`}
                   r="6"
                   transition={

--- a/web/tests/signal-plotter-home.test.mjs
+++ b/web/tests/signal-plotter-home.test.mjs
@@ -41,12 +41,18 @@ test("uses real pressed buttons and exposes the complete boundary story", async 
 
 test("animates the active path with an explicit reduced-motion final state", async () => {
   const plotter = await appFile("components/relay/SignalPlotter.tsx");
+  const signalPacket = plotter.match(/<motion\.circle[\s\S]*?\/>/u)?.[0] ?? "";
 
   assert.match(plotter, /from "motion\/react"/u);
   assert.match(plotter, /useReducedMotion\(\)/u);
   assert.match(plotter, /<AnimatePresence/u);
-  assert.match(plotter, /<motion\.circle/u);
+  assert.match(signalPacket, /<motion\.circle/u);
   assert.match(plotter, /reduceMotion\s*\?\s*\{ x: 500, y: 152, opacity: 1 \}/u);
+  assert.match(
+    signalPacket,
+    /initial=\{\{ x: 12, y: activeRoute\.sourceY, opacity: 0 \}\}/u,
+  );
+  assert.doesNotMatch(signalPacket, /initial=\{false\}/u);
   assert.match(plotter, /layoutId="active-relay-route"/u);
 });
 


### PR DESCRIPTION
## Summary

- make the relay packet initial state identical during server render and client hydration
- preserve the authored no-preference route animation
- keep reduced-motion transitions instant at the visible destination
- add a regression guard that rejects the mismatching `initial={false}` form

## Evidence

- Opera GX reduced-motion and no-preference regression passed twice with zero hydration errors
- root check: 376 tests, 370 passed, 6 platform-specific skips
- web: lint, typecheck, 59 tests, Vinext build, and Next/Vercel build passed
- root and web audits: 0 vulnerabilities
- package preview: relmio 0.9.0, 84 files
- Impeccable detector: no findings
- independent Sol review: SHIP, no actionable findings

## Scope

Exactly two web files. No backend, installer, n8n, credential, release, or deployment behavior changed.