### PR TITLE
docs: complete v0.9.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,17 @@ checks the registry separately after publication.
 
 ### Changed
 
+- Redesign the hosted app as an Editorial Console with an interactive
+  four-route Signal Plotter and an improved multi-turn chat console that can
+  stop in-flight responses.
 - Describe the AI Assistant's SSH-connected self-hosted target without
   provider-specific Hostinger or VPS labels, and document that direct local
   Docker-socket discovery is not supported.
 
 ### Fixed
 
+- Stabilize reduced-motion hydration by giving the Signal Plotter a
+  deterministic initial signal state before animation begins.
 - Keep the hosted repository control's offline metadata fallback synchronized
   with the prepared release version.
 


### PR DESCRIPTION
## Summary

- complete the v0.9.1 `Changed` notes for PR #48's Editorial Console redesign and PR #49's interactive Signal Plotter and improved stoppable chat console
- add the v0.9.1 `Fixed` note for PR #50's reduced-motion hydration correction
- preserve the existing PR #51 notes and the prepared v0.9.1 metadata

## Validation

- root check: 376 tests; 370 passed, 0 failed, 6 skipped
- web tests: 61 passed, 0 failed
- web lint, typecheck, and Vercel production build: passed
- root and web high-severity audits: 0 vulnerabilities
- package preview: `relmio@0.9.1`, 84 files
- immutable production image-pin regression: passed
- release metadata and diff checks: passed
- fresh Sol review: **SHIP**, no findings

## Distribution boundary

This PR changes only `CHANGELOG.md`. The expected pre-publication delta remains: npm, GitHub Release/Windows assets, and Homebrew are still at v0.9.0 until a separately authorized v0.9.1 release; WinGet remains outside this change.

No tag, publication, release, deployment, n8n/VPS change, credential operation, or package-manager update is included.
