### PR TITLE
docs: add Ko-fi support to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ until you rotate it.
 - [Reference](https://relmio.vercel.app/docs/reference)
 - [Changelog](https://relmio.vercel.app/changelog)
 
+## Support
+
+Relmio is free to use. If it helped you, you can buy me a coffee.
+
+<a href="https://ko-fi.com/paldogies" target="_blank" rel="noopener noreferrer"><img height="36" src="https://storage.ko-fi.com/cdn/kofi6.png?v=6" alt="Support Relmio on Ko-fi"></a>
+
 ## Legal
 
 Relmio is an unofficial, community-maintained project. It is not affiliated

--- a/npm/README.md
+++ b/npm/README.md
@@ -100,6 +100,12 @@ until you rotate it.
 - https://relmio.vercel.app/docs/security
 - https://relmio.vercel.app/changelog
 
+## Support
+
+Relmio is free to use. If it helped you, you can buy me a coffee.
+
+<a href="https://ko-fi.com/paldogies" target="_blank" rel="noopener noreferrer"><img height="36" src="https://storage.ko-fi.com/cdn/kofi6.png?v=6" alt="Support Relmio on Ko-fi"></a>
+
 Source and issues: https://github.com/Demonbane18/relmio
 
 License: Apache-2.0

--- a/test/documentation.test.js
+++ b/test/documentation.test.js
@@ -51,6 +51,11 @@ test("README surfaces are concise product entry points linked to canonical docs"
     assert.match(guide, /Authentication fails/u);
     assert.match(guide, /Local image build failed/u);
     assert.match(guide, /npx --yes --ignore-scripts relmio@latest/u);
+    assert.match(
+      guide,
+      /## Support[\s\S]*href="https:\/\/ko-fi\.com\/paldogies"[\s\S]*src="https:\/\/storage\.ko-fi\.com\/cdn\/kofi6\.png\?v=6"/u,
+    );
+    assert.doesNotMatch(guide, /<script\b/iu);
     assert.doesNotMatch(guide, /```mermaid/u);
   }
   assert.match(readme, /docs\/images\/brand\/relmio-banner-animated\.svg/u);


### PR DESCRIPTION
## Summary

- Add a dedicated Ko-fi support section to the GitHub and npm READMEs.
- Link the static Ko-fi button to https://ko-fi.com/paldogies without executable widget scripts.
- Add regression coverage for README parity and script exclusion.

## Scope

- Updated: README.md, npm/README.md, and test/documentation.test.js.
- Not changed: CHANGELOG.md, application code, hosted web files, installers, release metadata, Homebrew, or other distribution files.

## Verification

- npm run check: 470 passed, 6 intentional skips.
- npm audit --audit-level=high: 0 vulnerabilities.
- npm pack --dry-run: passed with the reviewed package contents.
- Every external npm README image returned HTTP 200 with an image content type.
- Staged diff, whitespace, and secret checks passed before commit.
